### PR TITLE
test: change b2c to not mandatory it is disabled for local execution

### DIFF
--- a/source/AcceptanceTests/AcceptanceTestFixture.cs
+++ b/source/AcceptanceTests/AcceptanceTestFixture.cs
@@ -71,8 +71,8 @@ public class AcceptanceTestFixture : IAsyncLifetime
         _azureEntraBackendBffScope = root.GetValue<string>("AZURE_ENTRA_BACKEND_BFF_SCOPE") ?? "https://devDataHubB2C.onmicrosoft.com/backend-bff/api";
         MarketParticipantUri = new Uri(root.GetValue<string>("MARKET_PARTICIPANT_URI") ?? "https://app-webapi-markpart-u-001.azurewebsites.net");
         B2CApiUri = new Uri(root.GetValue<string>("B2C_API_URI") ?? "https://app-b2cwebapi-edi-u-001.azurewebsites.net");
-        _b2cUsername = root.GetValue<string>("B2C_USERNAME") ?? throw new InvalidOperationException("B2C_USERNAME is not set in configuration");
-        _b2cPassword = root.GetValue<string>("B2C_PASSWORD") ?? throw new InvalidOperationException("B2C_PASSWORD is not set in configuration");
+        _b2cUsername = root.GetValue<string>("B2C_USERNAME") ?? "B2C_USERNAME is not set in configuration";
+        _b2cPassword = root.GetValue<string>("B2C_PASSWORD") ?? "B2C_PASSWORD is not set in configuration";
         EventPublisher = new IntegrationEventPublisher(serviceBusConnectionString, topicName);
         B2CAuthorizedHttpClient = new AsyncLazy<HttpClient>(CreateB2CAuthorizedHttpClientAsync);
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Next step is to get B2C test enabled for local executions. 

## References
