### PR TITLE
build: Increase tests build timeout period

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -27,27 +27,24 @@ jobs:
 
   # Run all tests in 'IntegrationTests.dll'
   integration_tests:
-    needs: dotnet_ci_build
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\IntegrationTests\bin\Release\net7.0\Energinet.DataHub.EDI.IntegrationTests.dll
-      download_attempt_limit: 20 # 20 retries, 15 seconds delay = 5 minutes
+      download_attempt_limit: 20 # 20 retries, 15 seconds delay = 5 minutes max wait
       dotnet_version: 7.0.200
 
   # Run all tests in 'ArchitectureTests.dll'
   architecture_tests:
-    needs: dotnet_ci_build
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\ArchitectureTests\bin\Release\net7.0\Energinet.DataHub.EDI.ArchitectureTests.dll
-      download_attempt_limit: 20 # 20 retries, 15 seconds delay = 5 minutes
+      download_attempt_limit: 20 # 20 retries, 15 seconds delay = 5 minutes max wait
       dotnet_version: 7.0.200
 
   # Run all tests in 'Tests.dll'
   tests:
-    needs: dotnet_ci_build
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\Tests\bin\Release\net7.0\Energinet.DataHub.EDI.Tests.dll
-      download_attempt_limit: 20 # 20 retries, 15 seconds delay = 5 minutes
+      download_attempt_limit: 20 # 20 retries, 15 seconds delay = 5 minutes max wait
       dotnet_version: 7.0.200

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -30,7 +30,7 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\IntegrationTests\bin\Release\net7.0\Energinet.DataHub.EDI.IntegrationTests.dll
-      download_attempt_limit: 20 # 20 retries, 15 seconds delay = 5 minutes max wait
+      download_attempt_limit: 20    # 20 retries with 15 seconds delay = 5 minutes wait before timeout
       dotnet_version: 7.0.200
 
   # Run all tests in 'ArchitectureTests.dll'
@@ -38,7 +38,7 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\ArchitectureTests\bin\Release\net7.0\Energinet.DataHub.EDI.ArchitectureTests.dll
-      download_attempt_limit: 20 # 20 retries, 15 seconds delay = 5 minutes max wait
+      download_attempt_limit: 20    # 20 retries with 15 seconds delay = 5 minutes wait before timeout
       dotnet_version: 7.0.200
 
   # Run all tests in 'Tests.dll'
@@ -46,5 +46,5 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\Tests\bin\Release\net7.0\Energinet.DataHub.EDI.Tests.dll
-      download_attempt_limit: 20 # 20 retries, 15 seconds delay = 5 minutes max wait
+      download_attempt_limit: 20    # 20 retries with 15 seconds delay = 5 minutes wait before timeout
       dotnet_version: 7.0.200

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -27,24 +27,27 @@ jobs:
 
   # Run all tests in 'IntegrationTests.dll'
   integration_tests:
+    needs: dotnet_ci_build
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\IntegrationTests\bin\Release\net7.0\Energinet.DataHub.EDI.IntegrationTests.dll
-      download_attempt_limit: 12
+      download_attempt_limit: 20 # 20 retries, 15 seconds delay = 5 minutes
       dotnet_version: 7.0.200
 
   # Run all tests in 'ArchitectureTests.dll'
   architecture_tests:
+    needs: dotnet_ci_build
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\ArchitectureTests\bin\Release\net7.0\Energinet.DataHub.EDI.ArchitectureTests.dll
-      download_attempt_limit: 12
+      download_attempt_limit: 20 # 20 retries, 15 seconds delay = 5 minutes
       dotnet_version: 7.0.200
 
   # Run all tests in 'Tests.dll'
   tests:
+    needs: dotnet_ci_build
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\Tests\bin\Release\net7.0\Energinet.DataHub.EDI.Tests.dll
-      download_attempt_limit: 12
+      download_attempt_limit: 20 # 20 retries, 15 seconds delay = 5 minutes
       dotnet_version: 7.0.200

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -27,7 +27,6 @@ jobs:
 
   # Run all tests in 'IntegrationTests.dll'
   integration_tests:
-    name: Integration tests
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\IntegrationTests\bin\Release\net7.0\Energinet.DataHub.EDI.IntegrationTests.dll
@@ -36,7 +35,6 @@ jobs:
 
   # Run all tests in 'ArchitectureTests.dll'
   architecture_tests:
-    name: Architecture tests
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\ArchitectureTests\bin\Release\net7.0\Energinet.DataHub.EDI.ArchitectureTests.dll
@@ -45,7 +43,6 @@ jobs:
 
   # Run all tests in 'Tests.dll'
   tests:
-    name: Unit tests
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\Tests\bin\Release\net7.0\Energinet.DataHub.EDI.Tests.dll

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -27,6 +27,7 @@ jobs:
 
   # Run all tests in 'IntegrationTests.dll'
   integration_tests:
+    name: Integration tests
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\IntegrationTests\bin\Release\net7.0\Energinet.DataHub.EDI.IntegrationTests.dll
@@ -35,6 +36,7 @@ jobs:
 
   # Run all tests in 'ArchitectureTests.dll'
   architecture_tests:
+    name: Architecture tests
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\ArchitectureTests\bin\Release\net7.0\Energinet.DataHub.EDI.ArchitectureTests.dll
@@ -43,6 +45,7 @@ jobs:
 
   # Run all tests in 'Tests.dll'
   tests:
+    name: Unit tests
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v12
     with:
       tests_dll_file_path: \source\Tests\bin\Release\net7.0\Energinet.DataHub.EDI.Tests.dll


### PR DESCRIPTION
## Description
Our test runs right now waits 3 minutes for the build to complete, then aborts. This PR increases it to 5 minutes. I think the only disadvantage on increasing the timeout is that if the build fails then the run will take longer to complete.

An alternative is to make the steps depend on the build, but then the tests overall time will be longer, since each test job won't start before the entire build is complete.