### PR TITLE
refac: ensure actors are informed when missing Content-Type header

### DIFF
--- a/source/Api/OutgoingMessages/PeekRequestListener.cs
+++ b/source/Api/OutgoingMessages/PeekRequestListener.cs
@@ -58,12 +58,19 @@ public class PeekRequestListener
         ArgumentNullException.ThrowIfNull(request);
 
         var cancellationToken = request.GetCancellationToken(hostCancellationToken);
-        var contentType = request.Headers.GetContentType();
+        var contentType = request.Headers.TryGetContentType();
+        if (contentType is null)
+        {
+            _logger.LogInformation(
+                "Could not parse desired format from Content-Type header, support values are: application/xml, application/json, application/ebix");
+            return request.CreateResponse(HttpStatusCode.UnsupportedMediaType);
+        }
+
         var desiredDocumentFormat = DocumentFormatParser.ParseFromContentTypeHeaderValue(contentType);
         if (desiredDocumentFormat is null)
         {
             _logger.LogInformation(
-                "Could not parse desired CIM format from Content-Type header value: {ContentType}",
+                "Could not parse desired document format from Content-Type header value: {ContentType}",
                 contentType);
             return request.CreateResponse(HttpStatusCode.UnsupportedMediaType);
         }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
When Actors peek they need to be informed when we are missing required headers, before this PR a 500 was returned if the content-type header was not set.

## References
