### PR TITLE
feat: Removing json serializing from inbox events

### DIFF
--- a/source/ApplyDBMigrationsApp/ApplyDBMigrationsApp.csproj
+++ b/source/ApplyDBMigrationsApp/ApplyDBMigrationsApp.csproj
@@ -136,6 +136,7 @@ limitations under the License.
     <EmbeddedResource Include="Scripts\Model\202310231329 Alter Bundles2.sql" />
     <EmbeddedResource Include="Scripts\Model\202310231329 Alter Bundles1.sql" />
     <EmbeddedResource Include="Scripts\Model\202310231329 Alter Bundles.sql" />
+    <EmbeddedResource Include="Scripts\Model\202311140927 Make EventPayload to varbinary for inboxEvents.sql" />
     <None Remove="Scripts\Model\202227101333 Add AggregatedTimeSeriesTransactions table.sql" />
     <None Remove="Scripts\Model\202310201142 resize ActorNumber nvarchar on Actor.sql" />
     <None Remove="Scripts\Model\202310231329 Alter Bundles1.sql" />

--- a/source/ApplyDBMigrationsApp/Scripts/Model/202311140927 Make EventPayload to varbinary for inboxEvents.sql
+++ b/source/ApplyDBMigrationsApp/Scripts/Model/202311140927 Make EventPayload to varbinary for inboxEvents.sql
@@ -1,0 +1,2 @@
+ALTER TABLE [dbo].[ReceivedInboxEvents] DROP COLUMN [EventPayload]
+ALTER TABLE [dbo].[ReceivedInboxEvents] ADD EventPayload VARBINARY(MAX) NULL

--- a/source/Infrastructure/InboxEvents/IInboxEventMapper.cs
+++ b/source/Infrastructure/InboxEvents/IInboxEventMapper.cs
@@ -31,17 +31,11 @@ public interface IInboxEventMapper
     /// <param name="referenceId"></param>
     /// <param name="cancellationToken"></param>
     /// <returns><see cref="INotification"/></returns>
-    Task<INotification> MapFromAsync(string payload, Guid referenceId, CancellationToken cancellationToken);
+    Task<INotification> MapFromAsync(byte[] payload, Guid referenceId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Determines whether the specified event type can be handled by the mapper
     /// </summary>
     /// <param name="eventType"></param>
     bool CanHandle(string eventType);
-
-    /// <summary>
-    /// Parses the event to JSON
-    /// </summary>
-    /// <param name="payload"></param>
-    string ToJson(byte[] payload);
 }

--- a/source/Infrastructure/InboxEvents/InboxEventReceiver.cs
+++ b/source/Infrastructure/InboxEvents/InboxEventReceiver.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Energinet.DataHub.EDI.Application.Configuration;
 using Energinet.DataHub.EDI.Common.DateTime;
 using Energinet.DataHub.EDI.Infrastructure.Configuration.DataAccess;
 
@@ -61,13 +60,7 @@ public class InboxEventReceiver
 
     private async Task RegisterAsync(string eventId, string eventType, Guid referenceId, byte[] eventPayload)
     {
-        _context.ReceivedInboxEvents.Add(new ReceivedInboxEvent(eventId, eventType, referenceId, ToJson(eventType, eventPayload), _dateTimeProvider.Now()));
+        _context.ReceivedInboxEvents.Add(new ReceivedInboxEvent(eventId, eventType, referenceId, eventPayload, _dateTimeProvider.Now()));
         await _context.SaveChangesAsync().ConfigureAwait(false);
-    }
-
-    private string ToJson(string eventType, byte[] eventPayload)
-    {
-        var mapper = _mappers.First(mapper => mapper.CanHandle(eventType));
-        return mapper.ToJson(eventPayload);
     }
 }

--- a/source/Infrastructure/InboxEvents/InboxEventsConfiguration.cs
+++ b/source/Infrastructure/InboxEvents/InboxEventsConfiguration.cs
@@ -14,7 +14,6 @@
 
 using Energinet.DataHub.EDI.Common.DataRetention;
 using Energinet.DataHub.EDI.Common.TimeEvents;
