### PR TITLE
fix handling of optional fields and time is at midnight in b2c

### DIFF
--- a/source/B2CWebApi/Configuration/DateTimeConfiguration.cs
+++ b/source/B2CWebApi/Configuration/DateTimeConfiguration.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.B2CWebApi.Configuration.Options;
+using NodaTime;
+
+namespace Energinet.DataHub.EDI.B2CWebApi.Configuration;
+
+public static class DateTimeConfiguration
+{
+    public static void AddDateTimeConfiguration(
+        this IServiceCollection serviceCollection,
+        IConfiguration configuration)
+    {
+        var options = configuration.Get<DateTimeOptions>()!;
+        serviceCollection.AddSingleton<DateTimeZone>(_ =>
+        {
+            var dateTimeZoneId = options.TIME_ZONE;
+            return DateTimeZoneProviders.Tzdb.GetZoneOrNull(dateTimeZoneId)!;
+        });
+    }
+}

--- a/source/B2CWebApi/Configuration/JwtConfiguration.cs
+++ b/source/B2CWebApi/Configuration/JwtConfiguration.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.App.WebApp.Authentication;
+using Energinet.DataHub.Core.App.WebApp.Authorization;
+using Energinet.DataHub.EDI.B2CWebApi.Configuration.Options;
+using Energinet.DataHub.EDI.B2CWebApi.Security;
+
+namespace Energinet.DataHub.EDI.B2CWebApi.Configuration;
+
+public static class JwtConfiguration
+{
+    public static void AddJwtTokenSecurity(
+        this IServiceCollection serviceCollection,
+        IConfiguration configuration)
+    {
+        var options = configuration.Get<JwtOptions>()!;
+        serviceCollection.AddJwtBearerAuthentication(options.EXTERNAL_OPEN_ID_URL, options.INTERNAL_OPEN_ID_URL, options.BACKEND_BFF_APP_ID);
+        serviceCollection.AddUserAuthentication<FrontendUser, FrontendUserProvider>();
+        serviceCollection.AddPermissionAuthorization();
+    }
+}

--- a/source/B2CWebApi/Configuration/Options/DateTimeOptions.cs
+++ b/source/B2CWebApi/Configuration/Options/DateTimeOptions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Energinet.DataHub.EDI.B2CWebApi.Configuration.Options;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1707", Justification = "To match naming in other domains")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1056", Justification = "Nuget expects a string")]
+
+public class DateTimeOptions
+{
+    public string TIME_ZONE { get; set; } = string.Empty;
+}

--- a/source/B2CWebApi/Controllers/RequestAggregatedMeasureDataController.cs
+++ b/source/B2CWebApi/Controllers/RequestAggregatedMeasureDataController.cs
@@ -19,6 +19,7 @@ using Energinet.DataHub.EDI.B2CWebApi.Models;
 using Energinet.DataHub.EDI.B2CWebApi.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using NodaTime;
 
 namespace Energinet.DataHub.EDI.B2CWebApi.Controllers;
 
@@ -28,13 +29,16 @@ public class RequestAggregatedMeasureDataController : ControllerBase
 {
     private readonly RequestAggregatedMeasureDataHttpClient _requestAggregatedMeasureDataHttpClient;
     private readonly UserContext<FrontendUser> _userContext;
+    private readonly DateTimeZone _dateTimeZone;
 
     public RequestAggregatedMeasureDataController(
         RequestAggregatedMeasureDataHttpClient requestAggregatedMeasureDataHttpClient,
-        UserContext<FrontendUser> userContext)
+        UserContext<FrontendUser> userContext,
+        DateTimeZone dateTimeZone)
     {
         _requestAggregatedMeasureDataHttpClient = requestAggregatedMeasureDataHttpClient;
         _userContext = userContext;
+        _dateTimeZone = dateTimeZone;
     }
 
     [HttpPost]
@@ -45,7 +49,7 @@ public class RequestAggregatedMeasureDataController : ControllerBase
         var token = GetToken(currentUser);
 
         var validationMessage = await _requestAggregatedMeasureDataHttpClient.RequestAsync(
-            RequestAggregatedMeasureDataHttpFactory.Create(request, currentUser.ActorNumber, currentUser.Role),
+            RequestAggregatedMeasureDataHttpFactory.Create(request, currentUser.ActorNumber, currentUser.Role, _dateTimeZone),
             token,
             cancellationToken).ConfigureAwait(false);
 

--- a/source/B2CWebApi/Models/RequestAggregatedMeasureDataMarketDocument.cs
+++ b/source/B2CWebApi/Models/RequestAggregatedMeasureDataMarketDocument.cs
@@ -21,7 +21,7 @@ public record RequestAggregatedMeasureDataMarketRequest(
     ProcessType ProcessType,
     MeteringPointType MeteringPointType,
     string StartDate,
-    string? EndDate,
+    string EndDate,
     string? GridArea,
     string? EnergySupplierId,
     string? BalanceResponsibleId);

