### PR TITLE
Total non-profiled consumption is sent to balance responsible

### DIFF
--- a/source/Application/Transactions/Aggregations/IAggregationResults.cs
+++ b/source/Application/Transactions/Aggregations/IAggregationResults.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Domain.Actors;
+using Domain.OutgoingMessages;
 using Domain.Transactions;
 using Domain.Transactions.Aggregations;
 
@@ -58,4 +59,8 @@ public interface IAggregationResults
     /// <param name="roleOfReceiver"></param>
     /// <param name="period"></param>
     Task<ReadOnlyCollection<Result>> NonProfiledConsumptionForAsync(Guid resultId, GridArea gridArea, MarketRole roleOfReceiver, Domain.Transactions.Aggregations.Period period);
+
+    #pragma warning disable
+    Task<AggregationResult> TotalNonProfiledConsumptionForBalanceResponsibleAsync(Guid resultsId, ProcessType aggregationProcess, GridArea gridArea, Domain.Transactions.Aggregations.Period period, ActorNumber balanceResponsible);
+    Task<ReadOnlyCollection<ActorNumber>> BalanceResponsiblesWithTotalNonProfiledConsumptionAsync(Guid resultsId, GridArea gridArea);
 }

--- a/source/Application/Transactions/Aggregations/IAggregationResults.cs
+++ b/source/Application/Transactions/Aggregations/IAggregationResults.cs
@@ -60,7 +60,20 @@ public interface IAggregationResults
     /// <param name="period"></param>
     Task<ReadOnlyCollection<Result>> NonProfiledConsumptionForAsync(Guid resultId, GridArea gridArea, MarketRole roleOfReceiver, Domain.Transactions.Aggregations.Period period);
 
-    #pragma warning disable
+    /// <summary>
+    /// Fetch result for non-profiled consumption for balance responsible
+    /// </summary>
+    /// <param name="resultsId"></param>
+    /// <param name="aggregationProcess"></param>
+    /// <param name="gridArea"></param>
+    /// <param name="period"></param>
+    /// <param name="balanceResponsible"></param>
     Task<AggregationResult> TotalNonProfiledConsumptionForBalanceResponsibleAsync(Guid resultsId, ProcessType aggregationProcess, GridArea gridArea, Domain.Transactions.Aggregations.Period period, ActorNumber balanceResponsible);
+
+    /// <summary>
+    /// Fetch the list of balance responsibles having a total non-profiled consumption result
+    /// </summary>
+    /// <param name="resultsId"></param>
+    /// <param name="gridArea"></param>
     Task<ReadOnlyCollection<ActorNumber>> BalanceResponsiblesWithTotalNonProfiledConsumptionAsync(Guid resultsId, GridArea gridArea);
 }

--- a/source/Application/Transactions/Aggregations/TransactionScheduler.cs
+++ b/source/Application/Transactions/Aggregations/TransactionScheduler.cs
@@ -44,6 +44,20 @@ public sealed class TransactionScheduler
         await ScheduleTotalProductionResultAsync(resultsId, aggregationProcess, gridArea, period).ConfigureAwait(false);
         await ScheduleNonProfiledConsumptionForBalanceResponsibleAsync(resultsId, aggregationProcess, gridArea, period).ConfigureAwait(false);
         await ScheduleNonProfiledConsumptionForEnergySupplierAsync(resultsId, aggregationProcess, gridArea, period).ConfigureAwait(false);
