### PR TITLE
chore: added tests to ensure outgoing message is created for aggreated measure data inbox events

### DIFF
--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/SampleData.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/SampleData.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Domain.Actors;
+using IntegrationTests.Factories;
+using NodaTime;
+
+namespace IntegrationTests.Application.Transactions.AggregatedMeasureData;
+
+internal sealed class SampleData
+{
+    internal static string GridAreaCode => "805";
+
+    internal static Instant StartOfPeriod => EffectiveDateFactory.InstantAsOfToday();
+
+    internal static Instant EndOfPeriod => EffectiveDateFactory.OffsetDaysFromToday(1);
+
+    internal static ActorNumber Receiver => ActorNumber.Create("8200000007743");
+
+    internal static MarketRole ReceiverRole => MarketRole.BalanceResponsibleParty;
+}

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenARejectedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenARejectedResultIsAvailableTests.cs
@@ -33,11 +33,11 @@ using RejectReason = Energinet.DataHub.Edi.Responses.RejectReason;
 namespace IntegrationTests.Application.Transactions.AggregatedMeasureData;
 
 [IntegrationTest]
-public class WhenAnRejectedResultIsAvailableTests : TestBase
+public class WhenARejectedResultIsAvailableTests : TestBase
 {
     private readonly B2BContext _b2BContext;
 
-    public WhenAnRejectedResultIsAvailableTests(DatabaseFixture databaseFixture)
+    public WhenARejectedResultIsAvailableTests(DatabaseFixture databaseFixture)
         : base(databaseFixture)
     {
         _b2BContext = GetService<B2BContext>();

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
@@ -1,0 +1,148 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Application.Configuration.DataAccess;
+using Domain.Actors;
+using Domain.Documents;
+using Domain.OutgoingMessages;
+using Domain.OutgoingMessages.NotifyAggregatedMeasureData;
+using Domain.Transactions;
+using Domain.Transactions.AggregatedMeasureData;
+using Energinet.DataHub.Edi.Responses;
+using Google.Protobuf.WellKnownTypes;
+using Infrastructure.Configuration.DataAccess;
+using Infrastructure.OutgoingMessages.Common;
+using IntegrationTests.Assertions;
+using IntegrationTests.Fixtures;
+using Xunit;
+using Xunit.Categories;
+using Period = Energinet.DataHub.Edi.Responses.Period;
+
+namespace IntegrationTests.Application.Transactions.AggregatedMeasureData;
+
+[IntegrationTest]
+public class WhenAnAcceptedResultIsAvailableTests : TestBase
+{
+    private readonly B2BContext _b2BContext;
+
+    public WhenAnAcceptedResultIsAvailableTests(DatabaseFixture databaseFixture)
+        : base(databaseFixture)
+    {
+        _b2BContext = GetService<B2BContext>();
+    }
+
+    [Fact]
+    public async Task Aggregated_measure_data_response_is_accepted()
+    {
+        // Arrange
+        var process = BuildProcess();
+        var acceptedEvent = GetAcceptedEvent(process);
+
+        // Act
+        await HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestAccepted), acceptedEvent, process.ProcessId.Id).ConfigureAwait(false);
+
+        // Assert
+        var outgoingMessage = await OutgoingMessageAsync(MarketRole.BalanceResponsibleParty, BusinessReason.BalanceFixing);
+        var timeSerie = acceptedEvent.Series.First();
+        outgoingMessage
+            .HasBusinessReason(CimCode.To(process.BusinessReason).Name)
+            .HasReceiverId(process.RequestedByActorId.Value)
+            .HasReceiverRole(MarketRole.FromCode(process.RequestedByActorRoleCode).Name)
+            .HasSenderRole(MarketRole.MeteringDataAdministrator.Name)
+            .HasSenderId(DataHubDetails.IdentificationNumber.Value)
+            .HasMessageRecordValue<TimeSeries>(timeSerie => timeSerie.SettlementVersion!, timeSerie.SettlementVersion);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        _b2BContext.Dispose();
+    }
+
+    private static AggregatedTimeSeriesRequestAccepted GetAcceptedEvent(AggregatedMeasureDataProcess aggregatedMeasureDataProcess)
+    {
+        var acceptedResponse = new AggregatedTimeSeriesRequestAccepted();
+        acceptedResponse.Series.Add(CreateSerie(aggregatedMeasureDataProcess));
+
+        return acceptedResponse;
+    }
+
+    private static Serie CreateSerie(AggregatedMeasureDataProcess aggregatedMeasureDataProcess)
+    {
+        var quantity = new DecimalValue() { Units = 12345, Nanos = 123450000, };
+        var point = new TimeSeriesPoint()
+        {
+            Quantity = quantity,
+            QuantityQuality = QuantityQuality.Incomplete,
+            Time = new Timestamp() { Seconds = 1, },
+        };
+
+        var period = new Period()
+        {
+            StartOfPeriod = new Timestamp() { Seconds = aggregatedMeasureDataProcess.StartOfPeriod.ToUnixTimeSeconds(), },
+            EndOfPeriod = new Timestamp() { Seconds = aggregatedMeasureDataProcess.EndOfPeriod?.ToUnixTimeSeconds() ?? 1, },
+            Resolution = Resolution.Pt15M,
+        };
+
+        return new Serie()
+        {
+#pragma warning disable CA1305
+            SettlementVersion = aggregatedMeasureDataProcess.SettlementVersion ?? "0",
+#pragma warning restore CA1305
+            GridArea = aggregatedMeasureDataProcess.MeteringGridAreaDomainId,
+            Product = Product.Tarif,
+            QuantityUnit = QuantityUnit.Kwh,
+            Period = period,
+            TimeSeriesPoints = { point },
+            TimeSeriesType = TimeSeriesType.Production,
+        };
+    }
+
+    private async Task<AssertOutgoingMessage> OutgoingMessageAsync(
+        MarketRole roleOfReceiver,
+        BusinessReason businessReason)
+    {
+        return await AssertOutgoingMessage.OutgoingMessageAsync(
+            DocumentType.NotifyAggregatedMeasureData.Name,
+            businessReason.Name,
+            roleOfReceiver,
+            GetService<IDatabaseConnectionFactory>()).ConfigureAwait(false);
+    }
+
+    private AggregatedMeasureDataProcess BuildProcess()
+    {
+        var process = new AggregatedMeasureDataProcess(
+          ProcessId.New(),
+          BusinessTransactionId.Create(Guid.NewGuid().ToString()),
+          SampleData.Receiver,
+          SampleData.ReceiverRole.Code,
+          CimCode.Of(BusinessReason.BalanceFixing),
+          null,
+          null,
+          null,
+          SampleData.StartOfPeriod,
+          SampleData.EndOfPeriod,
+          SampleData.GridAreaCode,
+          null,
+          null);
+
+        process.WasSentToWholesale();
+        _b2BContext.AggregatedMeasureDataProcesses.Add(process);
+        _b2BContext.SaveChanges();
+        return process;
+    }
+}

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
@@ -23,8 +23,10 @@ using Domain.OutgoingMessages.NotifyAggregatedMeasureData;
 using Domain.Transactions;
 using Domain.Transactions.AggregatedMeasureData;
 using Energinet.DataHub.Edi.Responses;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Infrastructure.Configuration.DataAccess;
