### PR TITLE
fix: Missing attributes are set to null when requesting in xml

### DIFF
--- a/source/Domain/Transactions/AggregatedMeasureData/AggregatedMeasureDataProcess.cs
+++ b/source/Domain/Transactions/AggregatedMeasureData/AggregatedMeasureDataProcess.cs
@@ -18,7 +18,6 @@ using Energinet.DataHub.EDI.Domain.OutgoingMessages;
 using Energinet.DataHub.EDI.Domain.OutgoingMessages.RejectedRequestAggregatedMeasureData;
 using Energinet.DataHub.EDI.Domain.Transactions.AggregatedMeasureData.ProcessEvents;
 using Energinet.DataHub.EDI.Domain.Transactions.Aggregations;
-using NodaTime;
 
 namespace Energinet.DataHub.EDI.Domain.Transactions.AggregatedMeasureData
 {
@@ -45,12 +44,12 @@ namespace Energinet.DataHub.EDI.Domain.Transactions.AggregatedMeasureData
             BusinessTransactionId = businessTransactionId;
             BusinessReason = businessReason;
             MeteringPointType = meteringPointType;
-            SettlementMethod = string.IsNullOrWhiteSpace(settlementMethod) ? null : settlementMethod;
+            SettlementMethod = settlementMethod;
             StartOfPeriod = startOfPeriod;
             EndOfPeriod = endOfPeriod;
             MeteringGridAreaDomainId = meteringGridAreaDomainId;
-            EnergySupplierId = string.IsNullOrWhiteSpace(energySupplierId) ? null : energySupplierId;
-            BalanceResponsibleId = string.IsNullOrWhiteSpace(balanceResponsibleId) ? null : balanceResponsibleId;
+            EnergySupplierId = energySupplierId;
+            BalanceResponsibleId = balanceResponsibleId;
             RequestedByActorId = requestedByActorId;
             RequestedByActorRoleCode = requestedByActorRoleCode;
             AddDomainEvent(new AggregatedMeasureProcessIsInitialized(processId));

--- a/source/Infrastructure/IncomingMessages/MessageHeaderExtractor.cs
+++ b/source/Infrastructure/IncomingMessages/MessageHeaderExtractor.cs
@@ -35,7 +35,7 @@ internal static class MessageHeaderExtractor
         var receiverId = string.Empty;
         var receiverRole = string.Empty;
         var createdAt = string.Empty;
-        var businessType = string.Empty;
+        string? businessType = null;
         var ns = rootElement.DefaultNamespace;
 
         await reader.AdvanceToAsync(headerElementName, rootElement.DefaultNamespace).ConfigureAwait(false);

--- a/source/Infrastructure/IncomingMessages/RequestAggregatedMeasureData/XmlMessageParser.cs
+++ b/source/Infrastructure/IncomingMessages/RequestAggregatedMeasureData/XmlMessageParser.cs
@@ -170,12 +170,12 @@ public class XmlMessageParser : IMessageParser<RequestAggregatedMeasureDataMarke
     {
         var id = string.Empty;
         var marketEvaluationPointType = string.Empty;
-        var marketEvaluationSettlementMethod = string.Empty;
+        string? marketEvaluationSettlementMethod = null;
         var startDateAndOrTimeDateTime = string.Empty;
         var endDateAndOrTimeDateTime = string.Empty;
         var meteringGridAreaDomainId = string.Empty;
-        var energySupplierMarketParticipantId = string.Empty;
-        var balanceResponsiblePartyMarketParticipantId = string.Empty;
+        string? energySupplierMarketParticipantId = null;
+        string? balanceResponsiblePartyMarketParticipantId = null;
         var ns = rootElement.DefaultNamespace;
 
         await reader.AdvanceToAsync(SeriesRecordElementName, ns).ConfigureAwait(false);
@@ -240,13 +240,13 @@ public class XmlMessageParser : IMessageParser<RequestAggregatedMeasureDataMarke
 
     private static Serie CreateSerie(
         ref string id,
-        ref string marketEvaluationPointType,
-        ref string marketEvaluationSettlementMethod,
+        ref string? marketEvaluationPointType,
+        ref string? marketEvaluationSettlementMethod,
         ref string startDateAndOrTimeDateTime,
-        ref string endDateAndOrTimeDateTime,
-        ref string meteringGridAreaDomainId,
-        ref string energySupplierMarketParticipantId,
-        ref string balanceResponsiblePartyMarketParticipantId)
+        ref string? endDateAndOrTimeDateTime,
+        ref string? meteringGridAreaDomainId,
+        ref string? energySupplierMarketParticipantId,
+        ref string? balanceResponsiblePartyMarketParticipantId)
     {
         var serie = new Serie(
             id,
@@ -259,13 +259,13 @@ public class XmlMessageParser : IMessageParser<RequestAggregatedMeasureDataMarke
             balanceResponsiblePartyMarketParticipantId);
 
         id = string.Empty;
-        marketEvaluationPointType = string.Empty;
-        marketEvaluationSettlementMethod = string.Empty;
+        marketEvaluationPointType = null;
+        marketEvaluationSettlementMethod = null;
         startDateAndOrTimeDateTime = string.Empty;
-        endDateAndOrTimeDateTime = string.Empty;
-        meteringGridAreaDomainId = string.Empty;
-        energySupplierMarketParticipantId = string.Empty;
-        balanceResponsiblePartyMarketParticipantId = string.Empty;
+        endDateAndOrTimeDateTime = null;
+        meteringGridAreaDomainId = null;
+        energySupplierMarketParticipantId = null;
+        balanceResponsiblePartyMarketParticipantId = null;
 
         return serie;
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
The json parser and xml parser at see missing attributes differently. Currently json gives "null" when an attribute is missing where xml return empty string.
This pr changes the xml parser to return null instead of empty string.

## References
