### PR TITLE
refac: Rename ProcessType to CalculationType

### DIFF
--- a/source/B2CWebApi/Factories/RequestAggregatedMeasureDataHttpFactory.cs
+++ b/source/B2CWebApi/Factories/RequestAggregatedMeasureDataHttpFactory.cs
@@ -14,8 +14,10 @@
 
 using Energinet.DataHub.EDI.B2CWebApi.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.IncomingMessages.Interfaces;
 using NodaTime;
+using MeteringPointType = Energinet.DataHub.EDI.B2CWebApi.Models.MeteringPointType;
 
 namespace Energinet.DataHub.EDI.B2CWebApi.Factories;
 
@@ -59,19 +61,19 @@ public static class RequestAggregatedMeasureDataHttpFactory
             new[] { serie });
     }
 
-    private static string? SetSettlementSeriesVersion(ProcessType processType)
+    private static string? SetSettlementSeriesVersion(CalculationType calculationType)
     {
-        if (processType == ProcessType.FirstCorrection)
+        if (calculationType == CalculationType.FirstCorrection)
         {
             return "D01";
         }
 
-        if (processType == ProcessType.SecondCorrection)
+        if (calculationType == CalculationType.SecondCorrection)
         {
             return "D02";
         }
 
-        if (processType == ProcessType.ThirdCorrection)
+        if (calculationType == CalculationType.ThirdCorrection)
         {
             return "D03";
         }
@@ -79,17 +81,17 @@ public static class RequestAggregatedMeasureDataHttpFactory
         return null;
     }
 
-    private static string MapToBusinessReasonCode(ProcessType requestProcessType)
+    private static string MapToBusinessReasonCode(CalculationType requestCalculationType)
     {
-        return requestProcessType switch
+        return requestCalculationType switch
         {
-            ProcessType.PreliminaryAggregation => "D03",
-            ProcessType.BalanceFixing => "D04",
-            ProcessType.WholesaleFixing => "D05",
-            ProcessType.FirstCorrection => "D32",
-            ProcessType.SecondCorrection => "D32",
-            ProcessType.ThirdCorrection => "D32",
-            _ => throw new ArgumentOutOfRangeException(nameof(requestProcessType), requestProcessType, "Unknown ProcessType"),
+            CalculationType.PreliminaryAggregation => BusinessReason.PreliminaryAggregation.Code,
+            CalculationType.BalanceFixing => BusinessReason.BalanceFixing.Code,
+            CalculationType.WholesaleFixing => BusinessReason.WholesaleFixing.Code,
+            CalculationType.FirstCorrection => BusinessReason.Correction.Code,
+            CalculationType.SecondCorrection => BusinessReason.Correction.Code,
+            CalculationType.ThirdCorrection => BusinessReason.Correction.Code,
+            _ => throw new ArgumentOutOfRangeException(nameof(requestCalculationType), requestCalculationType, "Unknown CalculationType"),
         };
     }
 

--- a/source/B2CWebApi/Models/RequestAggregatedMeasureDataMarketDocument.cs
+++ b/source/B2CWebApi/Models/RequestAggregatedMeasureDataMarketDocument.cs
@@ -18,7 +18,7 @@ namespace Energinet.DataHub.EDI.B2CWebApi.Models;
 /// Responsible for carrying the market message data from the incoming message before any data validation.
 /// </summary>
 public record RequestAggregatedMeasureDataMarketRequest(
-    ProcessType ProcessType,
+    CalculationType ProcessType, // TODO: Rename property to CalculationType when we implement RequestWholesaleSettlement in BFF
     MeteringPointType? MeteringPointType,
     string StartDate,
     string EndDate,
@@ -35,7 +35,7 @@ public enum MeteringPointType
     Exchange,
 }
 
-public enum ProcessType
+public enum CalculationType
 {
     PreliminaryAggregation,
     BalanceFixing,

--- a/source/Tests/B2CWebApi/RequestAggregatedMeasureData/RequestAggregatedMeasureDataFactoryTests.cs
+++ b/source/Tests/B2CWebApi/RequestAggregatedMeasureData/RequestAggregatedMeasureDataFactoryTests.cs
@@ -34,7 +34,7 @@ public class RequestAggregatedMeasureDataFactoryTests
         var startDay = 10;
         var endDay = 12;
         var request = new RequestAggregatedMeasureDataMarketRequest(
-            ProcessType: ProcessType.BalanceFixing,
+            ProcessType: CalculationType.BalanceFixing,
             MeteringPointType: MeteringPointType.Production,
             StartDate: $"2023-10-{startDay}T22:00:00.000Z",
             EndDate: $"2023-10-{endDay}T21:59:59.999Z",
@@ -74,7 +74,7 @@ public class RequestAggregatedMeasureDataFactoryTests
         var endDay = 12;
         var endDataMilliseconds = 998;
         var request = new RequestAggregatedMeasureDataMarketRequest(
-            ProcessType: ProcessType.BalanceFixing,
+            ProcessType: CalculationType.BalanceFixing,
             MeteringPointType: MeteringPointType.Production,
             StartDate: $"2023-10-10T22:00:00.000Z",
             EndDate: $"2023-10-{endDay}T21:59:59.{endDataMilliseconds}Z",


### PR DESCRIPTION
## Description

Rename ProcessType to CalculationType

- Don't rename `RequestAggregatedMeasureDataMarketRequest.ProcessType`, since that requires a change in the BFF. We will make that change when we implement RequestWholesaleSettlement in the BFF & B2C api

## References

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/46