+        await ScheduleTotalNonProfiledConsumptionForBalanceResponsibleAsync(resultsId, aggregationProcess, gridArea, period).ConfigureAwait(false);
+    }
+
+    private async Task ScheduleTotalNonProfiledConsumptionForBalanceResponsibleAsync(Guid resultsId, ProcessType aggregationProcess, GridArea gridArea, Domain.Transactions.Aggregations.Period period)
+    {
+        var balanceResponsibles = await _aggregationResults
+            .BalanceResponsiblesWithTotalNonProfiledConsumptionAsync(resultsId, gridArea).ConfigureAwait(false);
+
+        foreach (var actorNumber in balanceResponsibles)
+        {
+            var result = await _aggregationResults.TotalNonProfiledConsumptionForBalanceResponsibleAsync(resultsId, aggregationProcess, gridArea, period, actorNumber)
+                .ConfigureAwait(false);
+            await ScheduleAsync(aggregationProcess, actorNumber, MarketRole.BalanceResponsible, result).ConfigureAwait(false);
+        }
     }
 
     private async Task ScheduleNonProfiledConsumptionForBalanceResponsibleAsync(

--- a/source/Domain/Transactions/Aggregations/AggregationResult.cs
+++ b/source/Domain/Transactions/Aggregations/AggregationResult.cs
@@ -20,7 +20,18 @@ namespace Domain.Transactions.Aggregations;
 
 public class AggregationResult
 {
-    public AggregationResult(Guid id, IReadOnlyList<Point> points, GridArea gridArea, MeteringPointType meteringPointType, MeasurementUnit measureUnitType, Resolution resolution, Period period, SettlementType? settlementType, ActorNumber? aggregatedForActor = null)
+    public AggregationResult(
+        Guid id,
+        IReadOnlyList<Point> points,
+        GridArea gridArea,
+        MeteringPointType meteringPointType,
+        MeasurementUnit measureUnitType,
+        Resolution resolution,
+        Period period,
+        SettlementType? settlementType,
+        ActorNumber? aggregatedForActor = null,
+        ActorNumber? receivingActorNumber = null,
+        MarketRole? receivingActorRole = null)
     {
         Id = id;
         Points = points;
@@ -31,6 +42,8 @@ public class AggregationResult
         Period = period;
         SettlementType = settlementType;
         AggregatedForActor = aggregatedForActor;
+        ReceivingActorNumber = receivingActorNumber;
+        ReceivingActorRole = receivingActorRole;
     }
 
     public Guid Id { get; }
@@ -50,6 +63,10 @@ public class AggregationResult
     public SettlementType? SettlementType { get; }
 
     public ActorNumber? AggregatedForActor { get; }
+
+    public ActorNumber? ReceivingActorNumber { get; }
+
+    public MarketRole? ReceivingActorRole { get; }
 
     public static AggregationResult Consumption(
         Guid id,

--- a/source/Infrastructure/Transactions/Aggregations/AggregationResultsOverHttp.cs
+++ b/source/Infrastructure/Transactions/Aggregations/AggregationResultsOverHttp.cs
@@ -93,6 +93,21 @@ public class AggregationResultsOverHttp : IAggregationResults
         return Task.FromResult(new List<Result>().AsReadOnly());
     }
 
+    public Task<AggregationResult> TotalNonProfiledConsumptionForBalanceResponsibleAsync(
+        Guid resultsId,
+        ProcessType aggregationProcess,
+        GridArea gridArea,
+        Domain.Transactions.Aggregations.Period period,
+        ActorNumber balanceResponsible)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<ReadOnlyCollection<ActorNumber>> BalanceResponsiblesWithTotalNonProfiledConsumptionAsync(Guid resultsId, GridArea gridArea)
+    {
+        throw new NotImplementedException();
+    }
+
     private async Task<HttpResponseMessage> CallAsync<TRequest>(string apiVersion, TRequest request)
     {
         var executionPolicy = Policy

--- a/source/Infrastructure/Transactions/Aggregations/AggregationResultsOverHttp.cs
+++ b/source/Infrastructure/Transactions/Aggregations/AggregationResultsOverHttp.cs
@@ -93,14 +93,20 @@ public class AggregationResultsOverHttp : IAggregationResults
         return Task.FromResult(new List<Result>().AsReadOnly());
     }
 
-    public Task<AggregationResult> TotalNonProfiledConsumptionForBalanceResponsibleAsync(
+    public async Task<AggregationResult> TotalNonProfiledConsumptionForBalanceResponsibleAsync(
         Guid resultsId,
         ProcessType aggregationProcess,
         GridArea gridArea,
         Domain.Transactions.Aggregations.Period period,
         ActorNumber balanceResponsible)
     {
-        throw new NotImplementedException();
+        ArgumentNullException.ThrowIfNull(gridArea);
+        var requestUri = new Uri(
+            _serviceEndpoint, $"v3/batches/{resultsId}/processes/{gridArea.Code}/time-series-types/1");
+        var response = await _httpClient.GetAsync(requestUri).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        return await _aggregationResultMapper.MapToConsumptionResultAsync(
+            await response.Content.ReadAsStreamAsync().ConfigureAwait(false),  resultsId, gridArea.Code, period, SettlementType.NonProfiled).ConfigureAwait(false);
     }
 
     public async Task<ReadOnlyCollection<ActorNumber>> BalanceResponsiblesWithTotalNonProfiledConsumptionAsync(Guid resultsId, GridArea gridArea)

--- a/source/Infrastructure/Transactions/HttpClientAdapter.cs
+++ b/source/Infrastructure/Transactions/HttpClientAdapter.cs
@@ -31,4 +31,9 @@ public class HttpClientAdapter : IHttpClientAdapter
     {
         return _httpClient.PostAsync(uri, content);
     }
+
+    public Task<HttpResponseMessage> GetAsync(Uri uri)
+    {
+        return _httpClient.GetAsync(uri);
+    }
 }

--- a/source/Infrastructure/Transactions/IHttpClientAdapter.cs
+++ b/source/Infrastructure/Transactions/IHttpClientAdapter.cs
@@ -29,4 +29,10 @@ public interface IHttpClientAdapter
     /// <param name="uri"></param>
     /// <param name="content"></param>
     Task<HttpResponseMessage> PostAsync(Uri uri, HttpContent content);
+
+    /// <summary>
+    /// Issue a get request
+    /// </summary>
+    /// <param name="uri"></param>
+    Task<HttpResponseMessage> GetAsync(Uri uri);
 }

--- a/source/IntegrationTests/Factories/AggregationResultBuilder.cs
+++ b/source/IntegrationTests/Factories/AggregationResultBuilder.cs
@@ -34,12 +34,14 @@ internal class AggregationResultBuilder
     };
 
     private readonly MeasurementUnit _measureUnit = MeasurementUnit.Kwh;