--- a/source/B2CWebApi/Startup.cs
+++ b/source/B2CWebApi/Startup.cs
@@ -14,10 +14,10 @@
 
 using System.Text.Json.Serialization;
 using Energinet.DataHub.Core.App.WebApp.Authentication;
-using Energinet.DataHub.Core.App.WebApp.Authorization;
 using Energinet.DataHub.Core.App.WebApp.Diagnostics.HealthChecks;
 using Energinet.DataHub.Core.Logging.LoggingMiddleware;
 using Energinet.DataHub.EDI.B2CWebApi.Clients;
+using Energinet.DataHub.EDI.B2CWebApi.Configuration;
 using Energinet.DataHub.EDI.B2CWebApi.Configuration.Options;
 using Energinet.DataHub.EDI.B2CWebApi.Security;
 using Microsoft.OpenApi.Models;
@@ -67,9 +67,12 @@ public class Startup
 
         serviceCollection.AddOptions<JwtOptions>().Bind(Configuration);
         serviceCollection.AddOptions<EdiOptions>().Bind(Configuration);
+        serviceCollection.AddOptions<DateTimeOptions>().Bind(Configuration);
+
         serviceCollection.AddHttpLoggingScope(DomainName);
 
-        AddJwtTokenSecurity(serviceCollection);
+        serviceCollection.AddJwtTokenSecurity(Configuration);
+        serviceCollection.AddDateTimeConfiguration(Configuration);
         serviceCollection
             .AddHttpClient();
         var ediClientOptions = Configuration.Get<EdiOptions>()!;
@@ -107,16 +110,5 @@ public class Startup
             endpoints.MapLiveHealthChecks();
             endpoints.MapReadyHealthChecks();
         });
-    }
-
-    /// <summary>
-    /// Adds registrations of JwtTokenMiddleware and corresponding dependencies.
-    /// </summary>
-    private void AddJwtTokenSecurity(IServiceCollection serviceCollection)
-    {
-        var options = Configuration.Get<JwtOptions>()!;
-        serviceCollection.AddJwtBearerAuthentication(options.EXTERNAL_OPEN_ID_URL, options.INTERNAL_OPEN_ID_URL, options.BACKEND_BFF_APP_ID);
-        serviceCollection.AddUserAuthentication<FrontendUser, FrontendUserProvider>();
-        serviceCollection.AddPermissionAuthorization();
     }
 }

--- a/source/Infrastructure/IncomingMessages/RequestAggregatedMeasureData/RequestAggregatedMeasureDataMarketMessageFactory.cs
+++ b/source/Infrastructure/IncomingMessages/RequestAggregatedMeasureData/RequestAggregatedMeasureDataMarketMessageFactory.cs
@@ -53,14 +53,14 @@ public static class RequestAggregatedMeasureDataMarketMessageFactory
         var series = requestAggregatedMeasureData.Series
             .Select(serie => new Serie(
                 serie.Id,
-                serie.MarketEvaluationPointType,
-                serie.MarketEvaluationSettlementMethod,
+                string.IsNullOrWhiteSpace(serie.MarketEvaluationPointType) ? null : serie.MarketEvaluationPointType,
+                string.IsNullOrWhiteSpace(serie.MarketEvaluationSettlementMethod) ? null : serie.MarketEvaluationSettlementMethod,
                 serie.StartDateAndOrTimeDateTime,
-                serie.EndDateAndOrTimeDateTime,
-                serie.MeteringGridAreaDomainId,
-                serie.EnergySupplierMarketParticipantId,
-                serie.BalanceResponsiblePartyMarketParticipantId,
-                serie.SettlementSeriesVersion)).ToList();
+                string.IsNullOrWhiteSpace(serie.EndDateAndOrTimeDateTime) ? null : serie.EndDateAndOrTimeDateTime,
+                string.IsNullOrWhiteSpace(serie.MeteringGridAreaDomainId) ? null : serie.MeteringGridAreaDomainId,
+                string.IsNullOrWhiteSpace(serie.EnergySupplierMarketParticipantId) ? null : serie.EnergySupplierMarketParticipantId,
+                string.IsNullOrWhiteSpace(serie.BalanceResponsiblePartyMarketParticipantId) ? null : serie.BalanceResponsiblePartyMarketParticipantId,
+                string.IsNullOrWhiteSpace(serie.SettlementSeriesVersion) ? null : serie.SettlementSeriesVersion)).ToList();
 
         return new RequestAggregatedMeasureDataMarketMessage(
             requestAggregatedMeasureData.SenderId,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
- Ensure proto doesn't set empty string when it should be null 
- End and Start date should be at midnight local time. 

## References
PR: 
https://github.com/Energinet-DataHub/dh3-infrastructure/pull/540
https://github.com/Energinet-DataHub/greenforce-frontend/pull/2162