### PR TITLE
style: Update Rider/ReSharper with (some of) the StyleCop formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -201,7 +201,7 @@ csharp_style_unused_value_assignment_preference = discard_variable:suggestion
 
 # Index and range preferences
 csharp_style_prefer_index_operator = true:suggestion
-csharp_style_prefer_range_operator = true::silent
+csharp_style_prefer_range_operator = true:silent
 
 # Misc. preferences
 csharp_style_deconstructed_variable_declaration = true:suggestion
@@ -515,6 +515,14 @@ dotnet_diagnostic.SA1651.severity = error
 dotnet_diagnostic.SA1652.severity = none
 dotnet_diagnostic.SX1101.severity = error
 dotnet_diagnostic.SX1309.severity = error
+
+# ReSharper properties
+resharper_csharp_wrap_after_declaration_lpar = true
+resharper_csharp_wrap_after_invocation_lpar = true
+resharper_csharp_wrap_arguments_style = chop_if_long
+resharper_csharp_wrap_parameters_style = chop_if_long
+resharper_trailing_comma_in_multiline_lists = true
+resharper_wrap_chained_method_calls = chop_if_long
 
 ##############################################################
 # C# Test Conventions                                        #


### PR DESCRIPTION
## Description
EditorConfig is updated for Rider/ReSharper to:
 - Chop arguments to method calls and declarations if too long
 - Allow trailing commas in multiline lists
 - Chop chained method calls if too long

Additionally, there seemed to be an error wrt a range operator inspection, so this has been corrected too.