### PR TITLE
refac: Outgoingmessages are retrieved in a bundle

### DIFF
--- a/source/Application/OutgoingMessages/IOutgoingMessageRepository.cs
+++ b/source/Application/OutgoingMessages/IOutgoingMessageRepository.cs
@@ -33,6 +33,6 @@ namespace Application.OutgoingMessages
         /// <summary>
         /// Get all messages assigned to a bundle by id.
         /// </summary>
-        Task<IReadOnlyCollection<OutgoingMessage>> GetAsync(BundleId bundleId);
+        Task<OutgoingMessageBundle> GetAsync(BundleId bundleId);
     }
 }

--- a/source/Application/OutgoingMessages/PeekHandler.cs
+++ b/source/Application/OutgoingMessages/PeekHandler.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Application.Configuration;
@@ -76,25 +75,20 @@ public class PeekHandler : IRequestHandler<PeekCommand, PeekResult>
         {
             var timestamp = _systemDateTimeProvider.Now();
 
-            var outgoingMessages = await _outgoingMessageRepository.GetAsync(peekResult.BundleId).ConfigureAwait(false);
-            var result = await _documentFactory.CreateFromAsync(outgoingMessages, request.DocumentFormat, timestamp).ConfigureAwait(false);
+            var outgoingMessageBundle = await _outgoingMessageRepository.GetAsync(peekResult.BundleId).ConfigureAwait(false);
+            var result = await _documentFactory.CreateFromAsync(outgoingMessageBundle, request.DocumentFormat, timestamp).ConfigureAwait(false);
 
             document = new MarketDocument(result, peekResult.BundleId);
             await _marketDocumentRepository.AddAsync(document).ConfigureAwait(false);
 
-            var outgoingMessage = outgoingMessages.First();
-            var documentType = outgoingMessage.DocumentType;
-            var senderId = outgoingMessage.SenderId.Value;
-            var receiverId = outgoingMessage.Receiver.Number.Value;
-            var businessReason = outgoingMessage.BusinessReason;
             _archivedMessageRepository.Add(new ArchivedMessage(
                 peekResult.BundleId.Id.ToString(),
                 peekResult.BundleId.Id.ToString(),
-                documentType,
-                ActorNumber.Create(senderId),
-                ActorNumber.Create(receiverId),
+                outgoingMessageBundle.DocumentType,
+                ActorNumber.Create(outgoingMessageBundle.SenderId.Value),
+                ActorNumber.Create(outgoingMessageBundle.Receiver.Number.Value),
                 timestamp,
-                businessReason,
+                outgoingMessageBundle.BusinessReason,
                 result));
         }
 

--- a/source/Domain/OutgoingMessages/OutgoingMessageBundle.cs
+++ b/source/Domain/OutgoingMessages/OutgoingMessageBundle.cs
@@ -1,0 +1,66 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Domain.Actors;
+using Domain.Documents;
+using Domain.OutgoingMessages.Queueing;
+using Domain.Transactions;
+
+namespace Domain.OutgoingMessages
+{
+    public class OutgoingMessageBundle
+    {
+        public OutgoingMessageBundle(DocumentType documentType, ActorNumber receiverId, ProcessId processId, string businessReason, MarketRole receiverRole, ActorNumber senderId, MarketRole senderRole, string messageRecord, bool isPublished, BundleId? assignedBundleId, IReadOnlyCollection<OutgoingMessage> outgoingMessages)
+        {
+            DocumentType = documentType;
+            ReceiverId = receiverId;
+            ProcessId = processId;
+            BusinessReason = businessReason;
+            ReceiverRole = receiverRole;
+            SenderId = senderId;
+            SenderRole = senderRole;
+            MessageRecord = messageRecord;
+            IsPublished = isPublished;
+            AssignedBundleId = assignedBundleId;
+            OutgoingMessages = outgoingMessages;
+            Id = Guid.NewGuid();
+        }
+
+        public Guid Id { get; }
+
+        public bool IsPublished { get; private set; }
+
+        public ActorNumber ReceiverId { get; }
+
+        public DocumentType DocumentType { get; }
+
+        public ProcessId ProcessId { get; }
+
+        public string BusinessReason { get; }
+
+        public MarketRole ReceiverRole { get; }
+
+        public ActorNumber SenderId { get; }
+
+        public MarketRole SenderRole { get; }
+
+        public string MessageRecord { get; }
+
+        public Receiver Receiver => Receiver.Create(ReceiverId, ReceiverRole);
+
+        public BundleId? AssignedBundleId { get; private set; }
+
+        public IReadOnlyCollection<OutgoingMessage> OutgoingMessages { get; set; }
+    }
+}

--- a/source/Infrastructure/OutgoingMessages/OutgoingMessageRepository.cs
+++ b/source/Infrastructure/OutgoingMessages/OutgoingMessageRepository.cs
@@ -21,26 +21,41 @@ using Domain.OutgoingMessages.Queueing;
 using Infrastructure.Configuration.DataAccess;
 using Microsoft.EntityFrameworkCore;
 
-namespace Infrastructure.OutgoingMessages
+namespace Infrastructure.OutgoingMessages;
+
+public class OutgoingMessageRepository : IOutgoingMessageRepository
 {
-    public class OutgoingMessageRepository : IOutgoingMessageRepository
+    private readonly B2BContext _context;
+
+    public OutgoingMessageRepository(B2BContext context)
     {
-        private readonly B2BContext _context;
+        _context = context;
+    }
 
-        public OutgoingMessageRepository(B2BContext context)
-        {
-            _context = context;
-        }
+    public void Add(OutgoingMessage message)
+    {
+        _context.OutgoingMessages.Add(message);
+    }
 
-        public void Add(OutgoingMessage message)
-        {
-            _context.OutgoingMessages.Add(message);
-        }
+    public async Task<OutgoingMessageBundle> GetAsync(BundleId bundleId)
+    {
+        var outgoingMessages = (await _context.OutgoingMessages.Where(x => x.AssignedBundleId == bundleId)
+            .ToListAsync().ConfigureAwait(false)).AsReadOnly();
 
-        public async Task<IReadOnlyCollection<OutgoingMessage>> GetAsync(BundleId bundleId)
-        {
-            return (await _context.OutgoingMessages.Where(x => x.AssignedBundleId == bundleId)
-                .ToListAsync().ConfigureAwait(false)).AsReadOnly();
-        }
+        //All messages in a bundle have the same meta data
+        var firstMessage = outgoingMessages.FirstOrDefault()!;
+
+        return new OutgoingMessageBundle(
+            firstMessage.DocumentType,
+            firstMessage.ReceiverId,
+            firstMessage.ProcessId,
+            firstMessage.BusinessReason,
+            firstMessage.ReceiverRole,
+            firstMessage.SenderId,
+            firstMessage.SenderRole,
+            firstMessage.MessageRecord,
+            firstMessage.IsPublished,
+            firstMessage.AssignedBundleId,
+            outgoingMessages);
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-market-roles) before we can accept your contribution. --->

## Description

When all messages are enqueued they are from the same process and document-type. Meaning they go into the same bundle and have all the same metadata.

So when we retrieve OutGoingMessages they are now packed in an OutgoingMessageBundle and the metadata from the bundle is set on the type.

