### PR TITLE
Bugfix: Read sender role from message header

### DIFF
--- a/source/Infrastructure/OutgoingMessages/Common/Xml/HeaderWriter.cs
+++ b/source/Infrastructure/OutgoingMessages/Common/Xml/HeaderWriter.cs
@@ -52,7 +52,7 @@ internal static class HeaderWriter
         writer.WriteValue(messageHeader.SenderId);
         await writer.WriteEndElementAsync().ConfigureAwait(false);
 
-        await writer.WriteElementStringAsync(documentDetails.Prefix, "sender_MarketParticipant.marketRole.type", null, "DDZ")
+        await writer.WriteElementStringAsync(documentDetails.Prefix, "sender_MarketParticipant.marketRole.type", null, messageHeader.SenderRole)
             .ConfigureAwait(false);
 
         await writer.WriteStartElementAsync(documentDetails.Prefix, "receiver_MarketParticipant.mRID", null).ConfigureAwait(false);

--- a/source/Tests/Infrastructure/OutgoingMessages/NotifyAggreagtedMeasureData/NotifyAggregatedMeasureDataDocumentWriterTests.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/NotifyAggreagtedMeasureData/NotifyAggregatedMeasureDataDocumentWriterTests.cs
@@ -54,7 +54,7 @@ public class NotifyAggregatedMeasureDataDocumentWriterTests
         var header = new MessageHeader(
             ProcessType.BalanceFixing.Code,
             "1234567890123",
-            MarketRole.MeteringPointAdministrator.Name,
+            MarketRole.MeteredDataResponsible.Name,
             "1234567890321",
             MarketRole.GridOperator.Name,
             Guid.NewGuid().ToString(),


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description
Bugfix: Read sender role from message header
