### PR TITLE
feat: support for total consumption

### DIFF
--- a/source/Infrastructure/Infrastructure.csproj
+++ b/source/Infrastructure/Infrastructure.csproj
@@ -30,7 +30,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.EnergySupplying.RequestResponse" Version="1.2.0" />
     <PackageReference Include="Energinet.DataHub.MeteringPoints.IntegrationEvents" Version="1.0.4" />
     <PackageReference Include="Energinet.DataHub.MeteringPoints.RequestResponse" Version="1.0.4" />
-    <PackageReference Include="Energinet.DataHub.Wholesale.Contracts" Version="3.0.1" />
+    <PackageReference Include="Energinet.DataHub.Wholesale.Contracts" Version="4.0.0" />
     <PackageReference Include="MediatR" Version="12.0.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.6.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />

--- a/source/Infrastructure/Transactions/Aggregations/CalculationResultCompletedEventMapper.cs
+++ b/source/Infrastructure/Transactions/Aggregations/CalculationResultCompletedEventMapper.cs
@@ -57,7 +57,7 @@ public class CalculationResultCompletedEventMapper : IIntegrationEventMapper
     public bool CanHandle(string eventType)
     {
         ArgumentNullException.ThrowIfNull(eventType);
-        return eventType.Equals(CalculationResultCompleted.MessageType, StringComparison.OrdinalIgnoreCase);
+        return eventType.Equals(CalculationResultCompleted.MessageName, StringComparison.OrdinalIgnoreCase);
     }
 
     public string ToJson(byte[] payload)
@@ -124,6 +124,7 @@ public class CalculationResultCompletedEventMapper : IIntegrationEventMapper
             TimeSeriesType.NonProfiledConsumption => MeteringPointType.Consumption.Name,
             TimeSeriesType.NetExchangePerGa => MeteringPointType.Exchange.Name,
             TimeSeriesType.NetExchangePerNeighboringGa => MeteringPointType.Exchange.Name,
+            TimeSeriesType.TotalConsumption => MeteringPointType.Consumption.Name,
             TimeSeriesType.Unspecified => throw new InvalidOperationException("Unknown metering point type"),
             _ => throw new InvalidOperationException("Could not determine metering point type"),
         };


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

This PR will:
1) Update the Nuget package with the newest version of the `Calculation_result_completed` contract.
2) Add a test to ensure the grid area operator is informed when a result of this time-series-type is received.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* Som netvirksomhed vil jeg kunne modtage Total forbrug per netområde 27