+using Infrastructure.InboxEvents;
 using Infrastructure.OutgoingMessages.Common;
 using IntegrationTests.Assertions;
 using IntegrationTests.Fixtures;
@@ -68,30 +70,29 @@ public class WhenAnAcceptedResultIsAvailableTests : TestBase
     }
 
     // TODO: Raise condition, getting two unique eventIds pointing at the same reference?
-    // [Fact]
-    // public async Task Receive_2_Aggregated_measure_data_responses_is_accepted()
-    // {
-    //     // Arrange
-    //     var process = BuildProcess();
-    //     var acceptedEvent = GetAcceptedEvent(process);
-    //
-    //     // Act
-    //     var task01 = HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestAccepted), acceptedEvent, process.ProcessId.Id);
-    //     var task02 = HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestAccepted), acceptedEvent, process.ProcessId.Id);
-    //
-    //     await Task.WhenAll(task01, task02);
-    //
-    //     // Assert
-    //     var outgoingMessage = await OutgoingMessageAsync(MarketRole.BalanceResponsibleParty, BusinessReason.BalanceFixing);
-    //     var timeSerie = acceptedEvent.Series.First();
-    //     outgoingMessage
-    //         .HasBusinessReason(CimCode.To(process.BusinessReason).Name)
-    //         .HasReceiverId(process.RequestedByActorId.Value)
-    //         .HasReceiverRole(MarketRole.FromCode(process.RequestedByActorRoleCode).Name)
-    //         .HasSenderRole(MarketRole.MeteringDataAdministrator.Name)
-    //         .HasSenderId(DataHubDetails.IdentificationNumber.Value)
-    //         .HasMessageRecordValue<TimeSeries>(timeSerie => timeSerie.SettlementVersion!, timeSerie.SettlementVersion);
-    // }
+    [Fact]
+    public async Task Receive_2_Aggregated_measure_data_responses_is_accepted()
+    {
+        // Arrange
+        var process = BuildProcess();
+        var acceptedEvent = GetAcceptedEvent(process);
+
+        // Act
+        await GetService<InboxEventReceiver>().ReceiveAsync(Guid.NewGuid().ToString(), nameof(AggregatedTimeSeriesRequestAccepted), process.ProcessId.Id, acceptedEvent.ToByteArray()).ConfigureAwait(false);
+        await HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestAccepted), acceptedEvent, process.ProcessId.Id);
+
+        // Assert
+        var outgoingMessage = await OutgoingMessageAsync(MarketRole.BalanceResponsibleParty, BusinessReason.BalanceFixing);
+        var timeSerie = acceptedEvent.Series.First();
+        outgoingMessage
+            .HasBusinessReason(CimCode.To(process.BusinessReason).Name)
+            .HasReceiverId(process.RequestedByActorId.Value)
+            .HasReceiverRole(MarketRole.FromCode(process.RequestedByActorRoleCode).Name)
+            .HasSenderRole(MarketRole.MeteringDataAdministrator.Name)
+            .HasSenderId(DataHubDetails.IdentificationNumber.Value)
+            .HasMessageRecordValue<TimeSeries>(timeSerie => timeSerie.SettlementVersion!, timeSerie.SettlementVersion);
+    }
+
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
@@ -67,6 +67,31 @@ public class WhenAnAcceptedResultIsAvailableTests : TestBase
             .HasMessageRecordValue<TimeSeries>(timeSerie => timeSerie.SettlementVersion!, timeSerie.SettlementVersion);
     }
 
