### PR TITLE
fix: ensure we use same version accross our modules of Microsoft.Bcl.AsyncInterfaces

### DIFF
--- a/source/AcceptanceTests/AcceptanceTests.csproj
+++ b/source/AcceptanceTests/AcceptanceTests.csproj
@@ -29,6 +29,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />

--- a/source/Api/Api.csproj
+++ b/source/Api/Api.csproj
@@ -48,6 +48,7 @@ limitations under the License.
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Polly" Version="8.1.0" />
     </ItemGroup>
     <ItemGroup>

--- a/source/ApplyDBMigrationsApp/ApplyDBMigrationsApp.csproj
+++ b/source/ApplyDBMigrationsApp/ApplyDBMigrationsApp.csproj
@@ -36,6 +36,7 @@ limitations under the License.
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.2" />
   </ItemGroup>
 

--- a/source/B2CWebApi/B2CWebApi.csproj
+++ b/source/B2CWebApi/B2CWebApi.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Energinet.DataHub.Core.Logging.LoggingMiddleware " Version="3.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.2" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
 

--- a/source/BuildingBlocks.Application/BuildingBlocks.Application.csproj
+++ b/source/BuildingBlocks.Application/BuildingBlocks.Application.csproj
@@ -13,6 +13,7 @@
       <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.2" />
       <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="8.1.0" />
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
       <PackageReference Include="Microsoft.FeatureManagement" Version="3.1.1" />

--- a/source/BuildingBlocks.Infrastructure/BuildingBlocks.Infrastructure.csproj
+++ b/source/BuildingBlocks.Infrastructure/BuildingBlocks.Infrastructure.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.17.1" />
     <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />

--- a/source/IntegrationEvents/IntegrationEvents.Application/IntegrationEvents.Application.csproj
+++ b/source/IntegrationEvents/IntegrationEvents.Application/IntegrationEvents.Application.csproj
@@ -15,6 +15,7 @@
 
     <ItemGroup>
       <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="3.3.1" />
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/IntegrationEvents/IntegrationEvents.Infrastructure/IntegrationEvents.Infrastructure.csproj
+++ b/source/IntegrationEvents/IntegrationEvents.Infrastructure/IntegrationEvents.Infrastructure.csproj
@@ -16,6 +16,7 @@
       <PackageReference Include="Dapper" Version="2.0.123" />
       <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="3.3.1" />
       <PackageReference Include="Energinet.DataHub.Wholesale.Contracts" Version="8.2.0" />
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
       <PackageReference Include="NodaTime.Serialization.Protobuf" Version="2.0.1" />
     </ItemGroup>
 

--- a/source/IntegrationTests/IntegrationTests.csproj
+++ b/source/IntegrationTests/IntegrationTests.csproj
@@ -29,6 +29,7 @@ limitations under the License.
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.16.1" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
         <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
         <PackageReference Include="xunit" Version="2.6.2" />

--- a/source/OutgoingMessages.Application/OutgoingMessages.Application.csproj
+++ b/source/OutgoingMessages.Application/OutgoingMessages.Application.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.1.1"/>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="8.0.0" />
   </ItemGroup>

--- a/source/OutgoingMessages.Infrastructure/OutgoingMessages.Infrastructure.csproj
+++ b/source/OutgoingMessages.Infrastructure/OutgoingMessages.Infrastructure.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
   </ItemGroup>

--- a/source/Process.Infrastructure/Process.Infrastructure.csproj
+++ b/source/Process.Infrastructure/Process.Infrastructure.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="MediatR" Version="12.1.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
     <PackageReference Include="Polly" Version="8.1.0" />


### PR DESCRIPTION

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

We have implicit reference to different version of  Microsoft.Bcl.AsyncInterfaces in our healtchecks, which means that some checks can't find this assembly in excepted version and fails when health check is requested. 

## References
