### PR TITLE
refac: integrationevents should not be saved when processing fails

### DIFF
--- a/source/Infrastructure/Configuration/IntegrationEvents/IReceivedIntegrationEventRepository.cs
+++ b/source/Infrastructure/Configuration/IntegrationEvents/IReceivedIntegrationEventRepository.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Data;
 using System.Threading.Tasks;
 
 namespace Energinet.DataHub.EDI.Infrastructure.Configuration.IntegrationEvents;
@@ -26,5 +27,5 @@ public interface IReceivedIntegrationEventRepository
     /// Add a Received Integration Event to the database, if it doesn't already exists
     /// </summary>
     /// <returns>Returns true if the event was added to the database, and false if the event wasn't added because it already exists</returns>
-    Task<AddReceivedIntegrationEventResult> AddIfNotExistsAsync(Guid eventId, string eventType);
+    Task<AddReceivedIntegrationEventResult> AddIfNotExistsAsync(Guid eventId, string eventType, IDbConnection dbConnection, IDbTransaction dbTransaction);
 }

--- a/source/IntegrationTests/Infrastructure/Configuration/IntegrationEvents/TestFailingIntegrationEventProcessor.cs
+++ b/source/IntegrationTests/Infrastructure/Configuration/IntegrationEvents/TestFailingIntegrationEventProcessor.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Energinet.DataHub.Core.Messaging.Communication;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.Infrastructure.Configuration.IntegrationEvents.IntegrationEventMappers;
+using Energinet.DataHub.EDI.IntegrationTests.Infrastructure.Configuration.InternalCommands;
+using MediatR;
+
+namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.Configuration.IntegrationEvents;
+
+public class TestFailingIntegrationEventProcessor : IIntegrationEventProcessor
+{
+    private readonly IMediator _mediator;
+
+    public TestFailingIntegrationEventProcessor(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public string EventTypeToHandle => TestIntegrationEventMessage.TestIntegrationEventName;
+
+    public int MappedCount { get; private set; }
+
+    public async Task ProcessAsync(IntegrationEvent integrationEvent, CancellationToken cancellationToken)
+    {
+        MappedCount++;
+
+        var fromResult = await Task.FromResult<ICommand<Unit>>(new TestCommand());
+
+        await _mediator.Send(fromResult, cancellationToken).ConfigureAwait(false);
+
+#pragma warning disable CA2201
+        throw new Exception("Test exception");
+#pragma warning restore CA2201
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
The previous implementation would always save an entry into the `ReceivedIntegrationEvents` table, even if the underlying processing would fail. This PR refactors the `ReceivedIntegrationEventRepository` to take an `IDBConnection` and  `IDBTransaction` to ensure that a rollback is possible if processing the event fails.

## References
