### PR TITLE
fix: sql timeouts in our retention job

### DIFF
--- a/source/Infrastructure/Configuration/IntegrationEvents/ReceivedIntegrationEventsRetention.cs
+++ b/source/Infrastructure/Configuration/IntegrationEvents/ReceivedIntegrationEventsRetention.cs
@@ -49,7 +49,7 @@ public class ReceivedIntegrationEventsRetention : IDataRetention
             const string deleteStmt = @"
                 WITH CTE AS
                  (
-                     SELECT TOP 100 *
+                     SELECT TOP 500 *
                      FROM [dbo].[ReceivedIntegrationEvents]
                      WHERE [ProcessedDate] IS NOT NULL AND [ErrorMessage] IS NULL AND [ProcessedDate] < @LastMonthInstant
                  )
@@ -68,7 +68,9 @@ public class ReceivedIntegrationEventsRetention : IDataRetention
 
             try
             {
+                var numberDeletedRecords = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
                 await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation("Successfully deleted {NumberDeletedIntegrationEvents} of integration events", numberDeletedRecords);
             }
             catch (DbException e)
             {

--- a/source/Infrastructure/DataRetention/ExecuteDataRetentionsWhenADayHasPassed.cs
+++ b/source/Infrastructure/DataRetention/ExecuteDataRetentionsWhenADayHasPassed.cs
@@ -43,9 +43,9 @@ public class ExecuteDataRetentionsWhenADayHasPassed : INotificationHandler<ADayH
             .Handle<Exception>()
             .WaitAndRetryAsync(new[]
             {
-                TimeSpan.FromSeconds(1),
-                TimeSpan.FromSeconds(2),
-                TimeSpan.FromSeconds(4),
+                TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(15),
+                TimeSpan.FromSeconds(30),
             });
 
         foreach (var dataCleaner in _dataRetentions)

--- a/source/Infrastructure/InboxEvents/ReceivedInboxEventsRetention.cs
+++ b/source/Infrastructure/InboxEvents/ReceivedInboxEventsRetention.cs
@@ -49,7 +49,7 @@ public class ReceivedInboxEventsRetention : IDataRetention
             const string deleteStmt = @"
                 WITH CTE AS
                  (
-                     SELECT TOP 100 *
+                     SELECT TOP 500 *
                      FROM [dbo].[ReceivedInboxEvents]
                      WHERE [ErrorMessage] IS NULL AND [ProcessedDate] IS NOT NULL AND [ProcessedDate] < @LastMonthInstant
                  )
@@ -68,7 +68,9 @@ public class ReceivedInboxEventsRetention : IDataRetention
 
             try
             {
+                var numberDeletedRecords = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
                 await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation("Successfully deleted {NumberDeletedInboxEvents} of inbox events", numberDeletedRecords);
             }
             catch (DbException e)
             {

--- a/source/IntegrationTests/Infrastructure/Retention/RemoveInternalCommandsWhenADayHasPassedTests.cs
+++ b/source/IntegrationTests/Infrastructure/Retention/RemoveInternalCommandsWhenADayHasPassedTests.cs
@@ -21,6 +21,7 @@ using Energinet.DataHub.EDI.Application.Configuration.DataAccess;
 using Energinet.DataHub.EDI.Infrastructure.Configuration.DataAccess;
 using Energinet.DataHub.EDI.Infrastructure.Configuration.InternalCommands;
 using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.Retention;
@@ -37,7 +38,7 @@ public class RemoveInternalCommandsWhenADayHasPassedTests : TestBase
     {
         _b2BContext = GetService<B2BContext>();
         _systemDateTimeProvider = GetService<ISystemDateTimeProvider>();
-        _sut = new InternalCommandsRetention(GetService<IDatabaseConnectionFactory>());
+        _sut = new InternalCommandsRetention(GetService<IDatabaseConnectionFactory>(), GetService<ILogger<InternalCommandsRetention>>());
     }
 
     [Fact]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
We are still getting some timeouts in our nigthly clean ups. 
 This should address Sql connection time out after 30 sec because of smaller batch size for commands and a longer wait between retries if db is asleep. 

## References
