### PR TITLE
fix: limit amount of messages we work on in-memory to avoid OutOfMemo…

### DIFF
--- a/source/Api/RuntimeEnvironment.cs
+++ b/source/Api/RuntimeEnvironment.cs
@@ -51,7 +51,7 @@ namespace Api
             {
                 var variable = GetEnvironmentVariable(nameof(MAX_NUMBER_OF_PAYLOADS_IN_BUNDLE));
                 return string.IsNullOrWhiteSpace(variable) || int.TryParse(variable, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out var value) == false
-                    ? 100000
+                    ? 2000
                     : value;
             }
         }


### PR DESCRIPTION
The bundle message we tries to build consists of 11952 messages from wholesale around 133mb of raw data and since our default amount of messages to fit into a bundle is 100.000. Its loaded all 11952 messages into memory and converted them into our bundle messages. This operation for this amount of message usages around 1GB memory. 

For now, I have set the default message limit to 2.000 which give us a message bundle size at 40,7mb for the first message.

The sql reader was not able to fetch the generate bundle from the database. When change it to use Dapper, it completed within seconds with a bundle message size on around 74mb. We haven't investigate why the sql reader can't handle it. Because we have agreed to use dapper when reading data from the db.   
