### PR TITLE
feat: add permission to B2C RequestAggMeaData

### DIFF
--- a/source/B2CWebApi/Controllers/RequestAggregatedMeasureDataController.cs
+++ b/source/B2CWebApi/Controllers/RequestAggregatedMeasureDataController.cs
@@ -17,6 +17,7 @@ using Energinet.DataHub.EDI.B2CWebApi.Clients;
 using Energinet.DataHub.EDI.B2CWebApi.Factories;
 using Energinet.DataHub.EDI.B2CWebApi.Models;
 using Energinet.DataHub.EDI.B2CWebApi.Security;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Energinet.DataHub.EDI.B2CWebApi.Controllers;
@@ -37,6 +38,7 @@ public class RequestAggregatedMeasureDataController : ControllerBase
     }
 
     [HttpPost]
+    [Authorize(Roles = "request-aggregated-measured-data:view")]
     public async Task<ActionResult> RequestAsync(RequestAggregatedMeasureDataMarketRequest request, CancellationToken cancellationToken)
     {
         var currentUser = _userContext.CurrentUser;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
This PR will ensure that only users with the correct permission will be allowed to create requests for aggregated measured data.

Its builds on a PR created in MarkPart here: https://github.com/Energinet-DataHub/geh-market-participant/pull/635

## References
