### PR TITLE
fix: empty queue before publishing AggregationResultReady

### DIFF
--- a/source/AcceptanceTests/Dsl/AggregationResultDsl.cs
+++ b/source/AcceptanceTests/Dsl/AggregationResultDsl.cs
@@ -39,4 +39,9 @@ internal sealed class AggregationResultDsl
     {
         return _edi.PeekMessageAsync(actorNumber, new[] { actorRole, });
     }
+
+    internal async Task EmptyQueueForActor(string actorNumber, string actorRole)
+    {
+        await _edi.EmptyQueueAsync(actorNumber, new[] { actorRole, }).ConfigureAwait(false);
+    }
 }

--- a/source/AcceptanceTests/WhenAggregationResultIsPublishedTests.cs
+++ b/source/AcceptanceTests/WhenAggregationResultIsPublishedTests.cs
@@ -33,7 +33,10 @@ public sealed class WhenAggregationResultIsPublishedTests : TestRunner
     [Fact]
     public async Task Actor_can_peek_and_dequeue_aggregation_result()
     {
+        await _aggregations.EmptyQueueForActor(actorNumber: "5790000610976", actorRole: "metereddataresponsible").ConfigureAwait(false);
+
         await _aggregations.PublishResultFor(gridAreaCode: "543").ConfigureAwait(false);
+
         await _aggregations
             .ConfirmResultIsAvailableFor(actorNumber: "5790000610976", actorRole: "metereddataresponsible")
             .ConfigureAwait(false);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

## References