+    // TODO: Raise condition, getting two unique eventIds pointing at the same reference?
+    // [Fact]
+    // public async Task Receive_2_Aggregated_measure_data_responses_is_accepted()
+    // {
+    //     // Arrange
+    //     var process = BuildProcess();
+    //     var acceptedEvent = GetAcceptedEvent(process);
+    //
+    //     // Act
+    //     var task01 = HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestAccepted), acceptedEvent, process.ProcessId.Id);
+    //     var task02 = HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestAccepted), acceptedEvent, process.ProcessId.Id);
+    //
+    //     await Task.WhenAll(task01, task02);
+    //
+    //     // Assert
+    //     var outgoingMessage = await OutgoingMessageAsync(MarketRole.BalanceResponsibleParty, BusinessReason.BalanceFixing);
+    //     var timeSerie = acceptedEvent.Series.First();
+    //     outgoingMessage
+    //         .HasBusinessReason(CimCode.To(process.BusinessReason).Name)
+    //         .HasReceiverId(process.RequestedByActorId.Value)
+    //         .HasReceiverRole(MarketRole.FromCode(process.RequestedByActorRoleCode).Name)
+    //         .HasSenderRole(MarketRole.MeteringDataAdministrator.Name)
+    //         .HasSenderId(DataHubDetails.IdentificationNumber.Value)
+    //         .HasMessageRecordValue<TimeSeries>(timeSerie => timeSerie.SettlementVersion!, timeSerie.SettlementVersion);
+    // }
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
@@ -92,18 +92,6 @@ public class WhenAnAcceptedResultIsAvailableTests : TestBase
             .HasMessageRecordValue<TimeSeries>(timeSerie => timeSerie.SettlementVersion!, timeSerie.SettlementVersion);
     }
 
