### PR TITLE
test: Ensure success status code for request aggregated measure data with XML used in acceptance tests

### DIFF
--- a/source/AcceptanceTests/Drivers/EdiDriver.cs
+++ b/source/AcceptanceTests/Drivers/EdiDriver.cs
@@ -171,7 +171,7 @@ internal sealed class EdiDriver : IDisposable
         Assert.Equal(HttpStatusCode.Unauthorized, httpRequestException.StatusCode);
     }
 
-    public async Task<string> RequestAggregatedMeasureDataAsyncXmlAsync(XmlDocument payload, string token)
+    public async Task<string> RequestAggregatedMeasureDataXmlAsync(XmlDocument payload, string token)
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, "/api/RequestAggregatedMeasureMessageReceiver");
         request.Headers.Authorization = new AuthenticationHeaderValue("bearer", token);
@@ -179,6 +179,8 @@ internal sealed class EdiDriver : IDisposable
         request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/xml");
         var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
         var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
 
         return responseString;
     }

--- a/source/AcceptanceTests/Dsl/AggregatedMeasureDataRequestDsl.cs
+++ b/source/AcceptanceTests/Dsl/AggregatedMeasureDataRequestDsl.cs
@@ -71,6 +71,6 @@ public sealed class AggregatedMeasureDataRequestDsl
 
     internal Task<string> AggregatedMeasureDataWithXmlPayload(XmlDocument payload, string token)
     {
-        return _edi.RequestAggregatedMeasureDataAsyncXmlAsync(payload, token);
+        return _edi.RequestAggregatedMeasureDataXmlAsync(payload, token);
     }
 }

--- a/source/AcceptanceTests/Tests/B2BErrors/WhenPayloadDataIsDifferentFromTokenDataTests.cs
+++ b/source/AcceptanceTests/Tests/B2BErrors/WhenPayloadDataIsDifferentFromTokenDataTests.cs
@@ -23,7 +23,7 @@ using Xunit.Abstractions;
 namespace Energinet.DataHub.EDI.AcceptanceTests.Tests.B2BErrors;
 
 [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Test code should not configure await.")]
-[Collection("Acceptance test collection")]
+[Collection(AcceptanceTestCollection.AcceptanceTestCollectionName)]
 public class WhenPayloadDataIsDifferentFromTokenDataTests : BaseTestClass
 {
     public WhenPayloadDataIsDifferentFromTokenDataTests(ITestOutputHelper output, AcceptanceTestFixture fixture)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Ensure HTTP status code is correct when performing B2B error acceptance tests, so we get the correct exception if the HTTP request fails
