### PR TITLE
feat: Allow empty metering point type declaration in aggregation request

### DIFF
--- a/source/IntegrationTests/Application/IncomingMessages/RequestAggregatedMeasureDataMarketDocumentBuilder.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/RequestAggregatedMeasureDataMarketDocumentBuilder.cs
@@ -41,7 +41,7 @@ public class RequestAggregatedMeasureDataMarketDocumentBuilder
     private string _messageId = Guid.NewGuid().ToString();
     private string _serieId = Guid.NewGuid().ToString();
     private string _senderRole = ActorRole.EnergySupplier.Code;
-    private string _marketEvaluationPointType = "E17";
+    private string? _marketEvaluationPointType = "E17";
     private string? _marketEvaluationSettlementMethod = "D01";
     private string? _energySupplierMarketParticipantId = SampleData.NewEnergySupplierNumber;
     private string? _balanceResponsiblePartyMarketParticipantId = "5799999933318";
@@ -52,7 +52,7 @@ public class RequestAggregatedMeasureDataMarketDocumentBuilder
         return this;
     }
 
-    public RequestAggregatedMeasureDataMarketDocumentBuilder SetMarketEvaluationPointType(string marketEvaluationPointType)
+    public RequestAggregatedMeasureDataMarketDocumentBuilder SetMarketEvaluationPointType(string? marketEvaluationPointType)
     {
         _marketEvaluationPointType = marketEvaluationPointType;
         return this;

--- a/source/Process.Infrastructure/Transactions/AggregatedMeasureData/AggregatedMeasureDataRequestFactory.cs
+++ b/source/Process.Infrastructure/Transactions/AggregatedMeasureData/AggregatedMeasureDataRequestFactory.cs
@@ -17,6 +17,7 @@ using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData;
 using Energinet.DataHub.Edi.Requests;
 using Google.Protobuf;
+using Period = Energinet.DataHub.Edi.Requests.Period;
 
 namespace Energinet.DataHub.EDI.Process.Infrastructure.Transactions.AggregatedMeasureData;
 
@@ -38,9 +39,9 @@ public static class AggregatedMeasureDataRequestFactory
         return message;
     }
 
-    private static Edi.Requests.Period MapPeriod(AggregatedMeasureDataProcess process)
+    private static Period MapPeriod(AggregatedMeasureDataProcess process)
     {
-        var period = new Edi.Requests.Period
+        var period = new Period
         {
             Start = process.StartOfPeriod,
         };
@@ -56,11 +57,15 @@ public static class AggregatedMeasureDataRequestFactory
         var request = new AggregatedTimeSeriesRequest()
         {
             Period = MapPeriod(process),
-            MeteringPointType = process.MeteringPointType,
             RequestedByActorId = process.RequestedByActorId.Value,
             RequestedByActorRole = process.RequestedByActorRoleCode,
             BusinessReason = process.BusinessReason.Code,
         };
+
+        if (process.MeteringPointType != null)
+        {
+            request.MeteringPointType = process.MeteringPointType;
+        }
 
         if (process.SettlementMethod != null)
             request.SettlementMethod = process.SettlementMethod;

--- a/source/Tests/Domain/Transactions/AggregatedMeasureData/AggregatedMeasureDataRequestFactoryTests.cs
+++ b/source/Tests/Domain/Transactions/AggregatedMeasureData/AggregatedMeasureDataRequestFactoryTests.cs
@@ -18,6 +18,7 @@ using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasureData;
 using Energinet.DataHub.EDI.Process.Domain.Transactions;
 using Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData;
+using Energinet.DataHub.EDI.Process.Infrastructure.Transactions.AggregatedMeasureData;
 using Energinet.DataHub.Edi.Requests;
 using FluentAssertions;
 using Xunit;

--- a/source/Tests/Domain/Transactions/AggregatedMeasureData/AggregatedMeasureDataRequestFactoryTests.cs
+++ b/source/Tests/Domain/Transactions/AggregatedMeasureData/AggregatedMeasureDataRequestFactoryTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.EDI.B2CWebApi.Models;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasureData;
+using Energinet.DataHub.EDI.Process.Domain.Transactions;
+using Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData;
+using Energinet.DataHub.Edi.Requests;
+using FluentAssertions;
+using Xunit;
+using MeteringPointType = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.MeteringPointType;
+
+namespace Energinet.DataHub.EDI.Tests.Domain.Transactions.AggregatedMeasureData;
+
+public sealed class AggregatedMeasureDataRequestFactoryTests
+{
+    [Fact]
+    public void With_metering_point_type()
+    {
+        var process = new AggregatedMeasureDataProcess(
+            ProcessId.New(),
+            BusinessTransactionId.Create(Guid.NewGuid().ToString()),
+            ActorNumber.Create("8200000007743"),
+            MarketRole.BalanceResponsibleParty.Code,
+            BusinessReason.BalanceFixing,
+            MeteringPointType.Production.Code,
+            null,
+            "123456",
+            "123457",
+            "42",
+            null,
+            null,
+            null);
+
+        // Act
+        var serviceBusMessage = AggregatedMeasureDataRequestFactory.CreateServiceBusMessage(process);
+
+        // Assert
+        serviceBusMessage.Should().NotBeNull();
+
+        var request = AggregatedTimeSeriesRequest.Parser.ParseFrom(serviceBusMessage.Body);
+        request.MeteringPointType.Should().Be(MeteringPointType.Production.Code);
+    }
+
+    [Fact]
+    public void Without_metering_point_type()
+    {
+        var process = new AggregatedMeasureDataProcess(
+            ProcessId.New(),
+            BusinessTransactionId.Create(Guid.NewGuid().ToString()),
+            ActorNumber.Create("8200000007743"),
+            MarketRole.BalanceResponsibleParty.Code,
+            BusinessReason.BalanceFixing,
+            null,
+            null,
+            "123456",
+            "123457",
+            "42",
+            null,
+            null,
+            null);
+
+        // Act
+        var serviceBusMessage = AggregatedMeasureDataRequestFactory.CreateServiceBusMessage(process);
+
+        // Assert
+        serviceBusMessage.Should().NotBeNull();
+
+        var request = AggregatedTimeSeriesRequest.Parser.ParseFrom(serviceBusMessage.Body);
+        request.MeteringPointType.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Description
If an actor leaves out the metering point point type, it is interpreted as:
- EnergySupplier: All production and consumption
- Balance responsible party: All production and consumption
- Metered data responsible: All production, consumption, and exchange
