### PR TITLE
refac: Fetch the CIM actor ids in acceptance tests

### DIFF
--- a/source/AcceptanceTests/AcceptanceTestFixture.cs
+++ b/source/AcceptanceTests/AcceptanceTestFixture.cs
@@ -28,7 +28,8 @@ public class AcceptanceTestFixture : IAsyncLifetime
     internal const string EbixActorGridArea = "543";
     internal const string CimActorGridArea = "804";
 
-    internal const string ActorRole = "metereddataresponsible";
+    internal const string EbixActorNumber = "5790000610976"; // Corresponds to the "Mosaic 03" actor in the UI.
+    internal const string EbixActorRole = "metereddataresponsible";
 
     private readonly Uri _azureEntraB2CTenantUrl;
     private readonly string _azureEntraFrontendAppId;
@@ -61,7 +62,7 @@ public class AcceptanceTestFixture : IAsyncLifetime
         var azureEntraBackendAppId = root.GetValue<string>("backend-b2b-app-id") ?? throw new InvalidOperationException("backend-b2b-app-id is not set in configuration");
         ApiManagementUri = new Uri(root.GetValue<string>("apim-gateway-url") ?? throw new InvalidOperationException("apim-gateway-url secret is not set in configuration"));
 
-        MeteredDataResponsibleId = root.GetValue<string>("METERED_DATA_RESPONSIBLE_CLIENT_ID")
+        CimMeteredDataResponsibleId = root.GetValue<string>("METERED_DATA_RESPONSIBLE_CLIENT_ID")
                                    ?? throw new InvalidOperationException(
                                        "METERED_DATA_RESPONSIBLE_CLIENT_ID is not set in configuration");
 
@@ -70,11 +71,11 @@ public class AcceptanceTestFixture : IAsyncLifetime
             () => CreateB2BMeteredDataResponsibleAuthorizedHttpClientAsync(
                 azureB2CTenantId,
                 azureEntraBackendAppId,
-                MeteredDataResponsibleId,
+                CimMeteredDataResponsibleId,
                 meteredDataResponsibleSecret,
                 ApiManagementUri));
 
-        EnergySupplierId = root.GetValue<string>("ENERGY_SUPPLIER_CLIENT_ID")
+        CimEnergySupplierId = root.GetValue<string>("ENERGY_SUPPLIER_CLIENT_ID")
                            ?? throw new InvalidOperationException(
                                "ENERGY_SUPPLIER_CLIENT_ID is not set in configuration");
 
@@ -83,7 +84,7 @@ public class AcceptanceTestFixture : IAsyncLifetime
             () => CreateB2BEnergySupplierAuthorizedHttpClientAsync(
                 azureB2CTenantId,
                 azureEntraBackendAppId,
-                EnergySupplierId,
+                CimEnergySupplierId,
                 energySupplierSecret,
                 ApiManagementUri));
 
@@ -117,9 +118,9 @@ public class AcceptanceTestFixture : IAsyncLifetime
 
     internal AsyncLazy<HttpClient> B2BEnergySupplierAuthorizedHttpClient { get; }
 
-    internal string MeteredDataResponsibleId { get; }
+    internal string CimMeteredDataResponsibleId { get; }
 
