### PR TITLE
fix: missing SqlConnectionSource configuration in B2C app

### DIFF
--- a/source/Api/Program.cs
+++ b/source/Api/Program.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Threading.Tasks;
+using BuildingBlocks.Application.Configuration;
 using Energinet.DataHub.Core.App.FunctionApp.Extensions.DependencyInjection;
 using Energinet.DataHub.Core.Messaging.Communication;
 using Energinet.DataHub.EDI.Api.Authentication;
@@ -27,11 +28,13 @@ using Energinet.DataHub.EDI.Api.Configuration.Middleware.Correlation;
 using Energinet.DataHub.EDI.Application.Actors;
 using Energinet.DataHub.EDI.ArchivedMessages.Application.Configuration;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Authentication;
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.DataAccess;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.MessageBus.RemoteBusinessServices;
 using Energinet.DataHub.EDI.Common.DateTime;
 using Energinet.DataHub.EDI.IncomingMessages.Application.Configuration;
 using Energinet.DataHub.EDI.Infrastructure.Configuration;
+using Energinet.DataHub.EDI.Infrastructure.Configuration.DataAccess;
 using Energinet.DataHub.EDI.Infrastructure.Wholesale;
 using Energinet.DataHub.EDI.OutgoingMessages.Application.Configuration;
 using Energinet.DataHub.EDI.Process.Application.Configuration;
@@ -118,11 +121,12 @@ namespace Energinet.DataHub.EDI.Api
                             sp.GetRequiredService<AuthenticatedActor>());
                     });
 
-                    CompositionRoot.Initialize(services, databaseConnectionString!)
+                    services.AddScopedSqlDbContext<B2BContext>(configuration);
+
+                    CompositionRoot.Initialize(services)
                         .AddRemoteBusinessService<DummyRequest, DummyReply>("Dummy", "Dummy")
                         .AddBearerAuthentication(tokenValidationParameters)
                         .AddSystemClock(new SystemDateTimeProvider())
