### PR TITLE
fix: remove healthcheck for domain relay queue

### DIFF
--- a/source/Api/Program.cs
+++ b/source/Api/Program.cs
@@ -160,7 +160,6 @@ namespace Energinet.DataHub.EDI.Api
                     services.AddLiveHealthCheck();
                     services.AddExternalDomainServiceBusQueuesHealthCheck(
                         runtime.SERVICE_BUS_CONNECTION_STRING_FOR_DOMAIN_RELAY_MANAGE!,
-                        runtime.INCOMING_CHANGE_OF_SUPPLIER_MESSAGE_QUEUE_NAME!,
                         runtime.EDI_INBOX_MESSAGE_QUEUE_NAME!,
                         runtime.WHOLESALE_INBOX_MESSAGE_QUEUE_NAME!);
                     services.AddSqlServerHealthCheck(runtime.DB_CONNECTION_STRING!);

--- a/source/Api/Program.cs
+++ b/source/Api/Program.cs
@@ -101,9 +101,6 @@ namespace Energinet.DataHub.EDI.Api
                         runtime.WHOLESALE_INBOX_MESSAGE_QUEUE_NAME!));
 
                     services.AddSingleton(
-                        _ => new RequestChangeOfSupplierTransaction(runtime.INCOMING_CHANGE_OF_SUPPLIER_MESSAGE_QUEUE_NAME!));
-
-                    services.AddSingleton(
                         _ => new RequestChangeCustomerCharacteristicsTransaction("NotImplemented"));
 
                     services.AddApplicationInsights();

--- a/source/Api/RuntimeEnvironment.cs
+++ b/source/Api/RuntimeEnvironment.cs
@@ -27,8 +27,6 @@ namespace Energinet.DataHub.EDI.Api
         public virtual string? SERVICE_BUS_CONNECTION_STRING_FOR_DOMAIN_RELAY_SEND =>
             GetEnvironmentVariable(nameof(SERVICE_BUS_CONNECTION_STRING_FOR_DOMAIN_RELAY_SEND));
 
-        public virtual string? INCOMING_CHANGE_OF_SUPPLIER_MESSAGE_QUEUE_NAME => GetEnvironmentVariable(nameof(INCOMING_CHANGE_OF_SUPPLIER_MESSAGE_QUEUE_NAME));
-
         public virtual string? EDI_INBOX_MESSAGE_QUEUE_NAME => GetEnvironmentVariable(nameof(EDI_INBOX_MESSAGE_QUEUE_NAME));
 
         public virtual string? WHOLESALE_INBOX_MESSAGE_QUEUE_NAME => GetEnvironmentVariable(nameof(WHOLESALE_INBOX_MESSAGE_QUEUE_NAME));


### PR DESCRIPTION
The queue was removed from infrastructure in this commit:
https://github.com/Energinet-DataHub/dh3-infrastructure/commit/3d2fec1b903e5643278952a2b6b9fb136f5e6971#diff-ab63f0dcf4543b52070c7736d1f98cd9b1031c92f46ddd79febfc365a957a1fd

The health check needs to be removed