### PR TITLE
refac: Unit of work resolves the DbContexts

### DIFF
--- a/source/BuildingBlocks.Application/Extensions/DependencyInjection/SqlExtensions.cs
+++ b/source/BuildingBlocks.Application/Extensions/DependencyInjection/SqlExtensions.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics;
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration.Options;
 using Microsoft.EntityFrameworkCore;
@@ -38,6 +40,43 @@ public static class SqlExtensions
                 var source = sp.GetRequiredService<SqlConnectionSource>();
                 o.UseSqlServer(source.Connection, y => y.UseNodaTime().EnableRetryOnFailure());
             });
+
+        /*
+         * Verily, fair denizens of this digital realm, attend closely! Behold, the arcane machinations that unfold
+         * before thee are wrought by forbidden arts, dark and eldritch. The very sinews of reality strain and twist,
+         * as if the weaver of fate herself hath been vexed by these unhallowed incantations.
+         *
+         * Lo, the veil 'twixt the mundane and the mystical grows thin, and the boundaries of reason fray like ancient
+         * parchment. What mortal hand hath conjured such sorcery? What impious mind hath dared to plumb the abyssal
+         * depths of knowledge forbidden?
+         *
+         * Take heed, for herein lies a web of enigma, spun by unseen hands—a dance of bits and bytes, where logic and
+         * chaos entwine. The binary sigils flicker, whispering secrets to the ether, and algorithms dance a spectral
+         * jig upon the silicon stage.
+         *
+         * Yet, I beseech thee, tread with caution! For the path of forbidden arts is fraught with peril. The very
+         * fabric of reality may warp and buckle, and the cosmic balance tremble upon its axis. The Fates themselves
+         * may cast their dice anew, and the stars weep in celestial lament.
+         *
+         * Shouldst thou venture further, remember this: knowledge is both boon and bane. To wield it recklessly
+         * invites calamity, and hubris courts the wrath of unseen powers. Let thy curiosity be tempered by wisdom,
+         * and thy quest for mastery be guided by reverence.
+         *
+         * Thus, let this comment stand as a warning to all who pass this way: Here be sorcery! Proceed at thine own
+         * peril, and may the gods have mercy upon thy digital soul.
+         */
+
+        /*
+         * This is to circumvent that the DI framework does not like variance; in this particular case,
+         * that you cannot resolve a list of a super type and get a list of the concrete implementations.
+         */
+        if (typeof(TDbContext).IsAssignableTo(typeof(UnitOfWorkDbContext)))
+        {
+            services.AddScoped<UnitOfWorkDbContext>(
+                sp => sp.GetRequiredService<TDbContext>() as UnitOfWorkDbContext
+                      ?? throw new UnreachableException());
+        }
+
         return services;
     }
 }

--- a/source/BuildingBlocks.Infrastructure/IUnitOfWorkContext.cs
+++ b/source/BuildingBlocks.Infrastructure/IUnitOfWorkContext.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
+
+public abstract class UnitOfWorkContext : DbContext
+{
+    protected UnitOfWorkContext(DbContextOptions options)
+        : base(options)
+    {
+    }
+
+    protected UnitOfWorkContext()
+    {
+    }
+}

--- a/source/BuildingBlocks.Infrastructure/UnitOfWorkDbContext.cs
+++ b/source/BuildingBlocks.Infrastructure/UnitOfWorkDbContext.cs
@@ -16,14 +16,14 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
 
-public abstract class UnitOfWorkContext : DbContext
+public abstract class UnitOfWorkDbContext : DbContext
 {
-    protected UnitOfWorkContext(DbContextOptions options)
+    protected UnitOfWorkDbContext(DbContextOptions options)
         : base(options)
     {
     }
 
-    protected UnitOfWorkContext()
+    protected UnitOfWorkDbContext()
     {
     }
 }

