### PR TITLE
chore: Updated acceptance test request to ensure expected response from wholesale

### DIFF
--- a/source/AcceptanceTests/AcceptanceTests.csproj
+++ b/source/AcceptanceTests/AcceptanceTests.csproj
@@ -57,7 +57,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <EmbeddedResource Include="Messages\json\RequestAggregatedMeasureDataWithWrongMarketEvaluationPoint.json">
+      <EmbeddedResource Include="Messages\json\RequestAggregatedMeasureDataWithBadPeriod.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </EmbeddedResource>
       <EmbeddedResource Include="Messages\json\RequestAggregatedMeasureData.json">

--- a/source/AcceptanceTests/Drivers/EdiDriver.cs
+++ b/source/AcceptanceTests/Drivers/EdiDriver.cs
@@ -126,7 +126,7 @@ internal sealed class EdiDriver : IDisposable
     private static string GetContent(bool badRequest = false)
     {
         var jsonContent = badRequest
-            ? File.ReadAllText("Messages/json/RequestAggregatedMeasureDataWithWrongMarketEvaluationPoint.json")
+            ? File.ReadAllText("Messages/json/RequestAggregatedMeasureDataWithBadPeriod.json")
             : File.ReadAllText("Messages/json/RequestAggregatedMeasureData.json");
 
         jsonContent = jsonContent.Replace("{MessageId}", Guid.NewGuid().ToString(), StringComparison.InvariantCulture);

--- a/source/AcceptanceTests/Messages/json/RequestAggregatedMeasureData.json
+++ b/source/AcceptanceTests/Messages/json/RequestAggregatedMeasureData.json
@@ -28,7 +28,7 @@
     "Series": [
       {
         "mRID": "{TransactionId}",
-        "end_DateAndOrTime.dateTime": "2022-07-22T22:00:00Z",
+        "end_DateAndOrTime.dateTime": "2023-07-26T00:00:00Z",
         "marketEvaluationPoint.settlementMethod": {
           "value": "D01"
         },
@@ -42,7 +42,7 @@
         "settlement_Series.version": {
           "value": "D01"
         },
-        "start_DateAndOrTime.dateTime": "2022-06-17T22:00:00Z"
+        "start_DateAndOrTime.dateTime": "2023-07-26T00:00:00Z"
       }
     ]
   }

--- a/source/AcceptanceTests/Messages/json/RequestAggregatedMeasureDataWithBadPeriod.json
+++ b/source/AcceptanceTests/Messages/json/RequestAggregatedMeasureDataWithBadPeriod.json
@@ -33,7 +33,7 @@
           "value": "D01"
         },
         "marketEvaluationPoint.type": {
-          "value": "E17"
+          "value": "E18"
         },
         "meteringGridArea_Domain.mRID": {
           "codingScheme": "NDK",

--- a/source/AcceptanceTests/Messages/json/RequestAggregatedMeasureDataWithWrongMarketEvaluationPoint.json
+++ b/source/AcceptanceTests/Messages/json/RequestAggregatedMeasureDataWithWrongMarketEvaluationPoint.json
@@ -28,7 +28,7 @@
     "Series": [
       {
         "mRID": "{TransactionId}",
-        "end_DateAndOrTime.dateTime": "2022-07-22T22:00:00Z",
+        "end_DateAndOrTime.dateTime": "2021-07-22T22:00:00Z",
         "marketEvaluationPoint.settlementMethod": {
           "value": "D01"
         },
@@ -42,7 +42,7 @@
         "settlement_Series.version": {
           "value": "D01"
         },
-        "start_DateAndOrTime.dateTime": "2022-06-17T22:00:00Z"
+        "start_DateAndOrTime.dateTime": "2023-06-17T22:00:00Z"
       }
     ]
   }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description
After the removal of mocked data in wholesale we need to update our acceptance test requests.

We ensure a failed request by setting starting-time after end-time.

We ensure a good response by update the timeslots to timeslots where we know data exists.
By picking a relative new timeslot, we ensure, that we do not have to update this, in the short future.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
