### PR TITLE
refac: empty queues before running acceptancetests

### DIFF
--- a/source/AcceptanceTests/AcceptanceTests.csproj
+++ b/source/AcceptanceTests/AcceptanceTests.csproj
@@ -47,9 +47,6 @@
       <None Update="appsettings.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
-      <None Update="integrationtest.local.settings.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
     </ItemGroup>
 
     <ItemGroup>

--- a/source/AcceptanceTests/AcceptanceTests.csproj
+++ b/source/AcceptanceTests/AcceptanceTests.csproj
@@ -47,6 +47,9 @@
       <None Update="appsettings.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="integrationtest.local.settings.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
     <ItemGroup>

--- a/source/AcceptanceTests/Drivers/EdiDriver.cs
+++ b/source/AcceptanceTests/Drivers/EdiDriver.cs
@@ -77,17 +77,12 @@ internal sealed class EdiDriver : IDisposable
     public async Task EmptyQueueAsync(string actorNumber, string[] marketRoles)
     {
         var token = TokenBuilder.BuildToken(actorNumber, marketRoles, _azpToken);
-        var statusCode = HttpStatusCode.OK;
-        while (statusCode == HttpStatusCode.OK)
-        {
-            var peekResponse = await PeekAsync(token)
+        var peekResponse = await PeekAsync(token)
                 .ConfigureAwait(false);
-            statusCode = peekResponse.StatusCode;
-            if (statusCode == HttpStatusCode.OK)
-            {
-                await DequeueAsync(token, GetMessageId(peekResponse)).ConfigureAwait(false);
-                await EmptyQueueAsync(actorNumber, marketRoles).ConfigureAwait(false);
-            }
+        if (peekResponse.StatusCode == HttpStatusCode.OK)
+        {
+            await DequeueAsync(token, GetMessageId(peekResponse)).ConfigureAwait(false);
+            await EmptyQueueAsync(actorNumber, marketRoles).ConfigureAwait(false);
         }
     }
 

--- a/source/AcceptanceTests/Dsl/AggregatedMeasureDataRequestDsl.cs
+++ b/source/AcceptanceTests/Dsl/AggregatedMeasureDataRequestDsl.cs
@@ -29,12 +29,12 @@ internal sealed class AggregatedMeasureDataRequestDsl
 
     internal Task AggregatedMeasureDataFor(string actorNumber, string actorRole)
     {
-        return _edi.RequestAggregatedMeasureDataAsync(actorNumber, new[] { actorRole, });
+        return _edi.RequestAggregatedMeasureDataAsync(actorNumber, new[] { actorRole });
     }
 
     internal Task ConfirmAcceptedResultIsAvailableFor(string actorNumber, string actorRole)
     {
-        return _edi.PeekAcceptedAggregationMessageAsync(actorNumber, new[] { actorRole, });
+        return _edi.PeekAcceptedAggregationMessageAsync(actorNumber, new[] { actorRole });
     }
 
     internal Task RejectedAggregatedMeasureDataFor(string actorNumber, string actorRole)
@@ -44,6 +44,11 @@ internal sealed class AggregatedMeasureDataRequestDsl
 
     internal Task ConfirmRejectedResultIsAvailableFor(string actorNumber, string actorRole)
     {
-        return _edi.PeekRejectedMessageAsync(actorNumber, new[] { actorRole, });
+        return _edi.PeekRejectedMessageAsync(actorNumber, new[] { actorRole });
+    }
+
+    internal Task EmptyQueueForActor(string actorNumber, string actorRole)
+    {
+        return _edi.EmptyQueueAsync(actorNumber, new[] { actorRole });
     }
 }

--- a/source/AcceptanceTests/WhenAggregatedMeasureDataIsRequestedTests.cs
+++ b/source/AcceptanceTests/WhenAggregatedMeasureDataIsRequestedTests.cs
@@ -31,16 +31,16 @@ public sealed class WhenAggregatedMeasureDataIsRequestedTests : TestRunner
     [Fact]
     public async Task Actor_can_peek_and_dequeue_message_after_aggregated_measure_data_has_been_requested()
     {
-        await _aggregationRequest.AggregatedMeasureDataFor(actorNumber: "5790000610999", actorRole: "metereddataresponsible").ConfigureAwait(false);
+        await _aggregationRequest.AggregatedMeasureDataFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
 
-        await _aggregationRequest.ConfirmAcceptedResultIsAvailableFor(actorNumber: "5790000610999", actorRole: "metereddataresponsible").ConfigureAwait(false);
+        await _aggregationRequest.ConfirmAcceptedResultIsAvailableFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
     }
 
     [Fact]
     public async Task Actor_can_peek_and_dequeue_rejected_message_after_aggregated_measure_data_has_been_requested()
     {
-        await _aggregationRequest.RejectedAggregatedMeasureDataFor(actorNumber: "5790000610999", actorRole: "metereddataresponsible").ConfigureAwait(false);
+        await _aggregationRequest.RejectedAggregatedMeasureDataFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
 
-        await _aggregationRequest.ConfirmRejectedResultIsAvailableFor(actorNumber: "5790000610999", actorRole: "metereddataresponsible").ConfigureAwait(false);
+        await _aggregationRequest.ConfirmRejectedResultIsAvailableFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
     }
 }

