### PR TITLE
Fix: deleting processed internal commands in batches to avoid locking the …

### DIFF
--- a/source/Api/Configuration/SystemTimer.cs
+++ b/source/Api/Configuration/SystemTimer.cs
@@ -38,7 +38,7 @@ namespace Api.Configuration
         }
 
         [Function("ADayHasPassed")]
-        public Task ADayHasPassedAsync([TimerTrigger("0 0 * * * *")] TimerInfo timerTimerInfo, FunctionContext context)
+        public Task ADayHasPassedAsync([TimerTrigger("0 0 0 * * *")] TimerInfo timerTimerInfo, FunctionContext context)
         {
             return _mediator.Publish(new ADayHasPassed(_systemDateTimeProvider.Now()));
         }

--- a/source/IntegrationTests/Infrastructure/Retention/RemoveInternalCommandsWhenADayHasPassedTests.cs
+++ b/source/IntegrationTests/Infrastructure/Retention/RemoveInternalCommandsWhenADayHasPassedTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Configuration;
+using Application.Configuration.DataAccess;
+using Application.Configuration.TimeEvents;
+using Infrastructure.Configuration.DataAccess;
+using Infrastructure.Configuration.InternalCommands;
+using IntegrationTests.Fixtures;
+using Xunit;
+
+namespace IntegrationTests.Infrastructure.Retention;
+
+public class RemoveInternalCommandsWhenADayHasPassedTests : TestBase
+{
+    private readonly B2BContext _b2BContext;
+    private readonly ISystemDateTimeProvider _systemDateTimeProvider;
+    private readonly RemoveInternalCommandsWhenADayHasPassed _sut;
+
+    public RemoveInternalCommandsWhenADayHasPassedTests(
+        DatabaseFixture databaseFixture)
+        : base(databaseFixture)
+    {
+        _b2BContext = GetService<B2BContext>();
+        _systemDateTimeProvider = GetService<ISystemDateTimeProvider>();
+        _sut = new RemoveInternalCommandsWhenADayHasPassed(GetService<IDatabaseConnectionFactory>());
+    }
+
+    [Fact]
+    public async Task Clean_up_internal_commands_succeed()
+    {
+        // arrange
+        var amountOfProcessedInternalCommands = 2500;
+        var amountOfNotProcessedInternalCommands = 25;
+        await GenerateInternalCommands(amountOfProcessedInternalCommands, amountOfNotProcessedInternalCommands);
+
+        // Act
+        await _sut.Handle(new ADayHasPassed(_systemDateTimeProvider.Now()), CancellationToken.None);
+
+        // Assert
+        AssertProcessedInternalCommandIsRemoved(amountOfNotProcessedInternalCommands);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        _b2BContext.Dispose();
+        base.Dispose(disposing);
+    }
+
+    private void AssertProcessedInternalCommandIsRemoved(int amountOfNotProcessedInternalCommands)
+    {
+        var proccessedInternalCommands = _b2BContext.QueuedInternalCommands
+            .Where(command => command.ProcessedDate != null);
+        var notProccessedInternalCommands = _b2BContext.QueuedInternalCommands
+            .Where(command => command.ProcessedDate == null);
+
+        Assert.Equal(amountOfNotProcessedInternalCommands, notProccessedInternalCommands.Count());
+        Assert.Empty(proccessedInternalCommands);
+    }
+
+    private async Task GenerateInternalCommands(int amountOfProcessedInternalCommands, int amountOfNotProcessedInternalCommands)
+    {
+        for (int i = 0; i < amountOfProcessedInternalCommands; i++)
+        {
+            var processedCommand = new QueuedInternalCommand(Guid.NewGuid(), string.Empty, string.Empty, _systemDateTimeProvider.Now());
+            processedCommand.ProcessedDate = _systemDateTimeProvider.Now();
+            _b2BContext.QueuedInternalCommands.Add(processedCommand);
+        }
+
+        for (int i = 0; i < amountOfNotProcessedInternalCommands; i++)
+        {
+            var notProcessedCommand = new QueuedInternalCommand(Guid.NewGuid(), string.Empty, string.Empty, _systemDateTimeProvider.Now());
+            _b2BContext.QueuedInternalCommands.Add(notProcessedCommand);
+        }
+
+        await _b2BContext.SaveChangesAsync(CancellationToken.None);
+    }
+}


### PR DESCRIPTION
…system while deleting them one at a time.

Plus, fix our ADayHasPassed event to not trigger every hour but once a day.