### PR TITLE
feat: use receiver on outgoing message to determind the message receiver

### DIFF
--- a/source/OutgoingMessages.Domain/OutgoingMessages/Queueing/OutgoingMessage.cs
+++ b/source/OutgoingMessages.Domain/OutgoingMessages/Queueing/OutgoingMessage.cs
@@ -52,6 +52,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
             _serializedContent = serializedContent;
             FileStorageReference = CreateFileStorageReference(ReceiverId, timestamp, Id);
             RelatedToMessageId = relatedToMessageId;
+            Receiver = Receiver.Create(ReceiverId, ReceiverRole);
         }
 
         /// <summary>
@@ -77,6 +78,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
             SenderId = senderId;
             SenderRole = senderRole;
             FileStorageReference = fileStorageReference;
+            Receiver = Receiver.Create(ReceiverId, ReceiverRole);
             // _serializedContent is set later in OutgoingMessageRepository, by getting the message from File Storage
         }
 
@@ -98,7 +100,10 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
 
         public ActorRole SenderRole { get; }
 
-        public Receiver Receiver => Receiver.Create(ReceiverId, ReceiverRole);
+        /// <summary>
+        /// Reference the actor queue that should receive the message.
+        /// </summary>
+        public Receiver Receiver { get; }
 
         public BundleId? AssignedBundleId { get; private set; }
 
@@ -291,7 +296,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
         /// </summary>
         public Receiver GetActorMessageQueueMetadata()
         {
-            var actorMessageQueueReceiverRole = ReceiverRole;
+            var actorMessageQueueReceiverRole = Receiver.ActorRole;
 
             if (WorkaroundFlags.MeteredDataResponsibleToGridOperatorHack)
             {
@@ -300,7 +305,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
                     actorMessageQueueReceiverRole = actorMessageQueueReceiverRole.ForActorMessageQueue();
             }
 
-            return Receiver.Create(ReceiverId, actorMessageQueueReceiverRole);
+            return Receiver.Create(Receiver.Number, actorMessageQueueReceiverRole);
         }
 
         private static bool DocumentIsAggregatedMeasureData(DocumentType documentType)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
When we are going to support delegation we need to be able to distinguish between the receiver in the message and which queue should receive the message

## References