-using Energinet.DataHub.EDI.Infrastructure.DataRetention;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/source/Infrastructure/InboxEvents/InboxEventsProcessor.cs
+++ b/source/Infrastructure/InboxEvents/InboxEventsProcessor.cs
@@ -18,7 +18,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
-using Energinet.DataHub.EDI.Application.Configuration;
 using Energinet.DataHub.EDI.Common.DataAccess;
 using Energinet.DataHub.EDI.Common.DateTime;
 using MediatR;

--- a/source/Infrastructure/InboxEvents/ReceivedInboxEventsRetention.cs
+++ b/source/Infrastructure/InboxEvents/ReceivedInboxEventsRetention.cs
@@ -15,11 +15,9 @@
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Energinet.DataHub.EDI.Application.Configuration;
 using Energinet.DataHub.EDI.Common.DataAccess;
 using Energinet.DataHub.EDI.Common.DataRetention;
 using Energinet.DataHub.EDI.Common.DateTime;
-using Energinet.DataHub.EDI.Infrastructure.DataRetention;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using NodaTime;

--- a/source/Infrastructure/InboxEvents/ReceivedIntegrationEvent.cs
+++ b/source/Infrastructure/InboxEvents/ReceivedIntegrationEvent.cs
@@ -19,7 +19,7 @@ namespace Energinet.DataHub.EDI.Infrastructure.InboxEvents;
 
 public class ReceivedInboxEvent
 {
-    public ReceivedInboxEvent(string id, string eventType, Guid referenceId, string eventPayload, Instant occurredOn)
+    public ReceivedInboxEvent(string id, string eventType, Guid referenceId, byte[] eventPayload, Instant occurredOn)
     {
         Id = id;
         OccurredOn = occurredOn;
@@ -41,5 +41,7 @@ public class ReceivedInboxEvent
 
     public Guid ReferenceId { get; }
 
-    public string EventPayload { get; }
+#pragma warning disable CA1819
+    public byte[] EventPayload { get; }
+#pragma warning restore CA1819
 }

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/SampleData.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/SampleData.cs
@@ -14,7 +14,6 @@
 
 using Energinet.DataHub.EDI.Common.Actors;
 using Energinet.DataHub.EDI.IntegrationTests.Factories;
-using NodaTime;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.Transactions.AggregatedMeasureData;
 

--- a/source/IntegrationTests/Infrastructure/InboxEvents/TestInboxEventMapper.cs
+++ b/source/IntegrationTests/Infrastructure/InboxEvents/TestInboxEventMapper.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System;
-using System.Text.Json;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.EDI.Infrastructure.InboxEvents;
@@ -24,22 +24,14 @@ namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.InboxEvents;
 public class TestInboxEventMapper : IInboxEventMapper
 {
     #pragma warning disable // Method cannot be static since inherited from the interface
-    public Task<INotification> MapFromAsync(string payload, Guid referenceId, CancellationToken cancellationToken)
+    public Task<INotification> MapFromAsync(byte[] payload, Guid referenceId, CancellationToken cancellationToken)
     {
-        var inboxEvents = JsonSerializer.Deserialize<TestInboxEvent>(payload);
-
-        return Task.FromResult(new TestNotification(inboxEvents.EventProperty) as INotification);
+        return Task.FromResult(new TestNotification(Encoding.ASCII.GetString(payload)) as INotification);
     }
 
     public bool CanHandle(string eventType)
     {
         ArgumentNullException.ThrowIfNull(eventType);
         return eventType.Equals(nameof(TestInboxEvent), StringComparison.OrdinalIgnoreCase);
-    }
-
-    public string ToJson(byte[] payload)
-    {
-        var integrationEvent = JsonSerializer.Deserialize<TestInboxEvent>(payload);
-        return JsonSerializer.Serialize(integrationEvent);
     }
 }

--- a/source/IntegrationTests/Infrastructure/InboxEvents/WhenAggregatedTimeSeriesRequestAcceptedEventIsReceivedTests.cs
+++ b/source/IntegrationTests/Infrastructure/InboxEvents/WhenAggregatedTimeSeriesRequestAcceptedEventIsReceivedTests.cs
@@ -16,15 +16,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
-using Energinet.DataHub.EDI.Application.Configuration;
-using Energinet.DataHub.EDI.Application.GridAreas;
 using Energinet.DataHub.EDI.Common.DataAccess;
 using Energinet.DataHub.EDI.Common.DateTime;
 using Energinet.DataHub.EDI.Infrastructure.Configuration.DataAccess;
 using Energinet.DataHub.EDI.Infrastructure.InboxEvents;
 using Energinet.DataHub.EDI.IntegrationTests.Factories;
 using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
-using Energinet.DataHub.EDI.Process.Application.Transactions.Aggregations;
 using Energinet.DataHub.Edi.Responses;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
@@ -90,7 +87,7 @@ public class WhenAggregatedTimeSeriesRequestAcceptedEventIsReceivedTests : TestB
             _eventId,
             _eventType,
             _referenceId,
-            ToJson(),
+            _aggregatedTimeSeriesRequestAcceptedResponse.ToByteArray(),
             GetService<ISystemDateTimeProvider>().Now()));
         context.SaveChanges();
     }
