### PR TITLE
fix: Test of duplicated message id's

### DIFF
--- a/source/IntegrationTests/Application/IncomingMessages/RequestAggregatedMeasureData/InitializeAggregatedMeasureDataProcessesCommandTests.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/RequestAggregatedMeasureData/InitializeAggregatedMeasureDataProcessesCommandTests.cs
@@ -120,6 +120,7 @@ public class InitializeAggregatedMeasureDataProcessesCommandTests : TestBase
         var task02 = InvokeCommandAsync(new InitializeAggregatedMeasureDataProcessesCommand(marketMessage02));
 
         var tasks = new[] { task01, task02 };
+
         try
         {
             await Task.WhenAll(tasks);
@@ -135,12 +136,11 @@ public class InitializeAggregatedMeasureDataProcessesCommandTests : TestBase
 
         Assert.Single(processes);
 
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-        Assert.Single(tasks.Where(t => t.Status == TaskStatus.RanToCompletion));
-        Assert.Single(tasks.Where(t => t.Status == TaskStatus.Faulted));
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+        var taskStatuses = tasks.Select(t => t.Status).ToList();
+        Assert.Single(taskStatuses.Where(status => status == TaskStatus.RanToCompletion));
+        Assert.Single(taskStatuses.Where(status => status == TaskStatus.Faulted));
 
-        var completedTaskIndex = tasks.ToList().FindIndex(t => t.Status == TaskStatus.RanToCompletion);
+        var completedTaskIndex = taskStatuses.FindIndex(status => status == TaskStatus.RanToCompletion);
         var completedTaskMessage = completedTaskIndex == 0 ? marketMessage01 : marketMessage02;
 
         var process = processes.First();

--- a/source/IntegrationTests/Application/IncomingMessages/RequestAggregatedMeasureData/InitializeAggregatedMeasureDataProcessesCommandTests.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/RequestAggregatedMeasureData/InitializeAggregatedMeasureDataProcessesCommandTests.cs
@@ -134,7 +134,6 @@ public class InitializeAggregatedMeasureDataProcessesCommandTests : TestBase
         var processes = GetProcesses(marketMessage01.SenderNumber).ToList();
 
         Assert.Single(processes);
-        var process = processes.First();
 
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
         Assert.Single(tasks.Where(t => t.Status == TaskStatus.RanToCompletion));
@@ -143,6 +142,8 @@ public class InitializeAggregatedMeasureDataProcessesCommandTests : TestBase
 
         var completedTaskIndex = tasks.ToList().FindIndex(t => t.Status == TaskStatus.RanToCompletion);
         var completedTaskMessage = completedTaskIndex == 0 ? marketMessage01 : marketMessage02;
+
+        var process = processes.First();
 
         Assert.Equal(completedTaskMessage.Series.First().Id, process.BusinessTransactionId.Id);
         AssertProcessState(process, AggregatedMeasureDataProcess.State.Initialized);


### PR DESCRIPTION
## Description

`task02` in the integration test `Duplicated_message_id_across_commands_one_aggregated_measure_data_process_is_created` sometimes completes before `task01` locally, which causes the test to fail. The test now checks which task was successful, and uses that task for assertion.