### PR TITLE
fix: Reduced aggregation bundle size to 1

### DIFF
--- a/source/Domain/OutgoingMessages/Queueing/ActorMessageQueue.cs
+++ b/source/Domain/OutgoingMessages/Queueing/ActorMessageQueue.cs
@@ -59,7 +59,7 @@ public class ActorMessageQueue : Entity
         if (maxNumberOfMessagesInABundle != null)
             return maxNumberOfMessagesInABundle.Value;
 
-        return documentType.Category == MessageCategory.Aggregations ? 3 : 10000;
+        return documentType.Category == MessageCategory.Aggregations ? 1 : 10000;
     }
 
     public PeekResult Peek()

--- a/source/Tests/Domain/OutgoingMessages/Queueing/ActorMessageQueueTests.cs
+++ b/source/Tests/Domain/OutgoingMessages/Queueing/ActorMessageQueueTests.cs
@@ -147,18 +147,13 @@ public class ActorMessageQueueTests
     }
 
     [Fact]
-    public void Bundle_size_is_6_for_aggregations_message_category()
+    public void Bundle_size_is_1_for_aggregations_message_category()
     {
         var receiver = Receiver.Create(ActorNumber.Create("1234567890123"), MarketRole.EnergySupplier);
         var actorMessageQueue = ActorMessageQueue.CreateFor(receiver);
 
-        var messageAssignedToFirstBundle = null as OutgoingMessage;
-
-        for (var i = 0; i < 6; i++)
-        {
-            messageAssignedToFirstBundle = CreateOutgoingMessage(receiver, BusinessReason.BalanceFixing, DocumentType.NotifyAggregatedMeasureData);
-            actorMessageQueue.Enqueue(messageAssignedToFirstBundle);
-        }
+        var messageAssignedToFirstBundle = CreateOutgoingMessage(receiver, BusinessReason.BalanceFixing, DocumentType.NotifyAggregatedMeasureData);
+        actorMessageQueue.Enqueue(messageAssignedToFirstBundle);
 
         var messageAssignedToSecondBundle = CreateOutgoingMessage(receiver, BusinessReason.BalanceFixing);
         actorMessageQueue.Enqueue(messageAssignedToSecondBundle);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Currently bundles containing aggregations may contain 6 different messages. This is reduced to 1 to ensure we do not get "out of memory" exceptions

## References