-    private async Task AddInboxEvent(
-        AggregatedMeasureDataProcess process,
-        AggregatedTimeSeriesRequestAccepted acceptedEvent)
-    {
-        await GetService<InboxEventReceiver>()
-            .ReceiveAsync(
-                Guid.NewGuid().ToString(),
-                nameof(AggregatedTimeSeriesRequestAccepted),
-                process.ProcessId.Id,
-                acceptedEvent.ToByteArray()).ConfigureAwait(false);
-    }
-
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
@@ -147,6 +135,18 @@ public class WhenAnAcceptedResultIsAvailableTests : TestBase
             TimeSeriesPoints = { point },
             TimeSeriesType = TimeSeriesType.Production,
         };
+    }
+
+    private async Task AddInboxEvent(
+        AggregatedMeasureDataProcess process,
+        AggregatedTimeSeriesRequestAccepted acceptedEvent)
+    {
+        await GetService<InboxEventReceiver>()
+            .ReceiveAsync(
+                Guid.NewGuid().ToString(),
+                nameof(AggregatedTimeSeriesRequestAccepted),
+                process.ProcessId.Id,
+                acceptedEvent.ToByteArray()).ConfigureAwait(false);
     }
 
     private async Task<AssertOutgoingMessage> OutgoingMessageAsync(

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
@@ -69,16 +69,16 @@ public class WhenAnAcceptedResultIsAvailableTests : TestBase
             .HasMessageRecordValue<TimeSeries>(timeSerie => timeSerie.SettlementVersion!, timeSerie.SettlementVersion);
     }
 
-    // TODO: Raise condition, getting two unique eventIds pointing at the same reference?
     [Fact]
-    public async Task Receive_2_Aggregated_measure_data_responses_is_accepted()
+    public async Task Received_2_accepted_events_for_same_aggregated_measure_data_process()
     {
         // Arrange
         var process = BuildProcess();
         var acceptedEvent = GetAcceptedEvent(process);
 
         // Act
-        await GetService<InboxEventReceiver>().ReceiveAsync(Guid.NewGuid().ToString(), nameof(AggregatedTimeSeriesRequestAccepted), process.ProcessId.Id, acceptedEvent.ToByteArray()).ConfigureAwait(false);
+        await GetService<InboxEventReceiver>()
+            .ReceiveAsync(Guid.NewGuid().ToString(), nameof(AggregatedTimeSeriesRequestAccepted), process.ProcessId.Id, acceptedEvent.ToByteArray()).ConfigureAwait(false);
         await HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestAccepted), acceptedEvent, process.ProcessId.Id);
 
         // Assert

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
@@ -77,8 +77,7 @@ public class WhenAnAcceptedResultIsAvailableTests : TestBase
         var acceptedEvent = GetAcceptedEvent(process);
 
         // Act
