### PR TITLE
Test: unsuccessful dequeue for actor queue with no open bundles

### DIFF
--- a/source/Application/OutgoingMessages/Dequeue/DequeueHandler.cs
+++ b/source/Application/OutgoingMessages/Dequeue/DequeueHandler.cs
@@ -48,9 +48,9 @@ public class DequeueHandler : IRequestHandler<DequeueCommand, DequeCommandResult
             return new DequeCommandResult(false);
         }
 
-        actorQueue.Dequeue(bundleId);
+        var successful = actorQueue.Dequeue(bundleId);
 
-        return new DequeCommandResult(true);
+        return new DequeCommandResult(successful);
     }
 }
 

--- a/source/Domain/OutgoingMessages/Queueing/ActorMessageQueue.cs
+++ b/source/Domain/OutgoingMessages/Queueing/ActorMessageQueue.cs
@@ -20,6 +20,7 @@ namespace Domain.OutgoingMessages.Queueing;
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
 public class ActorMessageQueue : Entity
 {
+    // Used for persistent actor message queue entity.
     private readonly Guid _id;
     private readonly List<Bundle> _bundles = new();
 
@@ -71,10 +72,16 @@ public class ActorMessageQueue : Entity
         return new PeekResult(NextBundleToPeek(category)?.Id, NextBundleToPeek(category)?.DocumentTypeInBundle);
     }
 
-    public void Dequeue(BundleId bundleId)
+    public bool Dequeue(BundleId bundleId)
     {
         var bundle = _bundles.FirstOrDefault(bundle => bundle.Id == bundleId && bundle.IsDequeued == false);
-        bundle?.Dequeue();
+        if (bundle == null)
+        {
+            return false;
+        }
+
+        bundle.Dequeue();
+        return true;
     }
 
     private void EnsureApplicable(OutgoingMessage outgoingMessage)

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenADequeueIsRequestedTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenADequeueIsRequestedTests.cs
@@ -45,6 +45,25 @@ public class WhenADequeueIsRequestedTests : TestBase
     }
 
     [Fact]
+    public async Task Dequeue_is_unsuccessful_when_actor_queue_exits_without_a_open_bundle()
+    {
+        // Ensures we have a Actor queue with a bundle.
+        await GivenAMoveInTransactionHasBeenAccepted().ConfigureAwait(false);
+        var peekResult = await InvokeCommandAsync(new PeekCommand(
+            ActorNumber.Create(SampleData.NewEnergySupplierNumber),
+            MessageCategory.MasterData,
+            MarketRole.EnergySupplier,
+            DocumentFormat.Xml)).ConfigureAwait(false);
+
+        // Close the bundle
+        _ = await InvokeCommandAsync(new DequeueCommand(peekResult.MessageId.GetValueOrDefault().ToString(), MarketRole.EnergySupplier, ActorNumber.Create(SampleData.SenderId))).ConfigureAwait(false);
+
+        var dequeueResult = await InvokeCommandAsync(new DequeueCommand(peekResult.MessageId.GetValueOrDefault().ToString(), MarketRole.EnergySupplier, ActorNumber.Create(SampleData.SenderId))).ConfigureAwait(false);
+
+        Assert.False(dequeueResult.Success);
+    }
+
+    [Fact]
     public async Task Dequeue_is_Successful()
     {
         await GivenAMoveInTransactionHasBeenAccepted().ConfigureAwait(false);

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenADequeueIsRequestedTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenADequeueIsRequestedTests.cs
@@ -45,7 +45,7 @@ public class WhenADequeueIsRequestedTests : TestBase
     }
 
     [Fact]
-    public async Task Dequeue_is_unsuccessful_when_actor_queue_exits_without_a_open_bundle()
+    public async Task Dequeue_unknown_message_id_is_unsuccessful_when_actor_has_a_queue()
     {
         var unknownMessageId = Guid.NewGuid().ToString();
         // Created an Actor Queue with a bundle.

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenADequeueIsRequestedTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenADequeueIsRequestedTests.cs
@@ -47,18 +47,11 @@ public class WhenADequeueIsRequestedTests : TestBase
     [Fact]
     public async Task Dequeue_is_unsuccessful_when_actor_queue_exits_without_a_open_bundle()
     {
-        // Ensures we have a Actor queue with a bundle.
+        var unknownMessageId = Guid.NewGuid().ToString();
+        // Created an Actor Queue with a bundle.
         await GivenAMoveInTransactionHasBeenAccepted().ConfigureAwait(false);
-        var peekResult = await InvokeCommandAsync(new PeekCommand(
-            ActorNumber.Create(SampleData.NewEnergySupplierNumber),
-            MessageCategory.MasterData,
-            MarketRole.EnergySupplier,
-            DocumentFormat.Xml)).ConfigureAwait(false);
 
-        // Close the bundle
-        _ = await InvokeCommandAsync(new DequeueCommand(peekResult.MessageId.GetValueOrDefault().ToString(), MarketRole.EnergySupplier, ActorNumber.Create(SampleData.SenderId))).ConfigureAwait(false);
-
-        var dequeueResult = await InvokeCommandAsync(new DequeueCommand(peekResult.MessageId.GetValueOrDefault().ToString(), MarketRole.EnergySupplier, ActorNumber.Create(SampleData.SenderId))).ConfigureAwait(false);
+        var dequeueResult = await InvokeCommandAsync(new DequeueCommand(unknownMessageId, MarketRole.EnergySupplier, ActorNumber.Create(SampleData.SenderId))).ConfigureAwait(false);
 
         Assert.False(dequeueResult.Success);
     }

--- a/source/Tests/Domain/OutgoingMessages/Queueing/ActorMessageQueueTests.cs
+++ b/source/Tests/Domain/OutgoingMessages/Queueing/ActorMessageQueueTests.cs
@@ -77,8 +77,8 @@ public class ActorMessageQueueTests
         actorMessageQueue.Enqueue(outgoingMessage);
 
         var result = actorMessageQueue.Peek();
-        actorMessageQueue.Dequeue(result.BundleId!);
 
+        Assert.True(actorMessageQueue.Dequeue(result.BundleId!));
         Assert.Null(actorMessageQueue.Peek().BundleId);
     }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

Dequeue should return unsuccessful if an actor doesn't have an open bundle. 

This can be reproduced if an Actor with an existing Actor Queue dequeue with an unknown messageId.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