-    private readonly SettlementType? _settlementType = SettlementType.NonProfiled;
     private readonly ActorNumber _aggregatedForActor = default!;
+    private SettlementType? _settlementType = SettlementType.NonProfiled;
     private MeteringPointType _meteringPointType = MeteringPointType.Consumption;
     private GridArea _gridArea = GridArea.Create("123");
     private Period _period = new(SystemClock.Instance.GetCurrentInstant(), SystemClock.Instance.GetCurrentInstant());
     private Resolution _resolution = Resolution.Hourly;
+    private ActorNumber _receivingActorNumber = default!;
+    private MarketRole _receivingActorRole = default!;
 
     public static AggregationResultBuilder Result()
     {
@@ -57,7 +59,9 @@ internal class AggregationResultBuilder
             _resolution,
             _period,
             _settlementType,
-            _aggregatedForActor);
+            _aggregatedForActor,
+            _receivingActorNumber,
+            _receivingActorRole);
     }
 
     public AggregationResultBuilder WithGridArea(string gridAreaCode)
@@ -81,6 +85,24 @@ internal class AggregationResultBuilder
     public AggregationResultBuilder WithMeteringPointType(MeteringPointType meteringPointType)
     {
         _meteringPointType = meteringPointType;
+        return this;
+    }
+
+    public AggregationResultBuilder WithReceivingActorNumber(ActorNumber receivingActorNumber)
+    {
+        _receivingActorNumber = receivingActorNumber;
+        return this;
+    }
+
+    public AggregationResultBuilder WithReceivingActorRole(MarketRole receivingActorRole)
+    {
+        _receivingActorRole = receivingActorRole;
+        return this;
+    }
+
+    public AggregationResultBuilder WithSettlementMethod(SettlementType settlementType)
+    {
+        _settlementType = settlementType;
         return this;
     }
 }

--- a/source/IntegrationTests/TestDoubles/AggregationResultsStub.cs
+++ b/source/IntegrationTests/TestDoubles/AggregationResultsStub.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Application.Transactions.Aggregations;
 using Domain.Actors;
+using Domain.OutgoingMessages;
 using Domain.Transactions;
 using Domain.Transactions.Aggregations;
 using NodaTime;
@@ -56,6 +57,27 @@ public class AggregationResultsStub : IAggregationResults
     public Task<ReadOnlyCollection<Result>> NonProfiledConsumptionForAsync(Guid resultId, GridArea gridArea, MarketRole roleOfReceiver, Period period)
     {
         return Task.FromResult(_resultsForBalanceResponsible.AsReadOnly());
+    }
+
+    public Task<AggregationResult> TotalNonProfiledConsumptionForBalanceResponsibleAsync(
+        Guid resultsId,
+        ProcessType aggregationProcess,
+        GridArea gridArea,
+        Period period,
+        ActorNumber balanceResponsible)
+    {
+        return Task.FromResult(_resultsForActors[balanceResponsible]);
+    }
+
+    public Task<ReadOnlyCollection<ActorNumber>> BalanceResponsiblesWithTotalNonProfiledConsumptionAsync(Guid resultsId, GridArea gridArea)
+    {
+        return Task.FromResult(_resultsForActors.Where(
+            result => result.Value.ReceivingActorRole! == MarketRole.BalanceResponsible &&
+                      result.Value.MeteringPointType == MeteringPointType.Consumption &&
+                      result.Value.SettlementType! == SettlementType.NonProfiled)
+            .Select(x => x.Key)
+            .ToList()
+            .AsReadOnly());
     }
 
     public void Add(AggregationResult aggregationResult, ActorNumber targetActorNumber)

