### PR TITLE
Use environment variable ALLOW_TEST_TOKENS 

### DIFF
--- a/source/Api/Program.cs
+++ b/source/Api/Program.cs
@@ -102,7 +102,7 @@ namespace Api
                         .AddBearerAuthentication(tokenValidationParameters)
                         .AddAuthentication(sp =>
                         {
-                            if (runtime.IsRunningLocally() || runtime.PERFORMANCE_TEST_ENABLED)
+                            if (runtime.IsRunningLocally() || runtime.ALLOW_TEST_TOKENS)
                             {
                                 return new DevMarketActorAuthenticator(
                                     sp.GetRequiredService<IActorLookup>(),
@@ -157,7 +157,7 @@ namespace Api
 
         private static async Task<TokenValidationParameters> GetTokenValidationParametersAsync(RuntimeEnvironment runtime)
         {
-            if (runtime.IsRunningLocally() || runtime.PERFORMANCE_TEST_ENABLED)
+            if (runtime.IsRunningLocally() || runtime.ALLOW_TEST_TOKENS)
             {
 #pragma warning disable CA5404 // Do not disable token validation checks
                 return DevelopmentTokenValidationParameters();

--- a/source/Api/RuntimeEnvironment.cs
+++ b/source/Api/RuntimeEnvironment.cs
@@ -42,8 +42,8 @@ namespace Api
         public string? SERVICE_BUS_CONNECTION_STRING_FOR_DOMAIN_RELAY_MANAGE =>
             GetEnvironmentVariable(nameof(SERVICE_BUS_CONNECTION_STRING_FOR_DOMAIN_RELAY_MANAGE));
 
-        public virtual bool PERFORMANCE_TEST_ENABLED =>
-            bool.Parse(GetEnvironmentVariable(nameof(PERFORMANCE_TEST_ENABLED)) ?? "false");
+        public virtual bool ALLOW_TEST_TOKENS =>
+            bool.Parse(GetEnvironmentVariable(nameof(ALLOW_TEST_TOKENS)) ?? "false");
 
         public int MAX_NUMBER_OF_PAYLOADS_IN_BUNDLE
         {


### PR DESCRIPTION
## Description
Use environment variable ALLOW_TEST_TOKENS 
since previously used variable is now used to determine were the PerformanceTest is deployed