-        await GetService<InboxEventReceiver>()
-            .ReceiveAsync(Guid.NewGuid().ToString(), nameof(AggregatedTimeSeriesRequestAccepted), process.ProcessId.Id, acceptedEvent.ToByteArray()).ConfigureAwait(false);
+        await AddInboxEvent(process, acceptedEvent);
         await HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestAccepted), acceptedEvent, process.ProcessId.Id);
 
         // Assert
@@ -91,6 +90,18 @@ public class WhenAnAcceptedResultIsAvailableTests : TestBase
             .HasSenderRole(MarketRole.MeteringDataAdministrator.Name)
             .HasSenderId(DataHubDetails.IdentificationNumber.Value)
             .HasMessageRecordValue<TimeSeries>(timeSerie => timeSerie.SettlementVersion!, timeSerie.SettlementVersion);
+    }
+
+    private async Task AddInboxEvent(
+        AggregatedMeasureDataProcess process,
+        AggregatedTimeSeriesRequestAccepted acceptedEvent)
+    {
+        await GetService<InboxEventReceiver>()
+            .ReceiveAsync(
+                Guid.NewGuid().ToString(),
+                nameof(AggregatedTimeSeriesRequestAccepted),
+                process.ProcessId.Id,
+                acceptedEvent.ToByteArray()).ConfigureAwait(false);
     }
 
     protected override void Dispose(bool disposing)

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnRejectedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnRejectedResultIsAvailableTests.cs
@@ -1,0 +1,113 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using Application.Configuration.DataAccess;
+using Domain.Actors;
+using Domain.Documents;
+using Domain.OutgoingMessages;
+using Domain.OutgoingMessages.RejectedRequestAggregatedMeasureData;
+using Domain.Transactions;
+using Domain.Transactions.AggregatedMeasureData;
+using Energinet.DataHub.Edi.Responses;
+using Infrastructure.Configuration.DataAccess;
+using Infrastructure.OutgoingMessages.Common;
+using IntegrationTests.Assertions;
+using IntegrationTests.Fixtures;
+using Xunit;
+using Xunit.Categories;
+using RejectReason = Energinet.DataHub.Edi.Responses.RejectReason;
+
+namespace IntegrationTests.Application.Transactions.AggregatedMeasureData;
+
+[IntegrationTest]
+public class WhenAnRejectedResultIsAvailableTests : TestBase
+{
+    private readonly B2BContext _b2BContext;
+
+    public WhenAnRejectedResultIsAvailableTests(DatabaseFixture databaseFixture)
+        : base(databaseFixture)
+    {
+        _b2BContext = GetService<B2BContext>();
+    }
+
+    [Fact]
+    public async Task Aggregated_measure_data_response_is_rejected()
+    {
+        // Arrange
+        var process = BuildProcess();
+        var rejectReason = new RejectReason()
+        {
+            ErrorCode = ErrorCodes.NoDataForPeriod,
+        };
+        var rejectEvent = new AggregatedTimeSeriesRequestRejected()
+        {
+            RejectReasons = { rejectReason },
+        };
+
+        // Act
+        await HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestRejected), rejectEvent, process.ProcessId.Id).ConfigureAwait(false);
+
+        // Assert
+        var outgoingMessage = await OutgoingMessageAsync(MarketRole.BalanceResponsibleParty, BusinessReason.BalanceFixing);
+        outgoingMessage
+            .HasBusinessReason(CimCode.To(process.BusinessReason).Name)
+            .HasReceiverId(process.RequestedByActorId.Value)
+            .HasReceiverRole(MarketRole.FromCode(process.RequestedByActorRoleCode).Name)
+            .HasSenderRole(MarketRole.MeteringDataAdministrator.Name)
+            .HasSenderId(DataHubDetails.IdentificationNumber.Value)
+            .HasAnyMessageRecordValue<RejectedTimeSerie>(timeSerie => timeSerie.RejectReason.ErrorCode, rejectReason.ErrorCode.ToString());
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        _b2BContext.Dispose();
+    }
+
+    private async Task<AssertOutgoingMessage> OutgoingMessageAsync(
+        MarketRole roleOfReceiver,
+        BusinessReason businessReason)
+    {
+        return await AssertOutgoingMessage.OutgoingMessageAsync(
+            DocumentType.RejectAggregatedMeasureData.Name,
+            businessReason.Name,
+            roleOfReceiver,
+            GetService<IDatabaseConnectionFactory>()).ConfigureAwait(false);
+    }
+
+    private AggregatedMeasureDataProcess BuildProcess()
+    {
+        var process = new AggregatedMeasureDataProcess(
+          ProcessId.New(),
+          BusinessTransactionId.Create(Guid.NewGuid().ToString()),
+          SampleData.Receiver,
+          SampleData.ReceiverRole.Code,
+          CimCode.Of(BusinessReason.BalanceFixing),
+          null,
+          null,
+          null,
+          SampleData.StartOfPeriod,
+          SampleData.EndOfPeriod,
+          SampleData.GridAreaCode,
+          null,
+          null);
+
+        process.WasSentToWholesale();
+        _b2BContext.AggregatedMeasureDataProcesses.Add(process);
+        _b2BContext.SaveChanges();
+        return process;
+    }
+}

