### PR TITLE
fix: null reference exception for outgoing message created before points was introduced

### DIFF
--- a/source/OutgoingMessages.Application/MarketDocuments/NotifyWholesaleServices/NotifyWholesaleServicesEbixDocumentWriter.cs
+++ b/source/OutgoingMessages.Application/MarketDocuments/NotifyWholesaleServices/NotifyWholesaleServicesEbixDocumentWriter.cs
@@ -155,54 +155,57 @@ public class NotifyWholesaleServicesEbixDocumentWriter : EbixDocumentWriter
                     await writer.WriteEndElementAsync().ConfigureAwait(false);
                 } // End </MeteringGridAreaUsedDomainLocation>
 
-                foreach (var point in series.Points)
+                if (series.Points != null)
                 {
-                    // Begin <IntervalEnergyObservation>
-                    await writer.WriteStartElementAsync(DocumentDetails.Prefix, "IntervalEnergyObservation", null)
-                        .ConfigureAwait(false);
+                    foreach (var point in series.Points)
                     {
-                        // <Position />
-                        await writer.WriteElementStringAsync(DocumentDetails.Prefix, "Position", null, point.Position.ToString(NumberFormatInfo.InvariantInfo))
+                        // Begin <IntervalEnergyObservation>
+                        await writer.WriteStartElementAsync(DocumentDetails.Prefix, "IntervalEnergyObservation", null)
                             .ConfigureAwait(false);
-
-                        // <EnergyQuantity />
-                        if (point.Quantity != null)
                         {
+                            // <Position />
+                            await writer.WriteElementStringAsync(DocumentDetails.Prefix, "Position", null, point.Position.ToString(NumberFormatInfo.InvariantInfo))
+                                .ConfigureAwait(false);
+
+                            // <EnergyQuantity />
+                            if (point.Quantity != null)
+                            {
+                                await writer.WriteElementStringAsync(
+                                        DocumentDetails.Prefix,
+                                        "EnergyQuantity",
+                                        null,
+                                        point.Quantity.Value.ToString(NumberFormatInfo.InvariantInfo))
+                                    .ConfigureAwait(false);
+                            }
+
+                            // <EnergyPrice />
+                            if (point.Price != null)
+                            {
+                                await writer.WriteElementStringAsync(
+                                        DocumentDetails.Prefix,
+                                        "EnergyPrice",
+                                        null,
+                                        point.Price.Value.ToString(NumberFormatInfo.InvariantInfo))
+                                    .ConfigureAwait(false);
+                            }
+
+                            // <QuantityQuality />
+                            if (point.QuantityQuality != null)
+                            {
+                                await WriteCodeWithCodeListReferenceAttributesAsync("QuantityQuality", point.QuantityQuality.Value.ToString(), writer).ConfigureAwait(false);
+                            }
+
+                            // <EnergySum />
                             await writer.WriteElementStringAsync(
                                     DocumentDetails.Prefix,
-                                    "EnergyQuantity",
+                                    "EnergySum",
                                     null,
-                                    point.Quantity.Value.ToString(NumberFormatInfo.InvariantInfo))
+                                    point.Amount?.ToString(NumberFormatInfo.InvariantInfo) ?? "0")
                                 .ConfigureAwait(false);
-                        }
 
-                        // <EnergyPrice />
-                        if (point.Price != null)
-                        {
-                            await writer.WriteElementStringAsync(
-                                    DocumentDetails.Prefix,
-                                    "EnergyPrice",
-                                    null,
-                                    point.Price.Value.ToString(NumberFormatInfo.InvariantInfo))
-                                .ConfigureAwait(false);
-                        }
-
-                        // <QuantityQuality />
-                        if (point.QuantityQuality != null)
-                        {
-                            await WriteCodeWithCodeListReferenceAttributesAsync("QuantityQuality", point.QuantityQuality.Value.ToString(), writer).ConfigureAwait(false);
-                        }
-
-                        // <EnergySum />
-                        await writer.WriteElementStringAsync(
-                                DocumentDetails.Prefix,
-                                "EnergySum",
-                                null,
-                                point.Amount?.ToString(NumberFormatInfo.InvariantInfo) ?? "0")
-                            .ConfigureAwait(false);
-
-                        await writer.WriteEndElementAsync().ConfigureAwait(false);
-                    } // End </IntervalEnergyObservation>
+                            await writer.WriteEndElementAsync().ConfigureAwait(false);
+                        } // End </IntervalEnergyObservation>
+                    }
                 }
 
                 // <ChargeType />


### PR DESCRIPTION

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

We are getting a null reference exception on Test-001, because outgoing messages was created with out any points for notify wholesale in ebix format. 

## References