@@ -100,10 +97,5 @@ public class WhenAggregatedTimeSeriesRequestAcceptedEventIsReceivedTests : TestB
         var connection = await GetService<IDatabaseConnectionFactory>().GetConnectionAndOpenAsync(CancellationToken.None);
         var isProcessed = await connection.QueryFirstOrDefaultAsync($"SELECT * FROM dbo.ReceivedInboxEvents WHERE Id = @EventId AND ProcessedDate IS NOT NULL", new { EventId = eventId, });
         Assert.NotNull(isProcessed);
-    }
-
-    private string ToJson()
-    {
-        return new AggregatedTimeSeriesRequestAcceptedEventMapper(GetService<IGridAreaRepository>()).ToJson(_aggregatedTimeSeriesRequestAcceptedResponse.ToByteArray());
     }
 }

--- a/source/IntegrationTests/Infrastructure/InboxEvents/WhenAnInboxEventIsProcessingTests.cs
+++ b/source/IntegrationTests/Infrastructure/InboxEvents/WhenAnInboxEventIsProcessingTests.cs
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 using System;
-using System.Text.Json;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
-using Energinet.DataHub.EDI.Application.Configuration;
 using Energinet.DataHub.EDI.Common.DataAccess;
 using Energinet.DataHub.EDI.Common.DateTime;
 using Energinet.DataHub.EDI.Infrastructure.Configuration.DataAccess;
@@ -110,13 +109,8 @@ public class WhenAnInboxEventIsProcessingTests : TestBase
             _eventId,
             _eventType,
             _referenceId,
-            ToJson(),
+            Encoding.ASCII.GetBytes("Event1"),
             GetService<ISystemDateTimeProvider>().Now()));
         context.SaveChanges();
-    }
-
-    private string ToJson()
-    {
-        return _testInboxEventMapper.ToJson(JsonSerializer.SerializeToUtf8Bytes(new TestInboxEvent("Event1")));
     }
 }

--- a/source/Process.Application/Transactions/Aggregations/AggregatedTimeSeriesRequestAcceptedEventMapper.cs
+++ b/source/Process.Application/Transactions/Aggregations/AggregatedTimeSeriesRequestAcceptedEventMapper.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.EDI.Application.GridAreas;
@@ -38,10 +39,10 @@ public class AggregatedTimeSeriesRequestAcceptedEventMapper : IInboxEventMapper
         _gridAreaRepository = gridAreaRepository;
     }
 