--- a/source/IntegrationTests/Assertions/AssertOutgoingMessage.cs
+++ b/source/IntegrationTests/Assertions/AssertOutgoingMessage.cs
@@ -125,7 +125,7 @@ namespace IntegrationTests.Assertions
 
         public AssertOutgoingMessage HasAnyMessageRecordValue<TMessageRecord>(Func<TMessageRecord, object> propertySelector, object expectedValue)
         {
-            var sut = _serializer.Deserialize<IReadOnlyList<TMessageRecord>>(_message.MessageRecord);
+            IReadOnlyList<TMessageRecord> sut = _serializer.Deserialize<IReadOnlyList<TMessageRecord>>(_message.MessageRecord);
             Assert.Equal(expectedValue, sut.Select(propertySelector).First());
             return this;
         }

--- a/source/IntegrationTests/Assertions/AssertOutgoingMessage.cs
+++ b/source/IntegrationTests/Assertions/AssertOutgoingMessage.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Application.Configuration.DataAccess;
@@ -118,6 +120,13 @@ namespace IntegrationTests.Assertions
         {
             var sut = _serializer.Deserialize<TMessageRecord>(_message.MessageRecord);
             Assert.Equal(expectedValue, propertySelector(sut));
+            return this;
+        }
+
+        public AssertOutgoingMessage HasAnyMessageRecordValue<TMessageRecord>(Func<TMessageRecord, object> propertySelector, object expectedValue)
+        {
+            IReadOnlyList<TMessageRecord> sut = _serializer.Deserialize<IReadOnlyList<TMessageRecord>>(_message.MessageRecord);
+            Assert.Equal(expectedValue, sut.Select(propertySelector).First());
             return this;
         }
 

