### PR TITLE
fix: wrong date format for b2c requests

### DIFF
--- a/source/B2CWebApi/Factories/InstantFormatFactory.cs
+++ b/source/B2CWebApi/Factories/InstantFormatFactory.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using NodaTime;
+using NodaTime.Text;
+
+namespace Energinet.DataHub.EDI.B2CWebApi.Factories;
+
+public static class InstantFormatFactory
+{
+    public static string SetInstantToMidnight(string dateString, DateTimeZone dateTimeZone)
+    {
+        var instant = InstantPattern.ExtendedIso.Parse(dateString).Value;
+        var zonedDateTime = new ZonedDateTime(instant, dateTimeZone);
+        var dateTimeZoneAtMidnight = zonedDateTime.Date
+            .At(LocalTime.Midnight)
+            .InZoneStrictly(dateTimeZone);
+        return dateTimeZoneAtMidnight.ToInstant().ToString();
+    }
+}

--- a/source/B2CWebApi/Factories/RequestAggregatedMeasureDataHttpFactory.cs
+++ b/source/B2CWebApi/Factories/RequestAggregatedMeasureDataHttpFactory.cs
@@ -81,7 +81,7 @@ public static class RequestAggregatedMeasureDataHttpFactory
 
     private static string SetTimeToMidnight(string dateString, DateTimeZone dateTimeZone)
     {
-        _date = InstantPattern.General.Parse(dateString).Value;
+        _date = InstantPattern.ExtendedIso.Parse(dateString).Value;
         var zonedDateTime = new ZonedDateTime(_date, dateTimeZone);
         var dateTimeZoneAtMidnight = zonedDateTime.Date
             .At(LocalTime.Midnight)

--- a/source/B2CWebApi/Factories/RequestAggregatedMeasureDataHttpFactory.cs
+++ b/source/B2CWebApi/Factories/RequestAggregatedMeasureDataHttpFactory.cs
@@ -15,14 +15,11 @@
 using Energinet.DataHub.EDI.B2CWebApi.Models;
 using Energinet.DataHub.Edi.Requests;
 using NodaTime;
-using NodaTime.Text;
 
 namespace Energinet.DataHub.EDI.B2CWebApi.Factories;
 
 public static class RequestAggregatedMeasureDataHttpFactory
 {
-    private static Instant _date;
-
     public static RequestAggregatedMeasureData Create(
         RequestAggregatedMeasureDataMarketRequest request,
         string actorNumber,
@@ -48,8 +45,8 @@ public static class RequestAggregatedMeasureDataHttpFactory
         var serie = new Serie
         {
             Id = Guid.NewGuid().ToString(),
-            StartDateAndOrTimeDateTime = SetTimeToMidnight(request.StartDate, dateTimeZone),
-            EndDateAndOrTimeDateTime = SetTimeToMidnight(request.EndDate, dateTimeZone),
+            StartDateAndOrTimeDateTime = InstantFormatFactory.SetInstantToMidnight(request.StartDate, dateTimeZone),
+            EndDateAndOrTimeDateTime = InstantFormatFactory.SetInstantToMidnight(request.EndDate, dateTimeZone),
         };
 
         if (request.GridArea != null)
@@ -77,16 +74,6 @@ public static class RequestAggregatedMeasureDataHttpFactory
         data.Series.Add(serie);
 
         return data;
-    }
-
-    private static string SetTimeToMidnight(string dateString, DateTimeZone dateTimeZone)
-    {
-        _date = InstantPattern.ExtendedIso.Parse(dateString).Value;
-        var zonedDateTime = new ZonedDateTime(_date, dateTimeZone);
-        var dateTimeZoneAtMidnight = zonedDateTime.Date
-            .At(LocalTime.Midnight)
-            .InZoneStrictly(dateTimeZone);
-        return dateTimeZoneAtMidnight.ToInstant().ToString();
     }
 
     private static string SetSettlementSeriesVersion(ProcessType processType)

--- a/source/B2CWebApi/Factories/RequestAggregatedMeasureDataHttpFactory.cs
+++ b/source/B2CWebApi/Factories/RequestAggregatedMeasureDataHttpFactory.cs
@@ -83,8 +83,10 @@ public static class RequestAggregatedMeasureDataHttpFactory
     {
         _date = InstantPattern.General.Parse(dateString).Value;
         var zonedDateTime = new ZonedDateTime(_date, dateTimeZone);
-        var dateTimeZoneAtMidnight = zonedDateTime.Date.At(LocalTime.Midnight);
-        return dateTimeZoneAtMidnight.ToString();
+        var dateTimeZoneAtMidnight = zonedDateTime.Date
+            .At(LocalTime.Midnight)
+            .InZoneStrictly(dateTimeZone);
+        return dateTimeZoneAtMidnight.ToInstant().ToString();
     }
 
     private static string SetSettlementSeriesVersion(ProcessType processType)

--- a/source/Tests/B2CWebApi/RequestAggregatedMeasureData/InstantFormatFactoryTests.cs
+++ b/source/Tests/B2CWebApi/RequestAggregatedMeasureData/InstantFormatFactoryTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.B2CWebApi.Factories;
+using NodaTime;
+using NodaTime.Text;
+using Xunit;
+
+namespace Energinet.DataHub.EDI.Tests.B2CWebApi.RequestAggregatedMeasureData;
+
+public class InstantFormatFactoryTests
+{
+    private readonly DateTimeZone _dateTimeZone = DateTimeZoneProviders.Tzdb["Europe/Copenhagen"];
+
+    [Theory]
+    [InlineData("2023-10-02T22:00:00.000Z")]
+    [InlineData("2023-10-07T21:59:59.999Z")]
+    [InlineData("2022-06-23T22:00:00Z")]
+    [InlineData("2022-06-23T21:00:00Z")]
+    public void Can_set_instant_to_midnight(string instantString)
+    {
+        var instantAtMidget = InstantFormatFactory.SetInstantToMidnight(instantString, _dateTimeZone);
+        var parseResult = InstantPattern.General.Parse(instantAtMidget);
+
+        var zonedDateTime = new ZonedDateTime(parseResult.Value, _dateTimeZone);
+        Assert.True(zonedDateTime.TimeOfDay == LocalTime.Midnight);
+    }
+}

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -48,6 +48,7 @@ limitations under the License.
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\B2CWebApi\B2CWebApi.csproj" />
       <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
       <ProjectReference Include="..\Application\Application.csproj" />
     </ItemGroup>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
We should take instant format and not local datetime. 

## References