-    public async Task<INotification> MapFromAsync(string payload, Guid referenceId, CancellationToken cancellationToken)
+    public async Task<INotification> MapFromAsync(byte[] payload, Guid referenceId, CancellationToken cancellationToken)
     {
         var aggregation =
-            AggregatedTimeSeriesRequestAccepted.Parser.ParseJson(payload);
+            AggregatedTimeSeriesRequestAccepted.Parser.ParseFrom(payload.ToArray());
 
         var aggregatedTimeSerie = new AggregatedTimeSerie(
                 MapPoints(aggregation.TimeSeriesPoints),
@@ -59,13 +60,6 @@ public class AggregatedTimeSeriesRequestAcceptedEventMapper : IInboxEventMapper
     {
         ArgumentNullException.ThrowIfNull(eventType);
         return eventType.Equals(nameof(AggregatedTimeSeriesRequestAccepted), StringComparison.OrdinalIgnoreCase);
-    }
-
-    public string ToJson(byte[] payload)
-    {
-        var inboxEvent = AggregatedTimeSeriesRequestAccepted.Parser.ParseFrom(
-            payload);
-        return inboxEvent.ToString();
     }
 
     private static string MapMeteringPointType(TimeSeriesType timeSeriesType)

--- a/source/Process.Application/Transactions/Aggregations/AggregatedTimeSeriesRequestAcceptedEventMapper.cs
+++ b/source/Process.Application/Transactions/Aggregations/AggregatedTimeSeriesRequestAcceptedEventMapper.cs
@@ -42,7 +42,7 @@ public class AggregatedTimeSeriesRequestAcceptedEventMapper : IInboxEventMapper
     public async Task<INotification> MapFromAsync(byte[] payload, Guid referenceId, CancellationToken cancellationToken)
     {
         var aggregation =
-            AggregatedTimeSeriesRequestAccepted.Parser.ParseFrom(payload.ToArray());
+            AggregatedTimeSeriesRequestAccepted.Parser.ParseFrom(payload);
 
         var aggregatedTimeSerie = new AggregatedTimeSerie(
                 MapPoints(aggregation.TimeSeriesPoints),

--- a/source/Process.Application/Transactions/Aggregations/AggregatedTimeSeriesRequestRejectedMapper.cs
+++ b/source/Process.Application/Transactions/Aggregations/AggregatedTimeSeriesRequestRejectedMapper.cs
@@ -27,12 +27,10 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.Aggregations;
 
 public class AggregatedTimeSeriesRequestRejectedMapper : IInboxEventMapper
 {
-#pragma warning disable CA1822
     public Task<INotification> MapFromAsync(byte[] payload, Guid referenceId, CancellationToken cancellationToken)
-#pragma warning restore CA1822
     {
         var inboxEvent =
-            AggregatedTimeSeriesRequestRejected.Parser.ParseFrom(payload.ToArray());
+            AggregatedTimeSeriesRequestRejected.Parser.ParseFrom(payload);
         return Task.FromResult<INotification>(
             new AggregatedTimeSeriesRequestWasRejected(
                 referenceId,

--- a/source/Process.Application/Transactions/Aggregations/AggregatedTimeSeriesRequestRejectedMapper.cs
+++ b/source/Process.Application/Transactions/Aggregations/AggregatedTimeSeriesRequestRejectedMapper.cs
@@ -27,10 +27,12 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.Aggregations;
 
 public class AggregatedTimeSeriesRequestRejectedMapper : IInboxEventMapper
 {
-    public Task<INotification> MapFromAsync(string payload, Guid referenceId, CancellationToken cancellationToken)
+#pragma warning disable CA1822
+    public Task<INotification> MapFromAsync(byte[] payload, Guid referenceId, CancellationToken cancellationToken)
+#pragma warning restore CA1822
     {
         var inboxEvent =
-            AggregatedTimeSeriesRequestRejected.Parser.ParseJson(payload);
+            AggregatedTimeSeriesRequestRejected.Parser.ParseFrom(payload.ToArray());
         return Task.FromResult<INotification>(
             new AggregatedTimeSeriesRequestWasRejected(
                 referenceId,
@@ -41,13 +43,6 @@ public class AggregatedTimeSeriesRequestRejectedMapper : IInboxEventMapper
     {
         ArgumentNullException.ThrowIfNull(eventType);
         return eventType.Equals(nameof(AggregatedTimeSeriesRequestRejected), StringComparison.OrdinalIgnoreCase);
-    }
-
-    public string ToJson(byte[] payload)
-    {
-        var inboxEvent = AggregatedTimeSeriesRequestRejected.Parser.ParseFrom(
-            payload);
-        return inboxEvent.ToString();
     }
 
     private static IReadOnlyList<Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData.RejectReason> MapRejectReasons(RepeatedField<RejectReason> rejectReasons)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
It has happened that an inbox event had no data in "eventPayload". Which we cannot backtrace with the current implementation
This pull request removes the mapping from byte data to a json formatted string, keeping all the information received by the service bus

## References
