### PR TITLE
fix: Ensure that we set to midnight the same day

### DIFF
--- a/source/B2CWebApi/Factories/InstantFormatFactory.cs
+++ b/source/B2CWebApi/Factories/InstantFormatFactory.cs
@@ -19,16 +19,18 @@ namespace Energinet.DataHub.EDI.B2CWebApi.Factories;
 
 public static class InstantFormatFactory
 {
-    public static Instant SetInstantToMidnightSameDay(string dateString, DateTimeZone dateTimeZone)
+    public static Instant SetInstantToMidnight(string dateString, DateTimeZone dateTimeZone, Duration? addDuration = null)
     {
         var instant = InstantPattern.ExtendedIso.Parse(dateString).Value;
+
+        if (addDuration is not null)
+        {
+            instant = instant.Plus(addDuration!.Value);
+        }
+
         var zonedDateTime = new ZonedDateTime(instant, dateTimeZone);
         var dateTimeZoneAtMidnight = zonedDateTime.Date
             .At(LocalTime.Midnight);
-        if (zonedDateTime.Hour >= 22)
-        {
-            dateTimeZoneAtMidnight = dateTimeZoneAtMidnight.PlusDays(1);
-        }
 
         return dateTimeZoneAtMidnight
             .InZoneStrictly(dateTimeZone)

--- a/source/B2CWebApi/Factories/InstantFormatFactory.cs
+++ b/source/B2CWebApi/Factories/InstantFormatFactory.cs
@@ -19,13 +19,19 @@ namespace Energinet.DataHub.EDI.B2CWebApi.Factories;
 
 public static class InstantFormatFactory
 {
-    public static string SetInstantToMidnight(string dateString, DateTimeZone dateTimeZone)
+    public static Instant SetInstantToMidnightSameDay(string dateString, DateTimeZone dateTimeZone)
     {
         var instant = InstantPattern.ExtendedIso.Parse(dateString).Value;
         var zonedDateTime = new ZonedDateTime(instant, dateTimeZone);
         var dateTimeZoneAtMidnight = zonedDateTime.Date
-            .At(LocalTime.Midnight)
-            .InZoneStrictly(dateTimeZone);
-        return dateTimeZoneAtMidnight.ToInstant().ToString();
+            .At(LocalTime.Midnight);
+        if (zonedDateTime.Hour >= 22)
+        {
+            dateTimeZoneAtMidnight = dateTimeZoneAtMidnight.PlusDays(1);
+        }
+
+        return dateTimeZoneAtMidnight
+            .InZoneStrictly(dateTimeZone)
+            .ToInstant();
     }
 }

--- a/source/B2CWebApi/Factories/RequestAggregatedMeasureDataHttpFactory.cs
+++ b/source/B2CWebApi/Factories/RequestAggregatedMeasureDataHttpFactory.cs
@@ -45,8 +45,8 @@ public static class RequestAggregatedMeasureDataHttpFactory
         var serie = new Serie
         {
             Id = Guid.NewGuid().ToString(),
-            StartDateAndOrTimeDateTime = InstantFormatFactory.SetInstantToMidnightSameDay(request.StartDate, dateTimeZone).ToString(),
-            EndDateAndOrTimeDateTime = InstantFormatFactory.SetInstantToMidnightSameDay(request.EndDate, dateTimeZone).ToString(),
+            StartDateAndOrTimeDateTime = InstantFormatFactory.SetInstantToMidnight(request.StartDate, dateTimeZone).ToString(),
+            EndDateAndOrTimeDateTime = InstantFormatFactory.SetInstantToMidnight(request.EndDate, dateTimeZone, Duration.FromMilliseconds(1)).ToString(),
         };
 
         if (request.GridArea != null)

--- a/source/B2CWebApi/Factories/RequestAggregatedMeasureDataHttpFactory.cs
+++ b/source/B2CWebApi/Factories/RequestAggregatedMeasureDataHttpFactory.cs
@@ -45,8 +45,8 @@ public static class RequestAggregatedMeasureDataHttpFactory
         var serie = new Serie
         {
             Id = Guid.NewGuid().ToString(),
-            StartDateAndOrTimeDateTime = InstantFormatFactory.SetInstantToMidnight(request.StartDate, dateTimeZone),
-            EndDateAndOrTimeDateTime = InstantFormatFactory.SetInstantToMidnight(request.EndDate, dateTimeZone),
+            StartDateAndOrTimeDateTime = InstantFormatFactory.SetInstantToMidnightSameDay(request.StartDate, dateTimeZone).ToString(),
+            EndDateAndOrTimeDateTime = InstantFormatFactory.SetInstantToMidnightSameDay(request.EndDate, dateTimeZone).ToString(),
         };
 
         if (request.GridArea != null)

--- a/source/Tests/B2CWebApi/RequestAggregatedMeasureData/InstantFormatFactoryTests.cs
+++ b/source/Tests/B2CWebApi/RequestAggregatedMeasureData/InstantFormatFactoryTests.cs
@@ -29,6 +29,7 @@ public class InstantFormatFactoryTests
     [InlineData("2023-10-07T21:59:59.999Z")]
     [InlineData("2022-06-23T22:00:00Z")]
     [InlineData("2022-06-23T21:00:00Z")]
+    [InlineData("2022-01-23T23:00:00Z")]
     public void Can_set_instant_to_midnight(string instantString)
     {
         var instantAtMidget = InstantFormatFactory.SetInstantToMidnightSameDay(instantString, _dateTimeZone);
@@ -42,6 +43,7 @@ public class InstantFormatFactoryTests
     [InlineData("2022-06-23T22:00:00Z")]
     [InlineData("2023-10-07T21:59:59.999Z")]
     [InlineData("2022-06-23T21:00:00Z")]
+    [InlineData("2022-01-23T23:00:00Z")]
     public void Converts_to_same_day(string instantString)
     {
         var instantAtMidget = InstantFormatFactory.SetInstantToMidnightSameDay(instantString, _dateTimeZone);

--- a/source/Tests/B2CWebApi/RequestAggregatedMeasureData/InstantFormatFactoryTests.cs
+++ b/source/Tests/B2CWebApi/RequestAggregatedMeasureData/InstantFormatFactoryTests.cs
@@ -32,7 +32,7 @@ public class InstantFormatFactoryTests
     [InlineData("2022-01-23T23:00:00Z")]
     public void Can_set_instant_to_midnight(string instantString)
     {
-        var instantAtMidget = InstantFormatFactory.SetInstantToMidnightSameDay(instantString, _dateTimeZone);
+        var instantAtMidget = InstantFormatFactory.SetInstantToMidnight(instantString, _dateTimeZone);
 
         var zonedDateTime = new ZonedDateTime(instantAtMidget, _dateTimeZone);
         Assert.True(zonedDateTime.TimeOfDay == LocalTime.Midnight);
@@ -41,12 +41,26 @@ public class InstantFormatFactoryTests
     [Theory]
     [InlineData("2023-10-02T22:00:00.000Z")]
     [InlineData("2022-06-23T22:00:00Z")]
-    [InlineData("2023-10-07T21:59:59.999Z")]
-    [InlineData("2022-06-23T21:00:00Z")]
     [InlineData("2022-01-23T23:00:00Z")]
     public void Converts_to_same_day(string instantString)
     {
-        var instantAtMidget = InstantFormatFactory.SetInstantToMidnightSameDay(instantString, _dateTimeZone);
+        var instantAtMidget = InstantFormatFactory.SetInstantToMidnight(instantString, _dateTimeZone);
+
+        var inputInstant = InstantPattern.ExtendedIso.Parse(instantString).GetValueOrThrow();
+        Assert.True(instantAtMidget.Day() == inputInstant.Day(), $"The inputData was: {inputInstant} and the output was: {instantAtMidget}");
+    }
+
+    [Theory]
+    // summer time
+    [InlineData("2023-10-07T21:59:59.999Z", 1)]
+    [InlineData("2022-06-23T21:00:00Z", 3600000)] // adding an hour
+    [InlineData("2023-10-07T21:59:59.999Z", 3600000)] // adding an hour
+    // Winter time
+    [InlineData("2023-10-01T22:59:59.999Z", 1)]
+    [InlineData("2022-06-22T22:00:00Z", 3600000)] // adding an hour
+    public void Converts_to_next_day(string instantString, int milliseconds)
+    {
+        var instantAtMidget = InstantFormatFactory.SetInstantToMidnight(instantString, _dateTimeZone, Duration.FromMilliseconds(milliseconds));
 
         var inputInstant = InstantPattern.ExtendedIso.Parse(instantString).GetValueOrThrow();
         Assert.True(instantAtMidget.Day() == inputInstant.Day(), $"The inputData was: {inputInstant} and the output was: {instantAtMidget}");

--- a/source/Tests/B2CWebApi/RequestAggregatedMeasureData/InstantFormatFactoryTests.cs
+++ b/source/Tests/B2CWebApi/RequestAggregatedMeasureData/InstantFormatFactoryTests.cs
@@ -32,9 +32,9 @@ public class InstantFormatFactoryTests
     [InlineData("2022-01-23T23:00:00Z")]
     public void Can_set_instant_to_midnight(string instantString)
     {
-        var instantAtMidget = InstantFormatFactory.SetInstantToMidnight(instantString, _dateTimeZone);
+        var instantAtMidnight = InstantFormatFactory.SetInstantToMidnight(instantString, _dateTimeZone);
 
-        var zonedDateTime = new ZonedDateTime(instantAtMidget, _dateTimeZone);
+        var zonedDateTime = new ZonedDateTime(instantAtMidnight, _dateTimeZone);
         Assert.True(zonedDateTime.TimeOfDay == LocalTime.Midnight);
     }
 
@@ -44,10 +44,10 @@ public class InstantFormatFactoryTests
     [InlineData("2022-01-23T23:00:00Z")]
     public void Converts_to_same_day(string instantString)
     {
-        var instantAtMidget = InstantFormatFactory.SetInstantToMidnight(instantString, _dateTimeZone);
+        var instantAtMidnight = InstantFormatFactory.SetInstantToMidnight(instantString, _dateTimeZone);
 
         var inputInstant = InstantPattern.ExtendedIso.Parse(instantString).GetValueOrThrow();
-        Assert.True(instantAtMidget.Day() == inputInstant.Day(), $"The inputData was: {inputInstant} and the output was: {instantAtMidget}");
+        Assert.True(instantAtMidnight.Day() == inputInstant.Day(), $"The inputData was: {inputInstant} and the output was: {instantAtMidnight}");
     }
 
     [Theory]
@@ -60,9 +60,9 @@ public class InstantFormatFactoryTests
     [InlineData("2022-06-22T22:00:00Z", 3600000)] // adding an hour
     public void Converts_to_next_day(string instantString, int milliseconds)
     {
-        var instantAtMidget = InstantFormatFactory.SetInstantToMidnight(instantString, _dateTimeZone, Duration.FromMilliseconds(milliseconds));
+        var instantAtMidnight = InstantFormatFactory.SetInstantToMidnight(instantString, _dateTimeZone, Duration.FromMilliseconds(milliseconds));
 
         var inputInstant = InstantPattern.ExtendedIso.Parse(instantString).GetValueOrThrow();
-        Assert.True(instantAtMidget.Day() == inputInstant.Day(), $"The inputData was: {inputInstant} and the output was: {instantAtMidget}");
+        Assert.True(instantAtMidnight.Day() == inputInstant.Day(), $"The inputData was: {inputInstant} and the output was: {instantAtMidnight}");
     }
 }

--- a/source/Tests/B2CWebApi/RequestAggregatedMeasureData/RequestAggregatedMeasureDataFactoryTests.cs
+++ b/source/Tests/B2CWebApi/RequestAggregatedMeasureData/RequestAggregatedMeasureDataFactoryTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
+using Energinet.DataHub.EDI.B2CWebApi.Factories;
+using Energinet.DataHub.EDI.B2CWebApi.Models;
+using FluentAssertions.Execution;
+using Microsoft.EntityFrameworkCore.SqlServer.NodaTime.Extensions;
+using NodaTime;
+using NodaTime.Text;
+using Xunit;
+
+namespace Energinet.DataHub.EDI.Tests.B2CWebApi.RequestAggregatedMeasureData;
+
+public class RequestAggregatedMeasureDataFactoryTests
+{
+    private readonly DateTimeZone _dateTimeZone = DateTimeZoneProviders.Tzdb["Europe/Copenhagen"];
+
+    [Fact]
+    public void Can_create_RequestAggregatedMeasureData()
+    {
+        var senderId = "9876543210987";
+        var startDay = 10;
+        var endDay = 12;
+        var request = new RequestAggregatedMeasureDataMarketRequest(
+            ProcessType: ProcessType.BalanceFixing,
+            MeteringPointType: MeteringPointType.Production,
+            StartDate: $"2023-10-{startDay}T22:00:00.000Z",
+            EndDate: $"2023-10-{endDay}T21:59:59.999Z",
+            GridArea: "803",
+            EnergySupplierId: "579000000003042",
+            BalanceResponsibleId: "1234567890123");
+
+        var result = RequestAggregatedMeasureDataHttpFactory.Create(
+            request,
+            senderId,
+            MarketRole.MeteredDataResponsible.Name,
+            _dateTimeZone);
+
+        using var assertionScope = new AssertionScope();
+        Assert.Equal("D04", result.BusinessReason);
+        Assert.Equal(senderId, result.SenderId);
+        Assert.Equal(MarketRole.MeteredDataResponsible.Code, result.SenderRoleCode);
+        Assert.Equal("E74", result.MessageType);
+
+        Assert.All(result.Series, serie =>
+        {
+            Assert.Equal("E18", serie.MarketEvaluationPointType);
+            Assert.False(serie.HasMarketEvaluationSettlementMethod);
+            Assert.False(serie.HasSettlementSeriesVersion);
+
+            var startDate = InstantPattern.General.Parse(serie.StartDateAndOrTimeDateTime).GetValueOrThrow();
+            Assert.Equal(startDay, startDate.Day());
+            var endDate = InstantPattern.General.Parse(serie.EndDateAndOrTimeDateTime).GetValueOrThrow();
+            Assert.Equal(endDay, endDate.Day());
+        });
+    }
+
+    [Fact]
+    public void Can_create_RequestAggregatedMeasureData_wrong_endData_input()
+    {
+        var endDay = 12;
+        var endDataMilliseconds = 998;
+        var request = new RequestAggregatedMeasureDataMarketRequest(
+            ProcessType: ProcessType.BalanceFixing,
+            MeteringPointType: MeteringPointType.Production,
+            StartDate: $"2023-10-1022:00:00.000Z",
+            EndDate: $"2023-10-{endDay}T21:59:59.{endDataMilliseconds}Z",
+            GridArea: "803",
+            EnergySupplierId: "579000000003042",
+            BalanceResponsibleId: "1234567890123");
+
+        var result = RequestAggregatedMeasureDataHttpFactory.Create(
+            request,
+            "9876543210987",
+            MarketRole.MeteredDataResponsible.Name,
+            _dateTimeZone);
+
+        var endDate = InstantPattern.General.Parse(result.Series.First()!.EndDateAndOrTimeDateTime).GetValueOrThrow();
+        Assert.Equal(endDay - 1, endDate.Day());
+    }
+}

--- a/source/Tests/B2CWebApi/RequestAggregatedMeasureData/RequestAggregatedMeasureDataFactoryTests.cs
+++ b/source/Tests/B2CWebApi/RequestAggregatedMeasureData/RequestAggregatedMeasureDataFactoryTests.cs
@@ -75,7 +75,7 @@ public class RequestAggregatedMeasureDataFactoryTests
         var request = new RequestAggregatedMeasureDataMarketRequest(
             ProcessType: ProcessType.BalanceFixing,
             MeteringPointType: MeteringPointType.Production,
-            StartDate: $"2023-10-1022:00:00.000Z",
+            StartDate: $"2023-10-10T22:00:00.000Z",
             EndDate: $"2023-10-{endDay}T21:59:59.{endDataMilliseconds}Z",
             GridArea: "803",
             EnergySupplierId: "579000000003042",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

Currently when we set our enddate to midnight. This midnight are sometimes the day before the requested day. 
This ensures that we get the midnight of the requested day
