### PR TITLE
feat: ArchivedMessage file storage path based on incomming/outgoing type

### DIFF
--- a/source/ArchivedMessages.Interfaces/ArchivedMessage.cs
+++ b/source/ArchivedMessages.Interfaces/ArchivedMessage.cs
@@ -31,6 +31,7 @@ public class ArchivedMessage
         string receiverNumber, // Doesn't use ActorNumber since we want to make sure to always create a ArchivedMessage
         Instant createdAt,
         string? businessReason,
+        ArchivedMessageType archivedMessageType,
         Stream document)
     {
         Id = ArchivedMessageId.Create();
@@ -42,7 +43,8 @@ public class ArchivedMessage
         BusinessReason = businessReason;
         Document = document;
 
-        FileStorageReference = FileStorageReference.Create(FileStorageCategory, ReceiverNumber, createdAt, Id.Value);
+        var actorNumberForFileStorage = GetActorNumberForFileStoragePlacement(archivedMessageType, senderNumber, receiverNumber);
+        FileStorageReference = FileStorageReference.Create(FileStorageCategory, actorNumberForFileStorage, createdAt, Id.Value);
     }
 
     public ArchivedMessageId Id { get; }
@@ -62,4 +64,14 @@ public class ArchivedMessage
     public FileStorageReference FileStorageReference { get; }
 
     public Stream Document { get; }
+
+    private string GetActorNumberForFileStoragePlacement(ArchivedMessageType archivedMessageType, string senderActorNumber, string receiverActorNumber)
+    {
+        return archivedMessageType switch
+        {
+            ArchivedMessageType.IncomingMessage => SenderNumber,
+            ArchivedMessageType.OutgoingMessage => ReceiverNumber,
+            _ => throw new ArgumentOutOfRangeException(nameof(archivedMessageType), archivedMessageType, "Unknown ArchivedMessageType"),
+        };
+    }
 }

--- a/source/ArchivedMessages.Interfaces/ArchivedMessageType.cs
+++ b/source/ArchivedMessages.Interfaces/ArchivedMessageType.cs
@@ -1,0 +1,21 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Energinet.DataHub.EDI.ArchivedMessages.Interfaces;
+
+public enum ArchivedMessageType
+{
+    IncomingMessage,
+    OutgoingMessage,
+}

--- a/source/IncomingMessages.Application/IncomingMessageClient.cs
+++ b/source/IncomingMessages.Application/IncomingMessageClient.cs
@@ -19,6 +19,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.EDI.ArchivedMessages.Interfaces;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.Common.DateTime;
 using Energinet.DataHub.EDI.IncomingMessages.Interfaces;
 using IncomingMessages.Infrastructure;
 using IncomingMessages.Infrastructure.Messages;
@@ -37,6 +38,7 @@ public class IncomingMessageClient : IIncomingMessageClient
     private readonly IArchivedMessagesClient _archivedMessagesClient;
     private readonly ILogger<IncomingMessageClient> _logger;
     private readonly IRequestAggregatedMeasureDataReceiver _requestAggregatedMeasureDataReceiver;
+    private readonly ISystemDateTimeProvider _systemDateTimeProvider;
 
     public IncomingMessageClient(
         MarketMessageParser marketMessageParser,
@@ -44,7 +46,8 @@ public class IncomingMessageClient : IIncomingMessageClient
         ResponseFactory responseFactory,
         IArchivedMessagesClient archivedMessagesClient,
         ILogger<IncomingMessageClient> logger,
-        IRequestAggregatedMeasureDataReceiver requestAggregatedMeasureDataReceiver)
+        IRequestAggregatedMeasureDataReceiver requestAggregatedMeasureDataReceiver,
+        ISystemDateTimeProvider systemDateTimeProvider)
     {
         _marketMessageParser = marketMessageParser;
         _aggregatedMeasureDataMarketMessageValidator = aggregatedMeasureDataMarketMessageValidator;
@@ -52,6 +55,7 @@ public class IncomingMessageClient : IIncomingMessageClient
         _archivedMessagesClient = archivedMessagesClient;
         _logger = logger;
         _requestAggregatedMeasureDataReceiver = requestAggregatedMeasureDataReceiver;
+        _systemDateTimeProvider = systemDateTimeProvider;
     }
 
     public async Task<ResponseMessage> RegisterAndSendAsync(
@@ -117,7 +121,7 @@ public class IncomingMessageClient : IIncomingMessageClient
                 IncomingDocumentType.RequestAggregatedMeasureData.Name,
                 requestAggregatedMeasureDataMarketMessageParserResult.Dto!.SenderNumber,
                 requestAggregatedMeasureDataMarketMessageParserResult.Dto!.ReceiverNumber,
-                SystemClock.Instance.GetCurrentInstant(),
+                _systemDateTimeProvider.Now(),
                 requestAggregatedMeasureDataMarketMessageParserResult.Dto!.BusinessReason,
                 ArchivedMessageType.IncomingMessage,
                 message),