--- a/source/IntegrationTests/Assertions/AssertOutgoingMessage.cs
+++ b/source/IntegrationTests/Assertions/AssertOutgoingMessage.cs
@@ -125,7 +125,7 @@ namespace IntegrationTests.Assertions
 
         public AssertOutgoingMessage HasAnyMessageRecordValue<TMessageRecord>(Func<TMessageRecord, object> propertySelector, object expectedValue)
         {
-            IReadOnlyList<TMessageRecord> sut = _serializer.Deserialize<IReadOnlyList<TMessageRecord>>(_message.MessageRecord);
+            var sut = _serializer.Deserialize<IReadOnlyList<TMessageRecord>>(_message.MessageRecord);
             Assert.Equal(expectedValue, sut.Select(propertySelector).First());
             return this;
         }

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -123,7 +123,13 @@ namespace IntegrationTests
 
         protected async Task HavingReceivedInboxEventAsync(string eventType, IMessage eventPayload, Guid processId)
         {
-            await GetService<InboxEventReceiver>().ReceiveAsync(Guid.NewGuid().ToString(), eventType, processId, eventPayload.ToByteArray()).ConfigureAwait(false);
+            await GetService<InboxEventReceiver>().
+                ReceiveAsync(
+                    Guid.NewGuid().ToString(),
+                    eventType,
+                    processId,
+                    eventPayload.ToByteArray())
+                .ConfigureAwait(false);
             await ProcessReceivedInboxEventsAsync().ConfigureAwait(false);
             await ProcessInternalCommandsAsync().ConfigureAwait(false);
         }

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,6 +28,7 @@ using Application.Transactions.MoveIn;
 using Azure.Messaging.ServiceBus;
 using Google.Protobuf;
 using Infrastructure.Configuration;
+using Infrastructure.Configuration.DataAccess;
 using Infrastructure.Configuration.IntegrationEvents;
 using Infrastructure.Configuration.MessageBus;
 using Infrastructure.Configuration.MessageBus.RemoteBusinessServices;
@@ -52,6 +54,7 @@ namespace IntegrationTests
     {
         private readonly ServiceBusSenderFactoryStub _serviceBusSenderFactoryStub;
         private readonly HttpClientSpy _httpClientSpy;
+        private readonly B2BContext _b2BContext;
         private ServiceCollection? _services;
         private IServiceProvider _serviceProvider = default!;
         private bool _disposed;
@@ -66,6 +69,7 @@ namespace IntegrationTests
             TestAggregatedTimeSeriesRequestAcceptedHandlerSpy = new TestAggregatedTimeSeriesRequestAcceptedHandlerSpy();
             InboxEventNotificationHandler = new IntegrationTests.Infrastructure.InboxEvents.TestNotificationHandlerSpy();
             BuildServices();
+            _b2BContext = GetService<B2BContext>();
         }
 
         protected TestNotificationHandlerSpy NotificationHandlerSpy { get; }
@@ -93,6 +97,7 @@ namespace IntegrationTests
                 return;
             }
 
+            _b2BContext.Dispose();
             _serviceBusSenderFactoryStub.Dispose();
             ((ServiceProvider)_serviceProvider!).Dispose();
             _disposed = true;
@@ -116,6 +121,13 @@ namespace IntegrationTests
             await HavingProcessedInternalTasksAsync().ConfigureAwait(false);
         }
 
+        protected async Task HavingReceivedInboxEventAsync(string eventType, IMessage eventPayload, Guid processId)
+        {
+            await GetService<InboxEventReceiver>().ReceiveAsync(Guid.NewGuid().ToString(), eventType, processId, eventPayload.ToByteArray()).ConfigureAwait(false);
+            await ProcessReceivedInboxEventsAsync().ConfigureAwait(false);
+            await ProcessInternalCommandsAsync().ConfigureAwait(false);
+        }
+
         protected Task HavingProcessedInternalTasksAsync()
         {
             return ProcessBackgroundTasksAsync();
@@ -128,6 +140,21 @@ namespace IntegrationTests
                 .Append("SharedAccessKeyName=send;")
                 .Append(CultureInfo.InvariantCulture, $"SharedAccessKey={Guid.NewGuid():N}")
                 .ToString();
+        }
+
+        private async Task ProcessInternalCommandsAsync()
+        {
+            await ProcessBackgroundTasksAsync();
+
+            if (_b2BContext.QueuedInternalCommands.Any(command => command.ProcessedDate == null))
+            {
+                await ProcessInternalCommandsAsync();
+            }
+        }
+
+        private Task ProcessReceivedInboxEventsAsync()
+        {
+            return ProcessBackgroundTasksAsync();
         }
 
         private Task ProcessReceivedIntegrationEventsAsync()


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