--- a/source/IntegrationTests/TestDoubles/HttpClientSpy.cs
+++ b/source/IntegrationTests/TestDoubles/HttpClientSpy.cs
@@ -32,6 +32,11 @@ public class HttpClientSpy : IHttpClientAdapter
     private HttpStatusCode _responseCode = HttpStatusCode.OK;
     private string _businessProcessId = Guid.NewGuid().ToString();
 
+    public Task<HttpResponseMessage> GetAsync(Uri uri)
+    {
+        return Task.FromResult<HttpResponseMessage>(new HttpResponseMessage());
+    }
+
     public void AssertJsonContent(object expectedContent)
     {
         Assert.True(JToken.DeepEquals(JToken.Parse(JsonConvert.SerializeObject(expectedContent)), JToken.Parse(_messageBody)));

--- a/source/LearningTests/Infrastructure/Transactions/Aggregations/AggregationResultOverHttpTests.cs
+++ b/source/LearningTests/Infrastructure/Transactions/Aggregations/AggregationResultOverHttpTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Reflection;
+using Domain.OutgoingMessages;
 using Domain.Transactions;
 using Domain.Transactions.Aggregations;
 using Infrastructure.Configuration.Serialization;
@@ -82,6 +83,24 @@ public class AggregationResultOverHttpTests : IDisposable
             .ConfigureAwait(false);
 
         var aggregationResult = await _service.NonProfiledConsumptionForAsync(_batchId, _gridArea, energySuppliers[0], new Period(NodaTime.SystemClock.Instance.GetCurrentInstant(), NodaTime.SystemClock.Instance.GetCurrentInstant()))
+            .ConfigureAwait(false);
+
+        Assert.NotNull(aggregationResult);
+    }
+
+    [Fact]
+    public async Task Fetch_total_non_profiled_consumption_result_for_balance_responsible()
+    {
+        var batchId = Guid.Parse("607B9862-9273-4A06-9382-E7194BF57A1B");
+        var balanceResponsibles =
+            await _service.BalanceResponsiblesWithTotalNonProfiledConsumptionAsync(batchId,  GridArea.Create("543")).ConfigureAwait(false);
+
+        var aggregationResult = await _service.TotalNonProfiledConsumptionForBalanceResponsibleAsync(
+                _batchId,
+                ProcessType.BalanceFixing,
+                GridArea.Create(_gridArea),
+                new Period(NodaTime.SystemClock.Instance.GetCurrentInstant(), NodaTime.SystemClock.Instance.GetCurrentInstant()),
+                balanceResponsibles[0])
             .ConfigureAwait(false);
 
         Assert.NotNull(aggregationResult);

--- a/source/LearningTests/Infrastructure/Transactions/Aggregations/AggregationResultOverHttpTests.cs
+++ b/source/LearningTests/Infrastructure/Transactions/Aggregations/AggregationResultOverHttpTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Reflection;
+using Domain.Transactions;
 using Domain.Transactions.Aggregations;
 using Infrastructure.Configuration.Serialization;
 using Infrastructure.Transactions;
@@ -62,6 +63,16 @@ public class AggregationResultOverHttpTests : IDisposable
             .ConfigureAwait(false);
 
         Assert.NotEmpty(energySuppliers);
+    }
+
+    [Fact]
+    public async Task Fetch_list_of_balance_responsibles_for_which_a_total_non_profiled_consumption_result_is_available()
+    {
+        var batchId = Guid.Parse("607B9862-9273-4A06-9382-E7194BF57A1B");
+        var balanceResponsibles =
+            await _service.BalanceResponsiblesWithTotalNonProfiledConsumptionAsync(batchId,  GridArea.Create("543")).ConfigureAwait(false);
+
+        Assert.NotEmpty(balanceResponsibles);
     }
 
     [Fact]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description
Total non-profiled consumption is sent to balance responsible