--- a/source/IncomingMessages.Application/IncomingMessageClient.cs
+++ b/source/IncomingMessages.Application/IncomingMessageClient.cs
@@ -119,6 +119,7 @@ public class IncomingMessageClient : IIncomingMessageClient
                 requestAggregatedMeasureDataMarketMessageParserResult.Dto!.ReceiverNumber,
                 SystemClock.Instance.GetCurrentInstant(),
                 requestAggregatedMeasureDataMarketMessageParserResult.Dto!.BusinessReason,
+                ArchivedMessageType.IncomingMessage,
                 message),
             cancellationToken).ConfigureAwait(false);
     }

--- a/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
@@ -26,12 +26,15 @@ using Energinet.DataHub.EDI.BuildingBlocks.Domain.Authentication;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.DataAccess;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.MessageBus;
+using Energinet.DataHub.EDI.Common.DateTime;
 using Energinet.DataHub.EDI.IncomingMessages.Interfaces;
 using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.EDI.IntegrationTests.TestDoubles;
+using FluentAssertions;
 using IncomingMessages.Infrastructure.Configuration.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
 using Xunit;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.IncomingMessages;
@@ -42,6 +45,7 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
     private readonly ServiceBusSenderFactoryStub _serviceBusClientSenderFactory;
     private readonly ServiceBusSenderSpy _senderSpy;
     private readonly IncomingMessagesContext _incomingMessageContext;
+    private readonly SystemDateTimeProviderStub _dateTimeProvider;
 
     public WhenIncomingMessagesIsReceivedTests(IntegrationTestFixture integrationTestFixture)
         : base(integrationTestFixture)
@@ -51,6 +55,7 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
         _serviceBusClientSenderFactory.AddSenderSpy(_senderSpy);
         _incomingMessagesRequest = GetService<IIncomingMessageClient>();
         _incomingMessageContext = GetService<IncomingMessagesContext>();
+        _dateTimeProvider = (SystemDateTimeProviderStub)GetService<ISystemDateTimeProvider>();
     }
 
     [Fact]
@@ -216,6 +221,57 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
             () => Assert.Empty(messageIds));
     }
 
