### PR TITLE
feat: Support for RejectAggregatedMeasureDataResult in ebIX (team-phoenix#80)

### DIFF
--- a/source/Domain/Transactions/Aggregations/ReasonCode.cs
+++ b/source/Domain/Transactions/Aggregations/ReasonCode.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.Domain.Common;
+
+namespace Energinet.DataHub.EDI.Domain.Transactions.Aggregations;
+
+public class ReasonCode : EnumerationType
+{
+    public static readonly ReasonCode FullyAcceptet = new(0, nameof(FullyAcceptet), "A01");
+    public static readonly ReasonCode FullyRejected = new(1, nameof(FullyRejected), "A02");
+
+    public ReasonCode(int id, string name, string code)
+        : base(id, name)
+    {
+        Code = code;
+    }
+
+    public string Code { get; }
+
+    public static ReasonCode From(string valueToParseFrom)
+    {
+        return GetAll
+                <ReasonCode>()
+            .First(reasonCode => reasonCode.Name.Equals(valueToParseFrom, StringComparison.OrdinalIgnoreCase) ||
+                                 reasonCode.Code.Equals(valueToParseFrom, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/source/Infrastructure/OutgoingMessages/AggregationResult/AggregationResultEbixDocumentWriter.cs
+++ b/source/Infrastructure/OutgoingMessages/AggregationResult/AggregationResultEbixDocumentWriter.cs
@@ -50,7 +50,7 @@ public class AggregationResultEbixDocumentWriter : EbixDocumentWriter
     public override bool HandlesType(DocumentType documentType)
     {
         if (documentType == null) throw new ArgumentNullException(nameof(documentType));
-        return documentType.Name.Equals("NotifyAggregatedMeasureData", StringComparison.OrdinalIgnoreCase);
+        return DocumentType.NotifyAggregatedMeasureData == documentType;
     }
 
     protected override SettlementVersion? ExtractSettlementVersion(IReadOnlyCollection<string> marketActivityPayloads)

--- a/source/Infrastructure/OutgoingMessages/Common/CimCode.cs
+++ b/source/Infrastructure/OutgoingMessages/Common/CimCode.cs
@@ -169,6 +169,18 @@ public static class CimCode
         throw NoCodeFoundFor(quality.Name);
     }
 
+    public static string Of(ReasonCode reasonCode)
+    {
+        ArgumentNullException.ThrowIfNull(reasonCode);
+
+        if (reasonCode == ReasonCode.FullyAcceptet)
+            return "A01";
+        if (reasonCode == ReasonCode.FullyRejected)
+            return "A02";
+
+        throw NoCodeFoundFor(reasonCode.Name);
+    }
+
     public static string CodingSchemeOf(ActorNumber actorNumber)
     {
         ArgumentNullException.ThrowIfNull(actorNumber);

--- a/source/Infrastructure/OutgoingMessages/Common/Ebix/EbixHeaderWriter.cs
+++ b/source/Infrastructure/OutgoingMessages/Common/Ebix/EbixHeaderWriter.cs
@@ -42,7 +42,7 @@ internal static class EbixHeaderWriter
         await writer.WriteElementStringAsync(documentDetails.Prefix, "Identification", null, messageHeader.MessageId).ConfigureAwait(false);
         await writer.WriteStartElementAsync(documentDetails.Prefix, "DocumentType", null).ConfigureAwait(false);
         await writer.WriteAttributeStringAsync(null, "listAgencyIdentifier", null, "260").ConfigureAwait(false);
-        writer.WriteValue("E31");
+        writer.WriteValue(documentDetails.TypeCode);
         await writer.WriteEndElementAsync().ConfigureAwait(false);
 
         await writer.WriteElementStringAsync(documentDetails.Prefix, "Creation", null, messageHeader.TimeStamp.ToString()).ConfigureAwait(false);

--- a/source/Infrastructure/OutgoingMessages/Common/EbixCode.cs
+++ b/source/Infrastructure/OutgoingMessages/Common/EbixCode.cs
@@ -165,6 +165,18 @@ public static class EbixCode
         throw NoCodeFoundFor(quality.Name);
     }
 
+    public static string Of(ReasonCode reasonCode)
+    {
+        ArgumentNullException.ThrowIfNull(reasonCode);
+
+        if (reasonCode == ReasonCode.FullyAcceptet)
+            return "39";
+        if (reasonCode == ReasonCode.FullyRejected)
+            return "41";
+
+        throw NoCodeFoundFor(reasonCode.Name);
+    }
+
     private static Exception NoCodeFoundFor(string domainType)
     {
         return new InvalidOperationException($"No code has been defined for {domainType}");

--- a/source/Infrastructure/OutgoingMessages/RejectRequestAggregatedMeasureData/RejectRequestAggregatedMeasureDataEbixDocumentWriter.cs
+++ b/source/Infrastructure/OutgoingMessages/RejectRequestAggregatedMeasureData/RejectRequestAggregatedMeasureDataEbixDocumentWriter.cs
@@ -1,0 +1,96 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml;
+using Energinet.DataHub.EDI.Application.IncomingMessages;
+using Energinet.DataHub.EDI.Application.OutgoingMessages.Common;
+using Energinet.DataHub.EDI.Application.OutgoingMessages.Common.Xml;
+using Energinet.DataHub.EDI.Domain.Actors;
+using Energinet.DataHub.EDI.Domain.Documents;
+using Energinet.DataHub.EDI.Domain.OutgoingMessages;
+using Energinet.DataHub.EDI.Domain.OutgoingMessages.NotifyAggregatedMeasureData;
+using Energinet.DataHub.EDI.Domain.OutgoingMessages.RejectedRequestAggregatedMeasureData;
+using Energinet.DataHub.EDI.Domain.Transactions.Aggregations;
+using Energinet.DataHub.EDI.Infrastructure.OutgoingMessages.Common;
+using Energinet.DataHub.EDI.Infrastructure.OutgoingMessages.Common.Xml;
+using Point = Energinet.DataHub.EDI.Domain.OutgoingMessages.NotifyAggregatedMeasureData.Point;
+
+namespace Energinet.DataHub.EDI.Infrastructure.OutgoingMessages.AggregationResult;
+
+public class RejectRequestAggregatedMeasureDataEbixDocumentWriter : EbixDocumentWriter
+{
+    public RejectRequestAggregatedMeasureDataEbixDocumentWriter(IMessageRecordParser parser)
+        : base(
+            new DocumentDetails(
+            "DK_RejectRequestMeteredDataAggregated",
+            string.Empty,
+            "un:unece:260:data:EEM-DK_RejectRequestMeteredDataAggregated:v3",
+            "ns0",
+            "ERR"),
+            parser,
+            EbixCode.Of(ReasonCode.FullyRejected))
+    {
+    }
+
+    public override bool HandlesType(DocumentType documentType)
+    {
+        if (documentType == null) throw new ArgumentNullException(nameof(documentType));
+        return DocumentType.RejectRequestAggregatedMeasureData == documentType;
+    }
+
+    protected override async Task WriteMarketActivityRecordsAsync(IReadOnlyCollection<string> marketActivityPayloads, XmlWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(marketActivityPayloads);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        foreach (var rejectedTimeSerie in ParseFrom<RejectedTimeSerie>(marketActivityPayloads))
+        {
+            if (rejectedTimeSerie.RejectReasons.Count == 0)
+                throw new NotSupportedException("Unable to create reject message if no reason is supplied");
+
+            // Begin PayloadResponseEvent
+            await writer.WriteStartElementAsync(DocumentDetails.Prefix, "PayloadResponseEvent", null).ConfigureAwait(false);
+
+            await writer.WriteElementStringAsync(DocumentDetails.Prefix, "Identification", null, rejectedTimeSerie.TransactionId.ToString()).ConfigureAwait(false);
+
+            await writer.WriteStartElementAsync(DocumentDetails.Prefix, "StatusType", null).ConfigureAwait(false);
+            await writer.WriteAttributeStringAsync(null, "listAgencyIdentifier", null, "6").ConfigureAwait(false);
+            await writer.WriteStringAsync(EbixCode.Of(ReasonCode.FullyRejected)).ConfigureAwait(false);
+            await writer.WriteEndElementAsync().ConfigureAwait(false);
+
+            await writer.WriteStartElementAsync(DocumentDetails.Prefix, "ResponseReasonType", null).ConfigureAwait(false);
+            await writer.WriteAttributeStringAsync(null, "listAgencyIdentifier", null, "260").ConfigureAwait(false);
+            await writer.WriteStringAsync(rejectedTimeSerie.RejectReasons[0].ErrorCode).ConfigureAwait(false);
+            await writer.WriteEndElementAsync().ConfigureAwait(false);
+
+            await writer.WriteElementStringAsync(DocumentDetails.Prefix, "OriginalBusinessDocument", null, rejectedTimeSerie.OriginalTransactionIdReference).ConfigureAwait(false);
+
+            // End PayloadResponseEvent
+            await writer.WriteEndElementAsync().ConfigureAwait(false);
+        }
+    }
+
+    private Task WriteQualityIfRequiredAsync(XmlWriter writer, Point point)
+    {
+        if (point.Quality is null)
+            return Task.CompletedTask;
+
+        return writer.WriteElementStringAsync(DocumentDetails.Prefix, "QuantityQuality", null, EbixCode.Of(Quality.From(point.Quality)));
+    }
+}

--- a/source/Infrastructure/OutgoingMessages/RejectRequestAggregatedMeasureData/RejectRequestAggregatedMeasureDataJsonDocumentWriter.cs
+++ b/source/Infrastructure/OutgoingMessages/RejectRequestAggregatedMeasureData/RejectRequestAggregatedMeasureDataJsonDocumentWriter.cs
@@ -21,6 +21,8 @@ using Energinet.DataHub.EDI.Application.OutgoingMessages.Common;
 using Energinet.DataHub.EDI.Domain.Documents;
 using Energinet.DataHub.EDI.Domain.OutgoingMessages;
 using Energinet.DataHub.EDI.Domain.OutgoingMessages.RejectedRequestAggregatedMeasureData;
+using Energinet.DataHub.EDI.Domain.Transactions.Aggregations;
+using Energinet.DataHub.EDI.Infrastructure.OutgoingMessages.Common;
 using Energinet.DataHub.EDI.Infrastructure.OutgoingMessages.Common.Json;
 using DocumentFormat = Energinet.DataHub.EDI.Domain.Documents.DocumentFormat;
 
@@ -53,7 +55,7 @@ public class RejectRequestAggregatedMeasureDataJsonDocumentWriter : IDocumentWri
         var options = new JsonWriterOptions() { Indented = true };
         using var writer = new Utf8JsonWriter(stream, options);
 
-        JsonHeaderWriter.Write(header, DocumentType, TypeCode, "A02", writer);
+        JsonHeaderWriter.Write(header, DocumentType, TypeCode, CimCode.Of(ReasonCode.FullyRejected), writer);
         WriteSeries(marketActivityRecords, writer);
         writer.WriteEndObject();
         await writer.FlushAsync().ConfigureAwait(false);

--- a/source/Infrastructure/OutgoingMessages/RejectRequestAggregatedMeasureData/RejectRequestAggregatedMeasureDataXmlDocumentWriter.cs
+++ b/source/Infrastructure/OutgoingMessages/RejectRequestAggregatedMeasureData/RejectRequestAggregatedMeasureDataXmlDocumentWriter.cs
@@ -20,6 +20,8 @@ using Energinet.DataHub.EDI.Application.OutgoingMessages.Common;
 using Energinet.DataHub.EDI.Application.OutgoingMessages.Common.Xml;
 using Energinet.DataHub.EDI.Domain.Documents;
 using Energinet.DataHub.EDI.Domain.OutgoingMessages.RejectedRequestAggregatedMeasureData;
+using Energinet.DataHub.EDI.Domain.Transactions.Aggregations;
+using Energinet.DataHub.EDI.Infrastructure.OutgoingMessages.Common;
 using Energinet.DataHub.EDI.Infrastructure.OutgoingMessages.Common.Xml;
 
 namespace Energinet.DataHub.EDI.Infrastructure.OutgoingMessages.RejectRequestAggregatedMeasureData;
@@ -35,12 +37,13 @@ public class RejectRequestAggregatedMeasureDataXmlDocumentWriter : DocumentWrite
                 "cim",
                 "ERR"),
             parser,
-            "A02")
+            CimCode.Of(ReasonCode.FullyRejected))
     {
     }
 
     public override bool HandlesType(DocumentType documentType)
     {
+        if (documentType == null) throw new ArgumentNullException(nameof(documentType));
         return DocumentType.RejectRequestAggregatedMeasureData == documentType;
     }
 

--- a/source/Tests/Infrastructure/OutgoingMessages/RejectRequestAggregatedMeasureData/AssertRejectRequestAggregatedMeasureDataResultJsonDocument.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/RejectRequestAggregatedMeasureData/AssertRejectRequestAggregatedMeasureDataResultJsonDocument.cs
@@ -27,13 +27,13 @@ using Xunit;
 
 namespace Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.RejectRequestAggregatedMeasureData;
 
-internal sealed class RejectRequestAggregatedMeasureDataResultJsonDocument : IAssertRejectedAggregatedMeasureDataResultDocument
+internal sealed class AssertRejectRequestAggregatedMeasureDataResultJsonDocument : IAssertRejectedAggregatedMeasureDataResultDocument
 {
     private readonly JsonSchemaProvider _schemas = new(new CimJsonSchemas());
     private readonly JsonDocument _document;
     private readonly JsonElement _root;
 
-    public RejectRequestAggregatedMeasureDataResultJsonDocument(Stream document)
+    public AssertRejectRequestAggregatedMeasureDataResultJsonDocument(Stream document)
     {
         _document = JsonDocument.Parse(document);
         _root = _document.RootElement.GetProperty("RejectRequestAggregatedMeasureData_MarketDocument");

--- a/source/Tests/Infrastructure/OutgoingMessages/RejectRequestAggregatedMeasureData/AssertRejectedAggregatedMeasureDataResultEbixDocument.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/RejectRequestAggregatedMeasureData/AssertRejectedAggregatedMeasureDataResultEbixDocument.cs
@@ -1,0 +1,102 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Energinet.DataHub.EDI.Domain.OutgoingMessages;
+using Energinet.DataHub.EDI.Domain.Transactions.Aggregations;
+using Energinet.DataHub.EDI.Infrastructure.DocumentValidation;
+using Energinet.DataHub.EDI.Infrastructure.OutgoingMessages.Common;
+using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
+using NodaTime;
+
+namespace Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.RejectRequestAggregatedMeasureData;
+
+public class AssertRejectedAggregatedMeasureDataResultEbixDocument : IAssertRejectedAggregatedMeasureDataResultDocument
+{
+    private readonly AssertEbixDocument _documentAsserter;
+
+    public AssertRejectedAggregatedMeasureDataResultEbixDocument(AssertEbixDocument documentAsserter)
+    {
+        _documentAsserter = documentAsserter;
+        _documentAsserter.HasValue("HeaderEnergyDocument/DocumentType", "ERR");
+    }
+
+    public async Task<IAssertRejectedAggregatedMeasureDataResultDocument> DocumentIsValidAsync()
+    {
+        await _documentAsserter.HasValidStructureAsync(DocumentType.RejectRequestAggregatedMeasureData).ConfigureAwait(false);
+        return this;
+    }
+
+    public IAssertRejectedAggregatedMeasureDataResultDocument HasBusinessReason(BusinessReason businessReason)
+    {
+        _documentAsserter.HasValue("ProcessEnergyContext/EnergyBusinessProcess", EbixCode.Of(businessReason));
+        return this;
+    }
+
+    public IAssertRejectedAggregatedMeasureDataResultDocument HasReasonCode(string reasonCode)
+    {
+        _documentAsserter.HasValue("PayloadResponseEvent[1]/StatusType", EbixCode.Of(ReasonCode.From(reasonCode)));
+        return this;
+    }
+
+    public IAssertRejectedAggregatedMeasureDataResultDocument HasMessageId(string expectedMessageId)
+    {
+        _documentAsserter.HasValue("HeaderEnergyDocument/Identification", expectedMessageId);
+        return this;
+    }
+
+    public IAssertRejectedAggregatedMeasureDataResultDocument HasSenderId(string expectedSenderId)
+    {
+        _documentAsserter.HasValue("HeaderEnergyDocument/SenderEnergyParty/Identification", expectedSenderId);
+        return this;
+    }
+
+    public IAssertRejectedAggregatedMeasureDataResultDocument HasReceiverId(string expectedReceiverId)
+    {
+        _documentAsserter.HasValue("HeaderEnergyDocument/RecipientEnergyParty/Identification", expectedReceiverId);
+        return this;
+    }
+
+    public IAssertRejectedAggregatedMeasureDataResultDocument HasTimestamp(Instant expectedTimestamp)
+    {
+        _documentAsserter.HasValue("HeaderEnergyDocument/Creation", expectedTimestamp.ToString());
+        return this;
+    }
+
+    public IAssertRejectedAggregatedMeasureDataResultDocument HasTransactionId(Guid expectedTransactionId)
+    {
+        _documentAsserter.HasValue($"PayloadResponseEvent[1]/Identification", expectedTransactionId.ToString());
+        return this;
+    }
+
+    public IAssertRejectedAggregatedMeasureDataResultDocument HasOriginalTransactionId(string expectedOriginalTransactionId)
+    {
+        _documentAsserter.HasValue("PayloadResponseEvent[1]/OriginalBusinessDocument", expectedOriginalTransactionId);
+        return this;
+    }
+
+    public IAssertRejectedAggregatedMeasureDataResultDocument HasSerieReasonCode(string expectedSerieReasonCode)
+    {
+        _documentAsserter.HasValue($"PayloadResponseEvent[1]/ResponseReasonType", expectedSerieReasonCode);
+        return this;
+    }
+
+    public IAssertRejectedAggregatedMeasureDataResultDocument HasSerieReasonMessage(string expectedSerieReasonMessage)
+    {
+        //In ebIX we don't have a field for text information meaning this method should always assert true
+        return this;
+    }
+}

--- a/source/Tests/Infrastructure/OutgoingMessages/RejectRequestAggregatedMeasureData/RejectRequestAggregatedMeasureDataResultDocumentWriterTests.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/RejectRequestAggregatedMeasureData/RejectRequestAggregatedMeasureDataResultDocumentWriterTests.cs
@@ -16,10 +16,12 @@ using System.IO;
 using System.Threading.Tasks;
 using Energinet.DataHub.EDI.Application.OutgoingMessages.Common;
 using Energinet.DataHub.EDI.Infrastructure.Configuration.Serialization;
+using Energinet.DataHub.EDI.Infrastructure.OutgoingMessages.AggregationResult;
 using Energinet.DataHub.EDI.Infrastructure.OutgoingMessages.Common;
 using Energinet.DataHub.EDI.Infrastructure.OutgoingMessages.RejectRequestAggregatedMeasureData;
 using Energinet.DataHub.EDI.Tests.Factories;
 using Energinet.DataHub.EDI.Tests.Fixtures;
+using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.AggregationResult;
 using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
 using Xunit;
 using DocumentFormat = Energinet.DataHub.EDI.Domain.Documents.DocumentFormat;
@@ -43,6 +45,7 @@ public class RejectRequestAggregatedMeasureDataResultDocumentWriterTests : IClas
     [Theory]
     [InlineData(nameof(DocumentFormat.Xml))]
     [InlineData(nameof(DocumentFormat.Json))]
+    [InlineData(nameof(DocumentFormat.Ebix))]
     public async Task Can_create_document(string documentFormat)
     {
         var document = await CreateDocument(
@@ -68,7 +71,13 @@ public class RejectRequestAggregatedMeasureDataResultDocumentWriterTests : IClas
     {
         var documentHeader = resultBuilder.BuildHeader();
         var records = _parser.From(resultBuilder.BuildRejectedTimeSerie());
-        if (documentFormat == DocumentFormat.Xml)
+        if (documentFormat == DocumentFormat.Ebix)
+        {
+            return new RejectRequestAggregatedMeasureDataEbixDocumentWriter(_parser).WriteAsync(
+                documentHeader,
+                new[] { records, });
+        }
+        else if (documentFormat == DocumentFormat.Xml)
         {
             return new RejectRequestAggregatedMeasureDataXmlDocumentWriter(_parser).WriteAsync(
                 documentHeader,
@@ -84,14 +93,19 @@ public class RejectRequestAggregatedMeasureDataResultDocumentWriterTests : IClas
 
     private IAssertRejectedAggregatedMeasureDataResultDocument AssertDocument(Stream document, DocumentFormat documentFormat)
     {
-        if (documentFormat == DocumentFormat.Xml)
+        if (documentFormat == DocumentFormat.Ebix)
+        {
+            var assertEbixDocument = AssertEbixDocument.Document(document, "ns0");
+            return new AssertRejectedAggregatedMeasureDataResultEbixDocument(assertEbixDocument);
+        }
+        else if (documentFormat == DocumentFormat.Xml)
         {
             var assertXmlDocument = AssertXmlDocument.Document(document, "cim", _documentValidation.Validator);
             return new AssertRejectedAggregatedMeasureDataResultXmlDocument(assertXmlDocument);
         }
         else
         {
-            return new RejectRequestAggregatedMeasureDataResultJsonDocument(document);
+            return new AssertRejectRequestAggregatedMeasureDataResultJsonDocument(document);
         }
     }
 }


### PR DESCRIPTION
## Description
Main purpose for PR is support for RSM014 / DK_RejectRequestMeteredDataAggregated in ebIX.
Also created the ReasonCode enum as this has diffenent outputs for CIM and ebIX and it also improved readability in the code. Renamed file and class RejectRequestAggregatedMeasureDataResultJsonDocument to AssertRejectRequestAggregatedMeasureDataResultJsonDocument as the implementation is an asserter.

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-phoenix/80