-    internal string EnergySupplierId { get; }
+    internal string CimEnergySupplierId { get; }
 
     public Task InitializeAsync()
     {

--- a/source/AcceptanceTests/AcceptanceTestFixture.cs
+++ b/source/AcceptanceTests/AcceptanceTestFixture.cs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 using System.Net.Http.Headers;
-using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration; // DO NOT REMOVE THIS! use in debug mode
+using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.EDI.AcceptanceTests.Drivers;
 using Microsoft.Extensions.Configuration;
 using Nito.AsyncEx;
+
+// DO NOT REMOVE THIS! use in debug mode
 
 namespace Energinet.DataHub.EDI.AcceptanceTests;
 
@@ -26,10 +28,7 @@ public class AcceptanceTestFixture : IAsyncLifetime
     internal const string EbixActorGridArea = "543";
     internal const string CimActorGridArea = "804";
 
-    internal const string ActorNumber = "5790000610976"; // Corresponds to the "Mosaic 03" actor in the UI.
     internal const string ActorRole = "metereddataresponsible";
-
-    internal const string EdiSubsystemTestCimActorNumber = "5790000392551"; // Corresponds to the "EDI - SUBSYSTEM TEST CIM" in the UI.
 
     private readonly Uri _azureEntraB2CTenantUrl;
     private readonly string _azureEntraFrontendAppId;
@@ -62,13 +61,31 @@ public class AcceptanceTestFixture : IAsyncLifetime
         var azureEntraBackendAppId = root.GetValue<string>("backend-b2b-app-id") ?? throw new InvalidOperationException("backend-b2b-app-id is not set in configuration");
         ApiManagementUri = new Uri(root.GetValue<string>("apim-gateway-url") ?? throw new InvalidOperationException("apim-gateway-url secret is not set in configuration"));
 
-        var meteredDataResponsibleId = root.GetValue<string>("METERED_DATA_RESPONSIBLE_CLIENT_ID") ?? throw new InvalidOperationException("METERED_DATA_RESPONSIBLE_CLIENT_ID is not set in configuration");
-        var meteredDataResponsibleSecret = root.GetValue<string>("METERED_DATA_RESPONSIBLE_CLIENT_SECRET") ?? throw new InvalidOperationException("METERED_DATA_RESPONSIBLE_CLIENT_SECRET is not set in configuration");
-        B2BMeteredDataResponsibleAuthorizedHttpClient = new AsyncLazy<HttpClient>(() => CreateB2BMeteredDataResponsibleAuthorizedHttpClientAsync(azureB2CTenantId, azureEntraBackendAppId, meteredDataResponsibleId, meteredDataResponsibleSecret, ApiManagementUri));
+        MeteredDataResponsibleId = root.GetValue<string>("METERED_DATA_RESPONSIBLE_CLIENT_ID")
+                                   ?? throw new InvalidOperationException(
+                                       "METERED_DATA_RESPONSIBLE_CLIENT_ID is not set in configuration");
 
-        var energySupplierId = root.GetValue<string>("ENERGY_SUPPLIER_CLIENT_ID") ?? throw new InvalidOperationException("ENERGY_SUPPLIER_CLIENT_ID is not set in configuration");
+        var meteredDataResponsibleSecret = root.GetValue<string>("METERED_DATA_RESPONSIBLE_CLIENT_SECRET") ?? throw new InvalidOperationException("METERED_DATA_RESPONSIBLE_CLIENT_SECRET is not set in configuration");
+        B2BMeteredDataResponsibleAuthorizedHttpClient = new AsyncLazy<HttpClient>(
+            () => CreateB2BMeteredDataResponsibleAuthorizedHttpClientAsync(
+                azureB2CTenantId,
+                azureEntraBackendAppId,
+                MeteredDataResponsibleId,
+                meteredDataResponsibleSecret,
+                ApiManagementUri));
+
+        EnergySupplierId = root.GetValue<string>("ENERGY_SUPPLIER_CLIENT_ID")
+                           ?? throw new InvalidOperationException(
+                               "ENERGY_SUPPLIER_CLIENT_ID is not set in configuration");
+
         var energySupplierSecret = root.GetValue<string>("ENERGY_SUPPLIER_CLIENT_SECRET") ?? throw new InvalidOperationException("ENERGY_SUPPLIER_CLIENT_SECRET is not set in configuration");
-        B2BEnergySupplierAuthorizedHttpClient = new AsyncLazy<HttpClient>(() => CreateB2BEnergySupplierAuthorizedHttpClientAsync(azureB2CTenantId, azureEntraBackendAppId, energySupplierId, energySupplierSecret, ApiManagementUri));
+        B2BEnergySupplierAuthorizedHttpClient = new AsyncLazy<HttpClient>(
+            () => CreateB2BEnergySupplierAuthorizedHttpClientAsync(
+                azureB2CTenantId,
+                azureEntraBackendAppId,
+                EnergySupplierId,
+                energySupplierSecret,
+                ApiManagementUri));
 
         EbixCertificateThumbprint = root.GetValue<string>("EBIX_CERTIFICATE_THUMBPRINT") ?? "39D64F012A19C6F6FDFB0EA91D417873599D3325";
         EbixCertificatePassword = root.GetValue<string>("EBIX_CERTIFICATE_PASSWORD") ?? throw new InvalidOperationException("EBIX_CERTIFICATE_PASSWORD is not set in configuration");
@@ -99,6 +116,10 @@ public class AcceptanceTestFixture : IAsyncLifetime
     internal AsyncLazy<HttpClient> B2BMeteredDataResponsibleAuthorizedHttpClient { get; }
 
     internal AsyncLazy<HttpClient> B2BEnergySupplierAuthorizedHttpClient { get; }
+
+    internal string MeteredDataResponsibleId { get; }
+
+    internal string EnergySupplierId { get; }
 
     public Task InitializeAsync()
     {

--- a/source/AcceptanceTests/Tests/WhenEbixRequestIsReceivedTests.cs
+++ b/source/AcceptanceTests/Tests/WhenEbixRequestIsReceivedTests.cs
@@ -80,15 +80,15 @@ public sealed class WhenEbixPeekRequestIsReceivedTests
     public async Task Actor_cannot_peek_when_certificate_has_been_removed()
     {
         await _actor.PublishActorCertificateCredentialsRemovedForAsync(
-            _fixture.MeteredDataResponsibleId,
-            AcceptanceTestFixture.ActorRole,
+            AcceptanceTestFixture.EbixActorNumber,
+            AcceptanceTestFixture.EbixActorRole,
             _fixture.EbixCertificateThumbprint);
 
         await _ebix.ConfirmPeekWithRemovedCertificateIsNotAllowed();
 
         await _actor.ActorCertificateCredentialsAssignedAsync(
-            _fixture.MeteredDataResponsibleId,
-            AcceptanceTestFixture.ActorRole,
+            AcceptanceTestFixture.EbixActorNumber,
+            AcceptanceTestFixture.EbixActorRole,
             _fixture.EbixCertificateThumbprint);
     }
 
@@ -96,15 +96,15 @@ public sealed class WhenEbixPeekRequestIsReceivedTests
     public async Task Actor_cannot_dequeue_when_certificated_has_been_removed()
     {
         await _actor.PublishActorCertificateCredentialsRemovedForAsync(
-            _fixture.MeteredDataResponsibleId,
-            AcceptanceTestFixture.ActorRole,
+            AcceptanceTestFixture.EbixActorNumber,
+            AcceptanceTestFixture.EbixActorRole,
             _fixture.EbixCertificateThumbprint);
 
         await _ebix.ConfirmDequeueWithRemovedCertificateIsNotAllowed();
 
         await _actor.ActorCertificateCredentialsAssignedAsync(
-            _fixture.MeteredDataResponsibleId,
-            AcceptanceTestFixture.ActorRole,
+            AcceptanceTestFixture.EbixActorNumber,
+            AcceptanceTestFixture.EbixActorRole,
             _fixture.EbixCertificateThumbprint);
     }
 }

--- a/source/AcceptanceTests/Tests/WhenEbixRequestIsReceivedTests.cs
+++ b/source/AcceptanceTests/Tests/WhenEbixRequestIsReceivedTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using Energinet.DataHub.EDI.AcceptanceTests.Drivers;
 using Energinet.DataHub.EDI.AcceptanceTests.Drivers.Ebix;
 using Energinet.DataHub.EDI.AcceptanceTests.Dsl;
@@ -19,7 +20,7 @@ using Xunit.Categories;
 
 namespace Energinet.DataHub.EDI.AcceptanceTests.Tests;
 
-[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2007", Justification = "Test methods should not call ConfigureAwait(), as it may bypass parallelization limits")]
+[SuppressMessage("Usage", "CA2007", Justification = "Test methods should not call ConfigureAwait(), as it may bypass parallelization limits")]
 
 [IntegrationTest]
 [Collection(AcceptanceTestCollection.AcceptanceTestCollectionName)]
@@ -78,20 +79,32 @@ public sealed class WhenEbixPeekRequestIsReceivedTests
     [Fact]
     public async Task Actor_cannot_peek_when_certificate_has_been_removed()
     {
-        await _actor.PublishActorCertificateCredentialsRemovedForAsync(AcceptanceTestFixture.ActorNumber, AcceptanceTestFixture.ActorRole, _fixture.EbixCertificateThumbprint);
+        await _actor.PublishActorCertificateCredentialsRemovedForAsync(
+            _fixture.MeteredDataResponsibleId,
+            AcceptanceTestFixture.ActorRole,
+            _fixture.EbixCertificateThumbprint);
 
         await _ebix.ConfirmPeekWithRemovedCertificateIsNotAllowed();
 
-        await _actor.ActorCertificateCredentialsAssignedAsync(AcceptanceTestFixture.ActorNumber, AcceptanceTestFixture.ActorRole, _fixture.EbixCertificateThumbprint);
+        await _actor.ActorCertificateCredentialsAssignedAsync(
+            _fixture.MeteredDataResponsibleId,
+            AcceptanceTestFixture.ActorRole,
+            _fixture.EbixCertificateThumbprint);
     }
 
     [Fact]
     public async Task Actor_cannot_dequeue_when_certificated_has_been_removed()
     {
-        await _actor.PublishActorCertificateCredentialsRemovedForAsync(AcceptanceTestFixture.ActorNumber, AcceptanceTestFixture.ActorRole, _fixture.EbixCertificateThumbprint);
+        await _actor.PublishActorCertificateCredentialsRemovedForAsync(
+            _fixture.MeteredDataResponsibleId,
+            AcceptanceTestFixture.ActorRole,
+            _fixture.EbixCertificateThumbprint);
 
         await _ebix.ConfirmDequeueWithRemovedCertificateIsNotAllowed();
 
-        await _actor.ActorCertificateCredentialsAssignedAsync(AcceptanceTestFixture.ActorNumber, AcceptanceTestFixture.ActorRole, _fixture.EbixCertificateThumbprint);
+        await _actor.ActorCertificateCredentialsAssignedAsync(
+            _fixture.MeteredDataResponsibleId,
+            AcceptanceTestFixture.ActorRole,
+            _fixture.EbixCertificateThumbprint);
     }
 }

--- a/source/AcceptanceTests/Tests/WhenMonthlyAmountPerChargeResultResultIsPublishedTests.cs
+++ b/source/AcceptanceTests/Tests/WhenMonthlyAmountPerChargeResultResultIsPublishedTests.cs
@@ -28,10 +28,12 @@ namespace Energinet.DataHub.EDI.AcceptanceTests.Tests;
 public sealed class WhenMonthlyAmountPerChargeResultResultIsPublishedTests
 {
     private readonly AggregationResultDsl _aggregations;
+    private readonly AcceptanceTestFixture _fixture;
 
     public WhenMonthlyAmountPerChargeResultResultIsPublishedTests(AcceptanceTestFixture fixture)
     {
         ArgumentNullException.ThrowIfNull(fixture);
+        _fixture = fixture;
 
         _aggregations = new AggregationResultDsl(
             new EdiDriver(fixture.B2BEnergySupplierAuthorizedHttpClient),
@@ -45,8 +47,8 @@ public sealed class WhenMonthlyAmountPerChargeResultResultIsPublishedTests
 
         await _aggregations.PublishMonthlyChargeResultFor(
             AcceptanceTestFixture.CimActorGridArea,
-            AcceptanceTestFixture.EdiSubsystemTestCimActorNumber,
-            AcceptanceTestFixture.ActorNumber);
+            _fixture.EnergySupplierId,
+            _fixture.MeteredDataResponsibleId);
 
         await _aggregations.ConfirmResultIsAvailableFor();
     }

--- a/source/AcceptanceTests/Tests/WhenMonthlyAmountPerChargeResultResultIsPublishedTests.cs
+++ b/source/AcceptanceTests/Tests/WhenMonthlyAmountPerChargeResultResultIsPublishedTests.cs
@@ -47,8 +47,8 @@ public sealed class WhenMonthlyAmountPerChargeResultResultIsPublishedTests
 
         await _aggregations.PublishMonthlyChargeResultFor(
             AcceptanceTestFixture.CimActorGridArea,
-            _fixture.EnergySupplierId,
-            _fixture.MeteredDataResponsibleId);
+            _fixture.CimEnergySupplierId,
+            _fixture.CimMeteredDataResponsibleId);
 
         await _aggregations.ConfirmResultIsAvailableFor();
     }


### PR DESCRIPTION
## Description

Fetch the CIM actor ids instead on using hardcoded values. This should give us more flexibility in the future as we no longer require static actor numbers.

## References
#795 