+    [Fact]
+    public async Task Incoming_message_is_archived_with_correct_content()
+    {
+        // Assert
+        var authenticatedActor = GetService<AuthenticatedActor>();
+        var senderActorNumber = ActorNumber.Create("5799999933318");
+        authenticatedActor.SetAuthenticatedActor(new ActorIdentity(senderActorNumber, Restriction.Owned, ActorRole.BalanceResponsibleParty));
+        var messageStream = ReadJsonFile("Application\\IncomingMessages\\RequestAggregatedMeasureData.json");
+        var messageIdFromFile = "123564789123564789123564789123564789";
+        // Act
+        await _incomingMessagesRequest.RegisterAndSendAsync(
+            messageStream,
+            DocumentFormat.Json,
+            IncomingDocumentType.RequestAggregatedMeasureData,
+            CancellationToken.None);
+
+        // Assert
+        var generatedDocumentContent = await GetStreamContentAsStringAsync(messageStream);
+        var fileStorageReference = await GetArchivedMessageFileStorageReferenceFromDatabaseAsync(messageIdFromFile);
+        var fileContent = await GetFileFromFileStorageAsync("archived", fileStorageReference);
+        var archivedMessageFileContent = await GetStreamContentAsStringAsync(fileContent.Value.Content);
+        archivedMessageFileContent.Should().Be(generatedDocumentContent);
+    }
+
+    [Fact]
+    public async Task Incoming_message_is_archived_with_correct_file_storage_reference()
+    {
+        // Assert
+        int year = 2024,
+            month = 01,
+            date = 05;
+        _dateTimeProvider.SetNow(Instant.FromUtc(year, month, date, 04, 23));
+
+        var authenticatedActor = GetService<AuthenticatedActor>();
+        var senderActorNumber = ActorNumber.Create("5799999933318");
+        authenticatedActor.SetAuthenticatedActor(new ActorIdentity(senderActorNumber, Restriction.Owned, ActorRole.BalanceResponsibleParty));
+        var messageStream = ReadJsonFile("Application\\IncomingMessages\\RequestAggregatedMeasureData.json");
+        var messageIdFromFile = "123564789123564789123564789123564789";
+        // Act
+        await _incomingMessagesRequest.RegisterAndSendAsync(
+            messageStream,
+            DocumentFormat.Json,
+            IncomingDocumentType.RequestAggregatedMeasureData,
+            CancellationToken.None);
+
+        // Assert
+        var archivedMessageId = await GetArchivedMessageIdFromDatabaseAsync(messageIdFromFile);
+        var fileStorageReference = await GetArchivedMessageFileStorageReferenceFromDatabaseAsync(messageIdFromFile);
+        fileStorageReference.Should().Be($"{senderActorNumber.Value}/{year:0000}/{month:00}/{date:00}/{archivedMessageId:N}");
+    }
+
     protected override void Dispose(bool disposing)
     {
         _senderSpy.Dispose();
@@ -251,5 +307,13 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
         var sql = $"SELECT [MessageId] FROM [dbo].[MessageRegistry] WHERE SenderId = '{senderNumber.Value}'";
         var results = await connection.QueryAsync<dynamic>(sql);
         return results.ToList();
+    }
+
+    private async Task<Guid> GetArchivedMessageIdFromDatabaseAsync(string messageId)
+    {
+        using var connection = await GetService<IDatabaseConnectionFactory>().GetConnectionAndOpenAsync(CancellationToken.None);
+        var id = await connection.ExecuteScalarAsync<Guid>($"SELECT Id FROM [dbo].[ArchivedMessages] WHERE MessageId = '{messageId}'");
+
+        return id;
     }
 }

--- a/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
@@ -308,12 +308,4 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
         var results = await connection.QueryAsync<dynamic>(sql);
         return results.ToList();
     }
-
-    private async Task<Guid> GetArchivedMessageIdFromDatabaseAsync(string messageId)
-    {
-        using var connection = await GetService<IDatabaseConnectionFactory>().GetConnectionAndOpenAsync(CancellationToken.None);
-        var id = await connection.ExecuteScalarAsync<Guid>($"SELECT Id FROM [dbo].[ArchivedMessages] WHERE MessageId = '{messageId}'");
-
-        return id;
-    }
 }

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenAPeekIsRequestedTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenAPeekIsRequestedTests.cs
@@ -19,13 +19,16 @@ using System.Xml.Linq;
 using Dapper;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.DataAccess;
+using Energinet.DataHub.EDI.Common.DateTime;
 using Energinet.DataHub.EDI.IntegrationTests.Assertions;
 using Energinet.DataHub.EDI.IntegrationTests.Factories;
 using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
+using Energinet.DataHub.EDI.IntegrationTests.TestDoubles;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Configuration.DataAccess;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models;
 using FluentAssertions;
+using NodaTime;
 using Xunit;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages;
@@ -34,12 +37,14 @@ public class WhenAPeekIsRequestedTests : TestBase
 {
     private readonly OutgoingMessageDtoBuilder _outgoingMessageDtoBuilder;
     private readonly IOutgoingMessagesClient _outgoingMessagesClient;
+    private readonly SystemDateTimeProviderStub _dateTimeProvider;
 
     public WhenAPeekIsRequestedTests(IntegrationTestFixture integrationTestFixture)
         : base(integrationTestFixture)
     {
         _outgoingMessageDtoBuilder = new OutgoingMessageDtoBuilder();
         _outgoingMessagesClient = GetService<IOutgoingMessagesClient>();
+        _dateTimeProvider = (SystemDateTimeProviderStub)GetService<ISystemDateTimeProvider>();
     }
 
     [Fact]
@@ -89,19 +94,22 @@ public class WhenAPeekIsRequestedTests : TestBase
     }
 
     [Fact]