--- a/source/AcceptanceTests/WhenAggregatedMeasureDataIsRequestedTests.cs
+++ b/source/AcceptanceTests/WhenAggregatedMeasureDataIsRequestedTests.cs
@@ -31,6 +31,8 @@ public sealed class WhenAggregatedMeasureDataIsRequestedTests : TestRunner
     [Fact]
     public async Task Actor_can_peek_and_dequeue_message_after_aggregated_measure_data_has_been_requested()
     {
+        await _aggregationRequest.EmptyQueueForActor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
+
         await _aggregationRequest.AggregatedMeasureDataFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
 
         await _aggregationRequest.ConfirmAcceptedResultIsAvailableFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
@@ -39,6 +41,8 @@ public sealed class WhenAggregatedMeasureDataIsRequestedTests : TestRunner
     [Fact]
     public async Task Actor_can_peek_and_dequeue_rejected_message_after_aggregated_measure_data_has_been_requested()
     {
+        await _aggregationRequest.EmptyQueueForActor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
+
         await _aggregationRequest.RejectedAggregatedMeasureDataFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
 
         await _aggregationRequest.ConfirmRejectedResultIsAvailableFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);

--- a/source/AcceptanceTests/WhenAggregatedMeasureDataIsRequestedTests.cs
+++ b/source/AcceptanceTests/WhenAggregatedMeasureDataIsRequestedTests.cs
@@ -31,16 +31,16 @@ public sealed class WhenAggregatedMeasureDataIsRequestedTests : TestRunner
     [Fact]
     public async Task Actor_can_peek_and_dequeue_message_after_aggregated_measure_data_has_been_requested()
     {
-        await _aggregationRequest.AggregatedMeasureDataFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
+        await _aggregationRequest.AggregatedMeasureDataFor(actorNumber: "5790000610999", actorRole: "metereddataresponsible").ConfigureAwait(false);
 
-        await _aggregationRequest.ConfirmAcceptedResultIsAvailableFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
+        await _aggregationRequest.ConfirmAcceptedResultIsAvailableFor(actorNumber: "5790000610999", actorRole: "metereddataresponsible").ConfigureAwait(false);
     }
 
     [Fact]
     public async Task Actor_can_peek_and_dequeue_rejected_message_after_aggregated_measure_data_has_been_requested()
     {
-        await _aggregationRequest.RejectedAggregatedMeasureDataFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
+        await _aggregationRequest.RejectedAggregatedMeasureDataFor(actorNumber: "5790000610999", actorRole: "metereddataresponsible").ConfigureAwait(false);
 
-        await _aggregationRequest.ConfirmRejectedResultIsAvailableFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
+        await _aggregationRequest.ConfirmRejectedResultIsAvailableFor(actorNumber: "5790000610999", actorRole: "metereddataresponsible").ConfigureAwait(false);
     }
 }

--- a/source/AcceptanceTests/WhenAggregationResultIsPublishedTests.cs
+++ b/source/AcceptanceTests/WhenAggregationResultIsPublishedTests.cs
@@ -35,7 +35,7 @@ public sealed class WhenAggregationResultIsPublishedTests : TestRunner
     {
         await _aggregations.PublishResultFor(gridAreaCode: "543").ConfigureAwait(false);
         await _aggregations
-            .ConfirmResultIsAvailableFor(actorNumber: "5790000610999", actorRole: "metereddataresponsible")
+            .ConfirmResultIsAvailableFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible")
             .ConfigureAwait(false);
     }
 }

--- a/source/AcceptanceTests/WhenAggregationResultIsPublishedTests.cs
+++ b/source/AcceptanceTests/WhenAggregationResultIsPublishedTests.cs
@@ -35,7 +35,7 @@ public sealed class WhenAggregationResultIsPublishedTests : TestRunner
     {
         await _aggregations.PublishResultFor(gridAreaCode: "543").ConfigureAwait(false);
         await _aggregations
-            .ConfirmResultIsAvailableFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible")
+            .ConfirmResultIsAvailableFor(actorNumber: "5790000610999", actorRole: "metereddataresponsible")
             .ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