-                        .AddDatabaseContext(databaseConnectionString!)
                         .AddCorrelationContext(_ =>
                         {
                             var correlationContext = new CorrelationContext();
@@ -154,7 +158,7 @@ namespace Energinet.DataHub.EDI.Api
 
                     services.AddArchivedMessagesModule(configuration);
                     services.AddIncomingMessagesModule(configuration);
-                    ActorMessageQueueConfiguration.Configure(services);
+                    services.AddActorMessageQueueModule(configuration);
                     services.AddProcessModule(configuration);
                 })
                 .ConfigureLogging(logging =>

--- a/source/Api/Program.cs
+++ b/source/Api/Program.cs
@@ -100,8 +100,6 @@ namespace Energinet.DataHub.EDI.Api
                 })
                 .ConfigureServices(services =>
                 {
-                    var databaseConnectionString = runtime.DB_CONNECTION_STRING;
-
                     services.AddApplicationInsights();
                     services.ConfigureFunctionsApplicationInsights();
 

--- a/source/BuildingBlocks.Application/Configuration/SqlExtensions.cs
+++ b/source/BuildingBlocks.Application/Configuration/SqlExtensions.cs
@@ -12,17 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration;
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration.Options;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration;
+namespace BuildingBlocks.Application.Configuration;
 
 public static class SqlExtensions
 {
     public static void AddScopedSqlDbContext<TDbContext>(
-        this IServiceCollection services)
+        this IServiceCollection services,
+        IConfiguration configuration)
         where TDbContext : DbContext
     {
+        services
+            .AddOptions<SqlDatabaseConnectionOptions>()
+            .Bind(configuration)
+            .Validate(o => !string.IsNullOrEmpty(o.DB_CONNECTION_STRING), "DB_CONNECTION_STRING must be set");
+
+        services.AddScoped<SqlConnectionSource>();
+
         services.AddDbContext<TDbContext>((sp, o) =>
         {
             var source = sp.GetRequiredService<SqlConnectionSource>();

--- a/source/BuildingBlocks.Infrastructure/Configuration/SqlConnectionSource.cs
+++ b/source/BuildingBlocks.Infrastructure/Configuration/SqlConnectionSource.cs
@@ -13,16 +13,21 @@
 // limitations under the License.
 
 using System;
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration.Options;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
 
 namespace Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration;
 
 public sealed class SqlConnectionSource : IDisposable
 {
-    public SqlConnectionSource(string databaseConnectionString)
+    public SqlConnectionSource(IOptions<SqlDatabaseConnectionOptions> options)
     {
-        var builder = new SqlConnectionStringBuilder(databaseConnectionString);
-        builder.Encrypt = true;
+        if (options == null) throw new ArgumentNullException(nameof(options));
+        var builder = new SqlConnectionStringBuilder(options.Value.DB_CONNECTION_STRING)
+        {
+            Encrypt = true,
+        };
         Connection = new SqlConnection(builder.ConnectionString);
     }
 

--- a/source/IncomingMessages.Application/Configuration/IncomingMessagesConfiguration.cs
+++ b/source/IncomingMessages.Application/Configuration/IncomingMessagesConfiguration.cs
@@ -40,7 +40,7 @@ public static class IncomingMessagesConfiguration
                 o => !string.IsNullOrEmpty(o.INCOMING_MESSAGES_QUEUE_NAME),
                 "INCOMING_MESSAGES_QUEUE_NAME must be set");
 
-        services.AddScopedSqlDbContext<IncomingMessagesContext>();
+        services.AddScopedSqlDbContext<IncomingMessagesContext>(configuration);
         services.AddScoped<IIncomingMessageParser, IncomingMessageParser>();
         services.AddScoped<ITransactionIdRepository, TransactionIdRepository>();
         services.AddScoped<IMessageIdRepository, MessageIdRepository>();

--- a/source/Infrastructure/Configuration/CompositionRoot.cs
+++ b/source/Infrastructure/Configuration/CompositionRoot.cs
@@ -47,7 +47,7 @@ namespace Energinet.DataHub.EDI.Infrastructure.Configuration
     {
         private readonly IServiceCollection _services;
 
-        private CompositionRoot(IServiceCollection services, string connectionString)
+        private CompositionRoot(IServiceCollection services)
         {
             _services = services;
             services.AddSingleton<HttpClient>();
@@ -67,16 +67,9 @@ namespace Energinet.DataHub.EDI.Infrastructure.Configuration
             DataRetentionConfiguration.Configure(services);
         }
 
-        public static CompositionRoot Initialize(IServiceCollection services, string connectionString)
+        public static CompositionRoot Initialize(IServiceCollection services)
         {
-            return new CompositionRoot(services, connectionString);
-        }
-
-        public CompositionRoot AddDatabaseContext(string databaseConnectionString)
-        {
-            _services.AddScoped<SqlConnectionSource>(sp => new SqlConnectionSource(databaseConnectionString!));
-            _services.AddScopedSqlDbContext<B2BContext>();
-            return this;
+            return new CompositionRoot(services);
         }
 
         public CompositionRoot AddSystemClock(ISystemDateTimeProvider provider)

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -17,6 +17,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BuildingBlocks.Application.Configuration;
 using Energinet.DataHub.Core.Messaging.Communication.Subscriber;
 using Energinet.DataHub.EDI.Api;
 using Energinet.DataHub.EDI.Api.Authentication;
@@ -26,6 +27,7 @@ using Energinet.DataHub.EDI.ArchivedMessages.Application.Configuration;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Actors;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Authentication;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.DataAccess;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.MessageBus;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.MessageBus.RemoteBusinessServices;
@@ -177,10 +179,12 @@ namespace Energinet.DataHub.EDI.IntegrationTests
                     sp.GetRequiredService<IActorRepository>(),
                     sp.GetRequiredService<AuthenticatedActor>());
             });
-            CompositionRoot.Initialize(_services, DatabaseFixture.ConnectionString)
+
+            _services.AddScopedSqlDbContext<B2BContext>(config);
+
+            CompositionRoot.Initialize(_services)
                 .AddRemoteBusinessService<DummyRequest, DummyReply>(
                     sp => new RemoteBusinessServiceRequestSenderSpy<DummyRequest>("Dummy"), "Dummy")
-                .AddDatabaseContext(DatabaseFixture.ConnectionString)
                 .AddSystemClock(new SystemDateTimeProviderStub())
                 .AddCorrelationContext(_ =>
                 {
@@ -190,8 +194,7 @@ namespace Energinet.DataHub.EDI.IntegrationTests
                 })
                 .AddMessagePublishing();
 
-            ActorMessageQueueConfiguration.Configure(_services);
-
+            _services.AddActorMessageQueueModule(config);
             _services.AddProcessModule(config);
             _services.AddArchivedMessagesModule(config);
             _services.AddIncomingMessagesModule(config);

--- a/source/OutgoingMessages.Application/Configuration/ActorMessageQueueConfiguration.cs
+++ b/source/OutgoingMessages.Application/Configuration/ActorMessageQueueConfiguration.cs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using BuildingBlocks.Application.Configuration;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
-using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration;
 using Energinet.DataHub.EDI.OutgoingMessages.Application.MarketDocuments;
 using Energinet.DataHub.EDI.OutgoingMessages.Application.MarketDocuments.AggregationResult;
 using Energinet.DataHub.EDI.OutgoingMessages.Application.MarketDocuments.RejectRequestAggregatedMeasureData;
@@ -25,15 +25,16 @@ using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Configuration.DataAc
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.OutgoingMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.OutgoingMessages.Queueing;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Energinet.DataHub.EDI.OutgoingMessages.Application.Configuration;
 
 public static class ActorMessageQueueConfiguration
 {
-    public static void Configure(IServiceCollection services)
+    public static void AddActorMessageQueueModule(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddScopedSqlDbContext<ActorMessageQueueContext>();
+        services.AddScopedSqlDbContext<ActorMessageQueueContext>(configuration);
 
         //AddMessageGenerationServices
         services.AddScoped<DocumentFactory>();

--- a/source/OutgoingMessages.Application/OutgoingMessages.Application.csproj
+++ b/source/OutgoingMessages.Application/OutgoingMessages.Application.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ArchivedMessages.Infrastructure\ArchivedMessages.Infrastructure.csproj" />
     <ProjectReference Include="..\ArchivedMessages.Interfaces\ArchivedMessages.Interfaces.csproj" />
+    <ProjectReference Include="..\BuildingBlocks.Application\BuildingBlocks.Application.csproj" />
     <ProjectReference Include="..\OutgoingMessages.Interfaces\OutgoingMessages.Interfaces.csproj" />
     <ProjectReference Include="..\OutgoingMessages.Domain\OutgoingMessages.Domain.csproj" />
     <ProjectReference Include="..\OutgoingMessages.Infrastructure\OutgoingMessages.Infrastructure.csproj" />

--- a/source/Process.Application/Configuration/ProcessConfiguration.cs
+++ b/source/Process.Application/Configuration/ProcessConfiguration.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration;
+using BuildingBlocks.Application.Configuration;
 using Energinet.DataHub.EDI.Infrastructure.Configuration.IntegrationEvents.IntegrationEventMappers;
 using Energinet.DataHub.EDI.Infrastructure.InboxEvents;
 using Energinet.DataHub.EDI.Infrastructure.Wholesale;
@@ -46,7 +46,7 @@ public static class ProcessConfiguration
                 o => !string.IsNullOrEmpty(o.WHOLESALE_INBOX_MESSAGE_QUEUE_NAME),
                 "WHOLESALE_INBOX_MESSAGE_QUEUE_NAME must be set");
 
-        services.AddScopedSqlDbContext<ProcessContext>();
+        services.AddScopedSqlDbContext<ProcessContext>(configuration);
 
         //EventsConfiguration
         //TODO: can we move them out and delete ref to Infrastructure?

--- a/source/Process.Application/Process.Application.csproj
+++ b/source/Process.Application/Process.Application.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\BuildingBlocks.Application\BuildingBlocks.Application.csproj" />
     <ProjectReference Include="..\OutgoingMessages.Application\OutgoingMessages.Application.csproj" />
     <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
     <ProjectReference Include="..\OutgoingMessages.Interfaces\OutgoingMessages.Interfaces.csproj" />


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->
<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

No service for type 'Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration.SqlConnectionSource' has been 
registered.
## References