-    public async Task The_generated_document_is_archived_with_correct_content()
+    public async Task The_market_document_is_archived_with_correct_content()
     {
+        // Arrange
         var message = _outgoingMessageDtoBuilder
             .WithReceiverNumber(SampleData.NewEnergySupplierNumber)
             .WithReceiverRole(ActorRole.EnergySupplier)
             .Build();
         await EnqueueMessage(message);
 
+        // Act
         var result = await PeekMessage(MessageCategory.Aggregations);
 
+        // Assert
         result.Bundle.Should().NotBeNull();
-        var generatedDocumentContent = await GetStreamContentAsStringAsync(result.Bundle!);
 
+        var generatedDocumentContent = await GetStreamContentAsStringAsync(result.Bundle!);
         var fileStorageReference = await GetArchivedMessageFileStorageReferenceFromDatabaseAsync(result.MessageId!.Value);
         var fileContent = await GetFileFromFileStorageAsync("archived", fileStorageReference);
         var archivedMessageFileContent = await GetStreamContentAsStringAsync(fileContent.Value.Content);
@@ -109,7 +117,32 @@ public class WhenAPeekIsRequestedTests : TestBase
     }
 
     [Fact]
-    public async Task The_generated_market_document_is_added_to_database()
+    public async Task The_market_document_is_archived_with_correct_file_storage_reference()
+    {
+        // Arrange
+        int year = 2024,
+            month = 01,
+            date = 02;
+        _dateTimeProvider.SetNow(Instant.FromUtc(year, month, date, 11, 07));
+        var receiverNumber = SampleData.NewEnergySupplierNumber;
+        var message = _outgoingMessageDtoBuilder
+            .WithReceiverNumber(receiverNumber)
+            .WithReceiverRole(ActorRole.EnergySupplier)
+            .Build();
+        await EnqueueMessage(message);
+
+        // Act
+        var result = await PeekMessage(MessageCategory.Aggregations);
+
+        // Assert
+        result.Bundle.Should().NotBeNull();
+
+        var fileStorageReference = await GetArchivedMessageFileStorageReferenceFromDatabaseAsync(result.MessageId!.Value);
+        fileStorageReference.Should().Be($"{receiverNumber}/{year:0000}/{month:00}/{date:00}/{result.MessageId!.Value:N}");
+    }
+
+    [Fact]
+    public async Task The_market_document_is_added_to_database()
     {
         var message = _outgoingMessageDtoBuilder
             .WithReceiverNumber(SampleData.NewEnergySupplierNumber)

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenAPeekIsRequestedTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenAPeekIsRequestedTests.cs
@@ -137,8 +137,9 @@ public class WhenAPeekIsRequestedTests : TestBase
         // Assert
         result.Bundle.Should().NotBeNull();
 
+        var archivedMessageId = await GetArchivedMessageIdFromDatabaseAsync(result.MessageId!.Value.ToString());
         var fileStorageReference = await GetArchivedMessageFileStorageReferenceFromDatabaseAsync(result.MessageId!.Value);
-        fileStorageReference.Should().Be($"{receiverNumber}/{year:0000}/{month:00}/{date:00}/{result.MessageId!.Value:N}");
+        fileStorageReference.Should().Be($"{receiverNumber}/{year:0000}/{month:00}/{date:00}/{archivedMessageId:N}");
     }
 
     [Fact]

--- a/source/IntegrationTests/Application/SearchMessages/SearchMessagesTests.cs
+++ b/source/IntegrationTests/Application/SearchMessages/SearchMessagesTests.cs
@@ -252,7 +252,8 @@ public class SearchMessagesTests : TestBase
         string? receiverNumber = null,
         string? documentType = null,
         string? businessReason = null,