--- a/source/IncomingMessages.Infrastructure/Configuration/DataAccess/IncomingMessagesContext.cs
+++ b/source/IncomingMessages.Infrastructure/Configuration/DataAccess/IncomingMessagesContext.cs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 
 namespace IncomingMessages.Infrastructure.Configuration.DataAccess
 {
-    public class IncomingMessagesContext : DbContext
+    public class IncomingMessagesContext : UnitOfWorkContext
     {
         #nullable disable
         public IncomingMessagesContext(DbContextOptions<IncomingMessagesContext> options)

--- a/source/IncomingMessages.Infrastructure/Configuration/DataAccess/IncomingMessagesContext.cs
+++ b/source/IncomingMessages.Infrastructure/Configuration/DataAccess/IncomingMessagesContext.cs
@@ -17,7 +17,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace IncomingMessages.Infrastructure.Configuration.DataAccess
 {
-    public class IncomingMessagesContext : UnitOfWorkContext
+    public class IncomingMessagesContext : UnitOfWorkDbContext
     {
         #nullable disable
         public IncomingMessagesContext(DbContextOptions<IncomingMessagesContext> options)

--- a/source/Infrastructure/Configuration/DataAccess/UnitOfWork.cs
+++ b/source/Infrastructure/Configuration/DataAccess/UnitOfWork.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.DataAccess;
+using Energinet.DataHub.EDI.Process.Infrastructure.Configuration.DataAccess;
 using Microsoft.EntityFrameworkCore;
 
 namespace Energinet.DataHub.EDI.Infrastructure.Configuration.DataAccess;
@@ -40,6 +41,8 @@ public sealed class UnitOfWork : IUnitOfWork
 
     public async Task CommitTransactionAsync()
     {
-        await ResilientTransaction.New(_contexts[0]).SaveChangesAsync(_contexts).ConfigureAwait(false);
+        await ResilientTransaction
+            .New(_contexts.Single(c => c.GetType() == typeof(ProcessContext)))
+            .SaveChangesAsync(_contexts).ConfigureAwait(false);
     }
 }

--- a/source/Infrastructure/Configuration/DataAccess/UnitOfWork.cs
+++ b/source/Infrastructure/Configuration/DataAccess/UnitOfWork.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.DataAccess;
@@ -24,16 +26,16 @@ public sealed class UnitOfWork : IUnitOfWork
 {
     private readonly DbContext[] _contexts;
 
-    public UnitOfWork(params DbContext[] contexts)
+    public UnitOfWork(IEnumerable<UnitOfWorkDbContext> contexts)
     {
         ArgumentNullException.ThrowIfNull(contexts);
 
-        if (contexts.Length < 1)
+        _contexts = contexts.ToArray<DbContext>();
+
+        if (_contexts.Length < 1)
         {
             throw new ArgumentException("At least one context must be provided", nameof(contexts));
         }
-
-        _contexts = contexts;
     }
 
     public async Task CommitTransactionAsync()

--- a/source/IntegrationTests/Infrastructure/Configuration/DataAccess/UnitOfWorkTests.cs
+++ b/source/IntegrationTests/Infrastructure/Configuration/DataAccess/UnitOfWorkTests.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
+using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.Configuration.DataAccess;
+
+public sealed class UnitOfWorkTests : TestBase
+{
+    public UnitOfWorkTests(IntegrationTestFixture integrationTestFixture)
+        : base(integrationTestFixture)
+    {
+    }
+
+    public static IEnumerable<object[]> FindAllImplementationsOfUnitOfWorkDbContext()
+    {
+        var unitOfWorkDbContextType = typeof(UnitOfWorkDbContext);
+
+        var rootFolder = string.Join(
+            "\\",
+            AppDomain.CurrentDomain.BaseDirectory.Split("\\").Reverse().Skip(5).Reverse());
+
+        var assemblyPaths = Directory.GetFiles(rootFolder, "*.dll", SearchOption.AllDirectories)
+            .Where(p => p.Contains("net8.0", StringComparison.Ordinal))
+            .Where(p => p.Contains("Energinet.DataHub.EDI", StringComparison.Ordinal))
+            .DistinctBy(s => s.Split("\\").Last());
+
+        var assemblies = assemblyPaths.Select(Assembly.LoadFrom);
+
+        var types = assemblies
+            .SelectMany(a => a.GetExportedTypes())
+            .Where(t => unitOfWorkDbContextType.IsAssignableFrom(t) && !t.IsAbstract)
+            .ToArray();
+
+        return types.Select(t => new object[] { t });
+    }
+
+    [Theory]
+    [MemberData(nameof(FindAllImplementationsOfUnitOfWorkDbContext))]
+    public void METHOD(Type typeOfSpecificUnitOfWorkDbContext)
+    {
+        var getServiceMethodInfo = typeof(TestBase).GetMethod(
+            "GetService",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        var getServiceMethod = getServiceMethodInfo!.MakeGenericMethod(typeOfSpecificUnitOfWorkDbContext);
+
+        var someSpecificUnitOfWorkDbContext = getServiceMethod.Invoke(this, null);
+        var unitOfWorkDbContexts = GetServices<UnitOfWorkDbContext>();
+        var unitOfWorkDbContextOfSameTypeAsTheSpecificOne =
+            unitOfWorkDbContexts.Single(dbc => dbc.GetType() == typeOfSpecificUnitOfWorkDbContext);
+
+        someSpecificUnitOfWorkDbContext
+            .Should()
+            .BeSameAs(unitOfWorkDbContextOfSameTypeAsTheSpecificOne);
+    }
+}

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
-using BuildingBlocks.Application.Extensions.DependencyInjection;
 using BuildingBlocks.Application.FeatureFlag;
 using Dapper;
 using Energinet.DataHub.EDI.Api;
@@ -162,6 +162,12 @@ namespace Energinet.DataHub.EDI.IntegrationTests
             return ServiceProvider.GetRequiredService<T>();
         }
 
+        protected IReadOnlyCollection<T> GetServices<T>()
+            where T : notnull
+        {
+            return ServiceProvider.GetServices<T>().ToList().AsReadOnly();
+        }
+
         protected void ClearDbContextCaches()
         {
             if (_services == null) throw new InvalidOperationException("ServiceCollection is not yet initialized");
@@ -262,8 +268,6 @@ namespace Energinet.DataHub.EDI.IntegrationTests
 
             _services.AddTransient<IRequestHandler<TestCommand, Unit>, TestCommandHandler>();
             _services.AddTransient<IRequestHandler<TestCreateOutgoingMessageCommand, Unit>, TestCreateOutgoingCommandHandler>();
-
-            _services.AddScopedSqlDbContext<ProcessContext>(config);
 
             _services.AddAuthentication(
                 sp => new MarketActorAuthenticator(

--- a/source/OutgoingMessages.Infrastructure/Configuration/DataAccess/ActorMessageQueueContext.cs
+++ b/source/OutgoingMessages.Infrastructure/Configuration/DataAccess/ActorMessageQueueContext.cs
@@ -21,7 +21,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Configuration.DataAccess
 {
-    public class ActorMessageQueueContext : UnitOfWorkContext
+    public class ActorMessageQueueContext : UnitOfWorkDbContext
     {
         #nullable disable
         public ActorMessageQueueContext(DbContextOptions<ActorMessageQueueContext> options)

--- a/source/OutgoingMessages.Infrastructure/Configuration/DataAccess/ActorMessageQueueContext.cs
+++ b/source/OutgoingMessages.Infrastructure/Configuration/DataAccess/ActorMessageQueueContext.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queueing;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.OutgoingMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.OutgoingMessages.Queueing;
@@ -20,7 +21,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Configuration.DataAccess
 {
-    public class ActorMessageQueueContext : DbContext
+    public class ActorMessageQueueContext : UnitOfWorkContext
     {
         #nullable disable
         public ActorMessageQueueContext(DbContextOptions<ActorMessageQueueContext> options)

--- a/source/Process.Infrastructure/Configuration/DataAccess/ProcessContext.cs
+++ b/source/Process.Infrastructure/Configuration/DataAccess/ProcessContext.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
 using Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData;
 using Energinet.DataHub.EDI.Process.Infrastructure.InboxEvents;
 using Energinet.DataHub.EDI.Process.Infrastructure.InternalCommands;
@@ -21,7 +22,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Energinet.DataHub.EDI.Process.Infrastructure.Configuration.DataAccess
 {
-    public class ProcessContext : DbContext
+    public class ProcessContext : UnitOfWorkContext
     {
         #nullable disable
         public ProcessContext(DbContextOptions<ProcessContext> options)

--- a/source/Process.Infrastructure/Configuration/DataAccess/ProcessContext.cs
+++ b/source/Process.Infrastructure/Configuration/DataAccess/ProcessContext.cs
@@ -22,7 +22,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Energinet.DataHub.EDI.Process.Infrastructure.Configuration.DataAccess
 {
-    public class ProcessContext : UnitOfWorkContext
+    public class ProcessContext : UnitOfWorkDbContext
     {
         #nullable disable
         public ProcessContext(DbContextOptions<ProcessContext> options)


### PR DESCRIPTION
## Description
We introduce a new marker class, for DbContexts that are to be included in the UoW. We then let UoW resolve these and commit all of them automatically.

## References
Follow-up to #813.