-        string? messageId = null)
+        string? messageId = null,
+        ArchivedMessageType? archivedMessageType = null)
     {
         return new ArchivedMessage(
             messageId ?? "MessageId",
@@ -261,6 +262,7 @@ public class SearchMessagesTests : TestBase
             receiverNumber ?? "1234512345128",
             createdAt.GetValueOrDefault(_systemDateTimeProvider.Now()),
             businessReason ?? BusinessReason.BalanceFixing.Name,
+            archivedMessageType ?? ArchivedMessageType.OutgoingMessage,
             new MemoryStream());
     }
 

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -135,6 +135,14 @@ namespace Energinet.DataHub.EDI.IntegrationTests
             return fileStorageReference;
         }
 
+        protected async Task<Guid> GetArchivedMessageIdFromDatabaseAsync(string messageId)
+        {
+            using var connection = await GetService<IDatabaseConnectionFactory>().GetConnectionAndOpenAsync(CancellationToken.None);
+            var id = await connection.ExecuteScalarAsync<Guid>($"SELECT Id FROM [dbo].[ArchivedMessages] WHERE MessageId = '{messageId}'");
+
+            return id;
+        }
+
         protected Task<string> GetArchivedMessageFileStorageReferenceFromDatabaseAsync(Guid messageId) => GetArchivedMessageFileStorageReferenceFromDatabaseAsync(messageId.ToString());
 
         protected T GetService<T>()

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -116,19 +116,26 @@ namespace Energinet.DataHub.EDI.IntegrationTests
 
         protected static async Task<string> GetStreamContentAsStringAsync(Stream stream)
         {
+            ArgumentNullException.ThrowIfNull(stream);
+
+            if (stream.CanSeek && stream.Position != 0)
+                stream.Position = 0;
+
             using var streamReader = new StreamReader(stream, Encoding.UTF8);
             var stringContent = await streamReader.ReadToEndAsync();
 
             return stringContent;
         }
 
-        protected async Task<string> GetArchivedMessageFileStorageReferenceFromDatabaseAsync(Guid messageId)
+        protected async Task<string> GetArchivedMessageFileStorageReferenceFromDatabaseAsync(string messageId)
         {
             using var connection = await GetService<IDatabaseConnectionFactory>().GetConnectionAndOpenAsync(CancellationToken.None);
             var fileStorageReference = await connection.ExecuteScalarAsync<string>($"SELECT FileStorageReference FROM [dbo].[ArchivedMessages] WHERE MessageId = '{messageId}'");
 
             return fileStorageReference;
         }
+
+        protected Task<string> GetArchivedMessageFileStorageReferenceFromDatabaseAsync(Guid messageId) => GetArchivedMessageFileStorageReferenceFromDatabaseAsync(messageId.ToString());
 
         protected T GetService<T>()
             where T : notnull

--- a/source/OutgoingMessages.Application/OutgoingMessages/MessagePeeker.cs
+++ b/source/OutgoingMessages.Application/OutgoingMessages/MessagePeeker.cs
@@ -80,13 +80,14 @@ public class MessagePeeker
 
             await _archivedMessageClient.CreateAsync(
                 new ArchivedMessage(
-                   peekResult.BundleId.Id.ToString(),
-                   outgoingMessageBundle.DocumentType.ToString(),
-                   outgoingMessageBundle.SenderId.Value,
-                   outgoingMessageBundle.Receiver.Number.Value,
-                   timestamp,
-                   outgoingMessageBundle.BusinessReason,
-                   result),
+                    peekResult.BundleId.Id.ToString(),
+                    outgoingMessageBundle.DocumentType.ToString(),
+                    outgoingMessageBundle.SenderId.Value,
+                    outgoingMessageBundle.Receiver.Number.Value,
+                    timestamp,
+                    outgoingMessageBundle.BusinessReason,
+                    ArchivedMessageType.OutgoingMessage,
+                    result),
                 cancellationToken).ConfigureAwait(false);
 
             document = new MarketDocument(result, peekResult.BundleId);


### PR DESCRIPTION
## Description

ArchivedMessages file storage reference is now dependent on whether the archived message is an incoming message (sender actor number) or outgoing message (receiver actor number)

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/33
