### PR TITLE
test: Output logged errors in integration tests

### DIFF
--- a/source/IntegrationTests/Api/WhenMarketActorAuthenticatorMiddlewareIsCalledTests.cs
+++ b/source/IntegrationTests/Api/WhenMarketActorAuthenticatorMiddlewareIsCalledTests.cs
@@ -32,6 +32,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Api;
@@ -43,8 +44,8 @@ public class WhenMarketActorAuthenticatorMiddlewareIsCalledTests : TestBase
     private readonly FunctionExecutionDelegate _next;
     private readonly FunctionContextBuilder _functionContextBuilder;
 
-    public WhenMarketActorAuthenticatorMiddlewareIsCalledTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenMarketActorAuthenticatorMiddlewareIsCalledTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         AuthenticatedActor.SetAuthenticatedActor(null);
         _nextSpy = new NextSpy();

--- a/source/IntegrationTests/Application/ActorCertificate/WhenActorCertificateCredentialsAssignedEventIsReceived.cs
+++ b/source/IntegrationTests/Application/ActorCertificate/WhenActorCertificateCredentialsAssignedEventIsReceived.cs
@@ -28,6 +28,7 @@ using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.MarketParticipant.Infrastructure.Model.Contracts;
 using NodaTime;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.ActorCertificate;
@@ -37,8 +38,8 @@ namespace Energinet.DataHub.EDI.IntegrationTests.Application.ActorCertificate;
 [IntegrationTest]
 public class WhenActorCertificateCredentialsAssignedEventIsReceived : TestBase
 {
-    public WhenActorCertificateCredentialsAssignedEventIsReceived(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenActorCertificateCredentialsAssignedEventIsReceived(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
     }
 

--- a/source/IntegrationTests/Application/ActorCertificate/WhenActorCertificateCredentialsRemovedEventIsReceived.cs
+++ b/source/IntegrationTests/Application/ActorCertificate/WhenActorCertificateCredentialsRemovedEventIsReceived.cs
@@ -28,6 +28,7 @@ using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.MarketParticipant.Infrastructure.Model.Contracts;
 using NodaTime;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.ActorCertificate;
@@ -37,8 +38,8 @@ namespace Energinet.DataHub.EDI.IntegrationTests.Application.ActorCertificate;
 [IntegrationTest]
 public class WhenActorCertificateCredentialsRemovedEventIsReceived : TestBase
 {
-    public WhenActorCertificateCredentialsRemovedEventIsReceived(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenActorCertificateCredentialsRemovedEventIsReceived(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
     }
 

--- a/source/IntegrationTests/Application/Actors/CreateActorsTests.cs
+++ b/source/IntegrationTests/Application/Actors/CreateActorsTests.cs
@@ -24,6 +24,7 @@ using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.EDI.MasterData.Interfaces;
 using Energinet.DataHub.EDI.MasterData.Interfaces.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.Actors;
 
@@ -32,8 +33,8 @@ public class CreateActorsTests : TestBase
     private readonly IMasterDataClient _masterDataClient;
     private readonly IDatabaseConnectionFactory _connectionFactory;
 
-    public CreateActorsTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public CreateActorsTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _masterDataClient = GetService<IMasterDataClient>();
         _connectionFactory = GetService<IDatabaseConnectionFactory>();

--- a/source/IntegrationTests/Application/ArchivedMessages/WhenArchivedMessageIsCreatedTests.cs
+++ b/source/IntegrationTests/Application/ArchivedMessages/WhenArchivedMessageIsCreatedTests.cs
@@ -30,6 +30,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using NodaTime;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.ArchivedMessages;
 
@@ -37,8 +38,8 @@ public class WhenArchivedMessageIsCreatedTests : TestBase
 {
     private readonly IArchivedMessagesClient _archivedMessagesClient;
 
-    public WhenArchivedMessageIsCreatedTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenArchivedMessageIsCreatedTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _archivedMessagesClient = GetService<IArchivedMessagesClient>();
     }

--- a/source/IntegrationTests/Application/IncomingMessages/RequestAggregatedMeasureData/InitializeAggregatedMeasureDataProcessesCommandTests.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/RequestAggregatedMeasureData/InitializeAggregatedMeasureDataProcessesCommandTests.cs
@@ -30,6 +30,7 @@ using FluentAssertions;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.IncomingMessages.RequestAggregatedMeasureData;
@@ -41,8 +42,8 @@ public class InitializeAggregatedMeasureDataProcessesCommandTests : TestBase
     private readonly ServiceBusSenderSpy _senderSpy;
     private readonly ServiceBusSenderFactoryStub _serviceBusClientSenderFactory;
 
-    public InitializeAggregatedMeasureDataProcessesCommandTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public InitializeAggregatedMeasureDataProcessesCommandTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _processContext = GetService<ProcessContext>();
         _serviceBusClientSenderFactory = (ServiceBusSenderFactoryStub)GetService<IServiceBusSenderFactory>();

--- a/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
@@ -35,6 +35,7 @@ using FluentAssertions.Execution;
 using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.IncomingMessages;
 
@@ -46,8 +47,8 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
     private readonly IncomingMessagesContext _incomingMessageContext;
     private readonly SystemDateTimeProviderStub _dateTimeProvider;
 
-    public WhenIncomingMessagesIsReceivedTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenIncomingMessagesIsReceivedTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _serviceBusClientSenderFactory = (ServiceBusSenderFactoryStub)GetService<IServiceBusSenderFactory>();
         _senderSpy = new ServiceBusSenderSpy("Fake");

--- a/source/IntegrationTests/Application/IncomingMessages/WholesaleServices/WhenWholesaleServicesIsRequestedTests.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/WholesaleServices/WhenWholesaleServicesIsRequestedTests.cs
@@ -31,6 +31,7 @@ using FluentAssertions;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.IncomingMessages.WholesaleServices;
@@ -42,8 +43,8 @@ public class WhenWholesaleServicesIsRequestedTests : TestBase
     private readonly ServiceBusSenderFactoryStub _serviceBusClientSenderFactory;
     private readonly ServiceBusSenderSpy _senderSpy;
 
-    public WhenWholesaleServicesIsRequestedTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenWholesaleServicesIsRequestedTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _processContext = GetService<ProcessContext>();
         _serviceBusClientSenderFactory = (ServiceBusSenderFactoryStub)GetService<IServiceBusSenderFactory>();

--- a/source/IntegrationTests/Application/OutgoingMessages/DocumentFactory/DocumentFactoryTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/DocumentFactory/DocumentFactoryTests.cs
@@ -19,6 +19,7 @@ using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.MarketDocuments;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.DocumentFactory;
 
@@ -27,8 +28,8 @@ public class DocumentFactoryTests
 {
     private readonly IEnumerable<IDocumentWriter> _documentWriters;
 
-    public DocumentFactoryTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public DocumentFactoryTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _documentWriters = GetService<IEnumerable<IDocumentWriter>>();
     }

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenADequeueIsRequestedTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenADequeueIsRequestedTests.cs
@@ -24,6 +24,7 @@ using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages;
 
@@ -32,8 +33,8 @@ public class WhenADequeueIsRequestedTests : TestBase
     private readonly EnergyResultMessageDtoBuilder _energyResultMessageDtoBuilder;
     private readonly IOutgoingMessagesClient _outgoingMessagesClient;
 
-    public WhenADequeueIsRequestedTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenADequeueIsRequestedTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _energyResultMessageDtoBuilder = new EnergyResultMessageDtoBuilder();
         _outgoingMessagesClient = GetService<IOutgoingMessagesClient>();

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenAPeekIsRequestedTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenAPeekIsRequestedTests.cs
@@ -32,6 +32,7 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using NodaTime;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages;
 
@@ -41,8 +42,8 @@ public class WhenAPeekIsRequestedTests : TestBase
     private readonly IOutgoingMessagesClient _outgoingMessagesClient;
     private readonly SystemDateTimeProviderStub _dateTimeProvider;
 
-    public WhenAPeekIsRequestedTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenAPeekIsRequestedTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _energyResultMessageDtoBuilder = new EnergyResultMessageDtoBuilder();
         _outgoingMessagesClient = GetService<IOutgoingMessagesClient>();

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageTests.cs
@@ -36,6 +36,7 @@ using FluentAssertions.Execution;
 using Microsoft.EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using NodaTime;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages;
 
@@ -48,8 +49,8 @@ public class WhenEnqueueingOutgoingMessageTests : TestBase
     private readonly ActorMessageQueueContext _context;
     private readonly IFileStorageClient _fileStorageClient;
 
-    public WhenEnqueueingOutgoingMessageTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenEnqueueingOutgoingMessageTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _energyResultMessageDtoBuilder = new EnergyResultMessageDtoBuilder();
         _rejectedEnergyResultMessageDtoBuilder = new RejectedEnergyResultMessageDtoBuilder();

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageWithDelegationTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageWithDelegationTests.cs
@@ -32,6 +32,7 @@ using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models;
 using FluentAssertions;
 using NodaTime;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages;
 
@@ -45,8 +46,8 @@ public class WhenEnqueueingOutgoingMessageWithDelegationTests : TestBase
     private ActorNumberAndRoleDto _delegatedBy = CreateActorNumberAndRole(ActorNumber.Create("1234567891234"));
     private ActorNumberAndRoleDto _delegatedTo = CreateActorNumberAndRole(ActorNumber.Create("1234567891235"), actorRole: ActorRole.Delegated);
 
-    public WhenEnqueueingOutgoingMessageWithDelegationTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenEnqueueingOutgoingMessageWithDelegationTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _energyResultMessageDtoBuilder = new EnergyResultMessageDtoBuilder();
         _outgoingMessagesClient = GetService<IOutgoingMessagesClient>();

--- a/source/IntegrationTests/Application/SearchMessages/SearchMessagesTests.cs
+++ b/source/IntegrationTests/Application/SearchMessages/SearchMessagesTests.cs
@@ -28,6 +28,7 @@ using FluentAssertions;
 using NodaTime;
 using NodaTime.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.SearchMessages;
 
@@ -36,8 +37,8 @@ public class SearchMessagesTests : TestBase
     private readonly IArchivedMessagesClient _archivedMessagesClient;
     private readonly ISystemDateTimeProvider _systemDateTimeProvider;
 
-    public SearchMessagesTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public SearchMessagesTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _archivedMessagesClient = GetService<IArchivedMessagesClient>();
         _systemDateTimeProvider = GetService<ISystemDateTimeProvider>();

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/AggregatedTimeSeriesRequestAcceptedToAggregationResultTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/AggregatedTimeSeriesRequestAcceptedToAggregationResultTests.cs
@@ -35,6 +35,7 @@ using Google.Protobuf.WellKnownTypes;
 using NodaTime.Serialization.Protobuf;
 using NodaTime.Text;
 using Xunit;
+using Xunit.Abstractions;
 using Enum = System.Enum;
 using Period = Energinet.DataHub.Edi.Responses.Period;
 using Resolution = Energinet.DataHub.Edi.Responses.Resolution;
@@ -55,8 +56,8 @@ public sealed class AggregatedTimeSeriesRequestAcceptedToAggregationResultTests 
     private readonly IMasterDataClient _masterDataClient;
     private readonly IFileStorageClient _fileStorageClient;
 
-    public AggregatedTimeSeriesRequestAcceptedToAggregationResultTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public AggregatedTimeSeriesRequestAcceptedToAggregationResultTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _processContext = GetService<ProcessContext>();
         _inboxEventReceiver = GetService<IInboxEventReceiver>();

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/EnergyResultResponseFromWholesaleTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/EnergyResultResponseFromWholesaleTests.cs
@@ -27,6 +27,7 @@ using Energinet.DataHub.EDI.Process.Infrastructure.Configuration.DataAccess;
 using FluentAssertions;
 using NodaTime.Text;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 using RejectReason = Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData.RejectReason;
 
@@ -37,8 +38,8 @@ public class EnergyResultResponseFromWholesaleTests : TestBase
 {
     private readonly ProcessContext _processContext;
 
-    public EnergyResultResponseFromWholesaleTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public EnergyResultResponseFromWholesaleTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _processContext = GetService<ProcessContext>();
     }

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenARejectedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenARejectedResultIsAvailableTests.cs
@@ -27,6 +27,7 @@ using Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData;
 using Energinet.DataHub.EDI.Process.Infrastructure.Configuration.DataAccess;
 using Energinet.DataHub.Edi.Responses;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 using RejectReason = Energinet.DataHub.Edi.Responses.RejectReason;
 
@@ -37,8 +38,8 @@ public class WhenARejectedResultIsAvailableTests : TestBase
 {
     private readonly ProcessContext _processContext;
 
-    public WhenARejectedResultIsAvailableTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenARejectedResultIsAvailableTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _processContext = GetService<ProcessContext>();
     }

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
@@ -34,6 +34,7 @@ using Google.Protobuf;
 using NodaTime.Serialization.Protobuf;
 using NodaTime.Text;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 using DecimalValue = Energinet.DataHub.Edi.Responses.DecimalValue;
 using Period = Energinet.DataHub.Edi.Responses.Period;
@@ -51,8 +52,8 @@ public class WhenAnAcceptedResultIsAvailableTests : TestBase
     private readonly GridAreaBuilder _gridAreaBuilder = new();
     private readonly ProcessContext _processContext;
 
-    public WhenAnAcceptedResultIsAvailableTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenAnAcceptedResultIsAvailableTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _processContext = GetService<ProcessContext>();
     }

--- a/source/IntegrationTests/Application/Transactions/Aggregations/EnergyResultProducedV2ToAggregationResultTests.cs
+++ b/source/IntegrationTests/Application/Transactions/Aggregations/EnergyResultProducedV2ToAggregationResultTests.cs
@@ -29,6 +29,7 @@ using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models;
 using Energinet.DataHub.Wholesale.Contracts.IntegrationEvents;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 using Enum = System.Enum;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.Transactions.Aggregations;
@@ -48,8 +49,8 @@ public sealed class EnergyResultProducedV2ToAggregationResultTests : TestBase
     private readonly GridAreaBuilder _gridAreaBuilder = new();
     private readonly IFileStorageClient _fileStorageClient;
 
-    public EnergyResultProducedV2ToAggregationResultTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public EnergyResultProducedV2ToAggregationResultTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _masterDataClient = GetService<IMasterDataClient>();
         _integrationEventHandler = GetService<IIntegrationEventHandler>();

--- a/source/IntegrationTests/Application/Transactions/Aggregations/WhenAnEnergyResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/Aggregations/WhenAnEnergyResultIsAvailableTests.cs
@@ -30,6 +30,7 @@ using Energinet.DataHub.EDI.MasterData.Interfaces;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models;
 using Energinet.DataHub.Wholesale.Contracts.IntegrationEvents;
 using Xunit;
+using Xunit.Abstractions;
 using static Energinet.DataHub.Wholesale.Contracts.IntegrationEvents.EnergyResultProducedV2.Types;
 using Resolution = Energinet.DataHub.Wholesale.Contracts.IntegrationEvents.EnergyResultProducedV2.Types.Resolution;
 
@@ -40,8 +41,8 @@ public class WhenAnEnergyResultIsAvailableTests : TestBase
     private readonly EnergyResultProducedV2EventBuilder _eventBuilder = new();
     private readonly GridAreaBuilder _gridAreaBuilder = new();
 
-    public WhenAnEnergyResultIsAvailableTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenAnEnergyResultIsAvailableTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
     }
 

--- a/source/IntegrationTests/Application/Transactions/WholesaleCalculations/AmountPerChargeResultProducedV1Tests.cs
+++ b/source/IntegrationTests/Application/Transactions/WholesaleCalculations/AmountPerChargeResultProducedV1Tests.cs
@@ -34,6 +34,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using NodaTime;
 using NodaTime.Serialization.Protobuf;
 using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.Transactions.WholesaleCalculations;
 
@@ -46,8 +48,8 @@ public class AmountPerChargeResultProducedV1Tests : TestBase
     private IIntegrationEventHandler _integrationEventHandler;
 
     public AmountPerChargeResultProducedV1Tests(
-        IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+        IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _integrationEventHandler = GetService<IIntegrationEventHandler>();
         _databaseConnectionFactory = GetService<IDatabaseConnectionFactory>();
@@ -122,13 +124,13 @@ public class AmountPerChargeResultProducedV1Tests : TestBase
 
         var energySupplierMessage = await AssertOutgoingMessageAsync(ActorRole.EnergySupplier);
         var gridOperatorMessage = await AssertOutgoingMessageAsync(ActorRole.GridOperator);
-        var fetchSystemOperatorMessage = async () => await AssertOutgoingMessageAsync(ActorRole.SystemOperator);
+        var assertSystemOperatorMessage = async () => await AssertOutgoingMessageAsync(ActorRole.SystemOperator);
 
         energySupplierMessage.HasReceiverId(amountPerChargeEvent.EnergySupplierId);
         gridOperatorMessage.HasReceiverId(gridOperatorAndChargeOwner);
-        await fetchSystemOperatorMessage.Should()
-            .ThrowExactlyAsync<InvalidOperationException>()
-            .WithMessage("Sequence contains no elements");
+        await assertSystemOperatorMessage.Should()
+            .ThrowAsync<XunitException>()
+            .WithMessage("Expected object not to be <null>*");
     }
 
     [Fact]
@@ -151,13 +153,13 @@ public class AmountPerChargeResultProducedV1Tests : TestBase
 
         var energySupplierMessage = await AssertOutgoingMessageAsync(ActorRole.EnergySupplier);
         var gridOperatorMessage = await AssertOutgoingMessageAsync(ActorRole.GridOperator);
-        var fetchSystemOperatorMessage = async () => await AssertOutgoingMessageAsync(ActorRole.SystemOperator);
+        var assertSystemOperatorMessage = async () => await AssertOutgoingMessageAsync(ActorRole.SystemOperator);
 
         energySupplierMessage.HasReceiverId(amountPerChargeEvent.EnergySupplierId);
         gridOperatorMessage.HasReceiverId(gridOperator);
-        await fetchSystemOperatorMessage.Should()
-            .ThrowExactlyAsync<InvalidOperationException>()
-            .WithMessage("Sequence contains no elements");
+        await assertSystemOperatorMessage.Should()
+            .ThrowAsync<XunitException>()
+            .WithMessage("Expected object not to be <null>*");
     }
 
     [Fact]

--- a/source/IntegrationTests/Application/Transactions/WholesaleCalculations/MonthlyAmountPerChargeResultProducedV1Tests.cs
+++ b/source/IntegrationTests/Application/Transactions/WholesaleCalculations/MonthlyAmountPerChargeResultProducedV1Tests.cs
@@ -34,6 +34,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using NodaTime;
 using NodaTime.Serialization.Protobuf;
 using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
 using DecimalValue = Energinet.DataHub.Wholesale.Contracts.IntegrationEvents.Common.DecimalValue;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.Transactions.WholesaleCalculations;
@@ -47,8 +49,8 @@ public class MonthlyAmountPerChargeResultProducedV1Tests : TestBase
     private IIntegrationEventHandler _integrationEventHandler;
 
     public MonthlyAmountPerChargeResultProducedV1Tests(
-        IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+        IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _integrationEventHandler = GetService<IIntegrationEventHandler>();
         _databaseConnectionFactory = GetService<IDatabaseConnectionFactory>();
@@ -213,13 +215,14 @@ public class MonthlyAmountPerChargeResultProducedV1Tests : TestBase
 
         var energySupplierMessage = await AssertOutgoingMessageAsync(ActorRole.EnergySupplier);
         var gridOperatorMessage = await AssertOutgoingMessageAsync(ActorRole.GridOperator);
-        var fetchSystemOperatorMessage = async () => await AssertOutgoingMessageAsync(ActorRole.SystemOperator);
 
         energySupplierMessage.HasReceiverId(amountPerChargeEvent.EnergySupplierId);
         gridOperatorMessage.HasReceiverId(gridOperatorAndChargeOwner);
-        await fetchSystemOperatorMessage.Should()
-            .ThrowExactlyAsync<InvalidOperationException>()
-            .WithMessage("Sequence contains no elements");
+
+        var assertSystemOperatorMessage = async () => await AssertOutgoingMessageAsync(ActorRole.SystemOperator);
+        await assertSystemOperatorMessage.Should()
+            .ThrowAsync<XunitException>()
+            .WithMessage("Expected object not to be <null>*");
     }
 
     [Fact]
@@ -242,13 +245,13 @@ public class MonthlyAmountPerChargeResultProducedV1Tests : TestBase
 
         var energySupplierMessage = await AssertOutgoingMessageAsync(ActorRole.EnergySupplier);
         var gridOperatorMessage = await AssertOutgoingMessageAsync(ActorRole.GridOperator);
-        var fetchSystemOperatorMessage = async () => await AssertOutgoingMessageAsync(ActorRole.SystemOperator);
+        var assertSystemOperatorMessage = async () => await AssertOutgoingMessageAsync(ActorRole.SystemOperator);
 
         energySupplierMessage.HasReceiverId(amountPerChargeEvent.EnergySupplierId);
         gridOperatorMessage.HasReceiverId(gridOperator);
-        await fetchSystemOperatorMessage.Should()
-            .ThrowExactlyAsync<InvalidOperationException>()
-            .WithMessage("Sequence contains no elements");
+        await assertSystemOperatorMessage.Should()
+            .ThrowAsync<XunitException>()
+            .WithMessage("Expected object not to be <null>*");
     }
 
     [Fact]

--- a/source/IntegrationTests/Application/Transactions/WholesaleServices/WhenARejectedWholesaleServicesIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/WholesaleServices/WhenARejectedWholesaleServicesIsAvailableTests.cs
@@ -28,6 +28,7 @@ using Energinet.DataHub.EDI.Process.Domain.Transactions.WholesaleServices;
 using Energinet.DataHub.EDI.Process.Infrastructure.Configuration.DataAccess;
 using Energinet.DataHub.Edi.Responses;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 using ChargeType = Energinet.DataHub.EDI.Process.Domain.Transactions.WholesaleServices.ChargeType;
 using RejectReason = Energinet.DataHub.Edi.Responses.RejectReason;
@@ -39,8 +40,8 @@ public sealed class WhenARejectedWholesaleServicesIsAvailableTests : TestBase
 {
     private readonly ProcessContext _processContext;
 
-    public WhenARejectedWholesaleServicesIsAvailableTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenARejectedWholesaleServicesIsAvailableTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _processContext = GetService<ProcessContext>();
     }

--- a/source/IntegrationTests/Application/Transactions/WholesaleServices/WhenAnAcceptedWholesaleServicesResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/WholesaleServices/WhenAnAcceptedWholesaleServicesResultIsAvailableTests.cs
@@ -30,6 +30,7 @@ using Energinet.DataHub.EDI.Process.Infrastructure.Configuration.DataAccess;
 using Energinet.DataHub.Edi.Responses;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.Transactions.WholesaleServices;
@@ -39,8 +40,8 @@ public class WhenAnAcceptedWholesaleServicesResultIsAvailableTests : TestBase
 {
     private readonly ProcessContext _processContext;
 
-    public WhenAnAcceptedWholesaleServicesResultIsAvailableTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenAnAcceptedWholesaleServicesResultIsAvailableTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _processContext = GetService<ProcessContext>();
     }

--- a/source/IntegrationTests/Infrastructure.CimMessageAdapter/Messages/RequestAggregatedMeasureData/IncomingMessageReceiverTests.cs
+++ b/source/IntegrationTests/Infrastructure.CimMessageAdapter/Messages/RequestAggregatedMeasureData/IncomingMessageReceiverTests.cs
@@ -36,6 +36,7 @@ using Energinet.DataHub.EDI.Process.Interfaces;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.CimMessageAdapter.Messages.RequestAggregatedMeasureData;
 
@@ -45,8 +46,8 @@ public class IncomingMessageReceiverTests : TestBase, IAsyncLifetime
     private readonly ProcessContext _processContext;
     private readonly RequestAggregatedMeasureDataMessageValidator _requestAggregatedMeasureDataMessageValidator;
 
-    public IncomingMessageReceiverTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public IncomingMessageReceiverTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _marketMessageParser = GetService<MarketMessageParser>();
         _processContext = GetService<ProcessContext>();

--- a/source/IntegrationTests/Infrastructure/Authentication/MarketActors/MarketActorAuthenticatorTests.cs
+++ b/source/IntegrationTests/Infrastructure/Authentication/MarketActors/MarketActorAuthenticatorTests.cs
@@ -23,6 +23,7 @@ using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.EDI.MasterData.Interfaces.Models;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.Authentication.MarketActors
@@ -33,8 +34,8 @@ namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.Authentication.M
         private readonly IMarketActorAuthenticator _authenticator;
         private readonly AuthenticatedActor _authenticatedActor;
 
-        public MarketActorAuthenticatorTests(IntegrationTestFixture integrationTestFixture)
-            : base(integrationTestFixture)
+        public MarketActorAuthenticatorTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+            : base(integrationTestFixture, testOutputHelper)
         {
             _authenticator = GetService<IMarketActorAuthenticator>();
             _authenticatedActor = GetService<AuthenticatedActor>();

--- a/source/IntegrationTests/Infrastructure/Configuration/InternalCommands/InternalCommandProcessorTests.cs
+++ b/source/IntegrationTests/Infrastructure/Configuration/InternalCommands/InternalCommandProcessorTests.cs
@@ -23,6 +23,7 @@ using Energinet.DataHub.EDI.Process.Infrastructure.Configuration.DataAccess;
 using Energinet.DataHub.EDI.Process.Infrastructure.InternalCommands;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Categories;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.Configuration.InternalCommands;
@@ -34,8 +35,8 @@ public class InternalCommandProcessorTests : TestBase
     private readonly ICommandScheduler _scheduler;
     private readonly IDatabaseConnectionFactory _connectionFactory;
 
-    public InternalCommandProcessorTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public InternalCommandProcessorTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _processor = GetService<InternalCommandProcessor>();
         _scheduler = GetService<ICommandScheduler>();

--- a/source/IntegrationTests/Infrastructure/Configuration/InternalCommands/InternalCommandRegistrationTests.cs
+++ b/source/IntegrationTests/Infrastructure/Configuration/InternalCommands/InternalCommandRegistrationTests.cs
@@ -21,6 +21,7 @@ using Energinet.DataHub.EDI.Process.Domain.Commands;
 using Energinet.DataHub.EDI.Process.Infrastructure.InternalCommands;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.Configuration.InternalCommands;
 
@@ -28,8 +29,8 @@ public class InternalCommandRegistrationTests : TestBase
 {
     private readonly InternalCommandMapper _mapper;
 
-    public InternalCommandRegistrationTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public InternalCommandRegistrationTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _mapper = GetService<InternalCommandMapper>();
     }

--- a/source/IntegrationTests/Infrastructure/InboxEvents/WhenAggregatedTimeSeriesRequestAcceptedEventIsReceivedTests.cs
+++ b/source/IntegrationTests/Infrastructure/InboxEvents/WhenAggregatedTimeSeriesRequestAcceptedEventIsReceivedTests.cs
@@ -27,6 +27,7 @@ using Energinet.DataHub.Edi.Responses;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.InboxEvents;
 
@@ -40,8 +41,8 @@ public class WhenAggregatedTimeSeriesRequestAcceptedEventIsReceivedTests : TestB
     private readonly AggregatedTimeSeriesRequestAccepted _aggregatedTimeSeriesRequestAcceptedResponse;
     private readonly GridAreaBuilder _gridAreaBuilder = new();
 
-    public WhenAggregatedTimeSeriesRequestAcceptedEventIsReceivedTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenAggregatedTimeSeriesRequestAcceptedEventIsReceivedTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _processor = GetService<InboxEventsProcessor>();
         _aggregatedTimeSeriesRequestAcceptedResponse = CreateResponseFromWholeSale();

--- a/source/IntegrationTests/Infrastructure/InboxEvents/WhenAnInboxEventIsProcessingTests.cs
+++ b/source/IntegrationTests/Infrastructure/InboxEvents/WhenAnInboxEventIsProcessingTests.cs
@@ -25,6 +25,7 @@ using Energinet.DataHub.EDI.Process.Infrastructure.InboxEvents;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.InboxEvents;
 
@@ -36,8 +37,8 @@ public class WhenAnInboxEventIsProcessingTests : TestBase
     private readonly InboxEventsProcessor _inboxProcessor;
     private readonly TestInboxEventMapper _testInboxEventMapper;
 
-    public WhenAnInboxEventIsProcessingTests(IntegrationTestFixture integrationTestFixture)
-     : base(integrationTestFixture)
+    public WhenAnInboxEventIsProcessingTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _testInboxEventMapper = new TestInboxEventMapper();
         _inboxProcessor = new InboxEventsProcessor(

--- a/source/IntegrationTests/Infrastructure/InboxEvents/WhenAnInboxEventIsReceivedTests.cs
+++ b/source/IntegrationTests/Infrastructure/InboxEvents/WhenAnInboxEventIsReceivedTests.cs
@@ -24,6 +24,7 @@ using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.EDI.Process.Infrastructure.Configuration.DataAccess;
 using Energinet.DataHub.EDI.Process.Infrastructure.InboxEvents;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.InboxEvents;
 
@@ -36,8 +37,8 @@ public class WhenAnInboxEventIsReceivedTests : TestBase
     private readonly Guid _referenceId = Guid.NewGuid();
     private InboxEventReceiver _receiver;
 
-    public WhenAnInboxEventIsReceivedTests(IntegrationTestFixture integrationTestFixture)
-     : base(integrationTestFixture)
+    public WhenAnInboxEventIsReceivedTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _receiver = new InboxEventReceiver(
             GetService<ProcessContext>(),

--- a/source/IntegrationTests/Infrastructure/IntegrationEvents/WhenAnActorActivatedIsAvailableTests.cs
+++ b/source/IntegrationTests/Infrastructure/IntegrationEvents/WhenAnActorActivatedIsAvailableTests.cs
@@ -24,6 +24,7 @@ using Energinet.DataHub.EDI.IntegrationTests.Factories;
 using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.MarketParticipant.Infrastructure.Model.Contracts;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.IntegrationEvents;
 
@@ -31,8 +32,8 @@ public class WhenAnActorActivatedIsAvailableTests : TestBase
 {
     private readonly IDatabaseConnectionFactory _connectionFactory;
 
-    public WhenAnActorActivatedIsAvailableTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenAnActorActivatedIsAvailableTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _connectionFactory = GetService<IDatabaseConnectionFactory>();
     }

--- a/source/IntegrationTests/Infrastructure/IntegrationEvents/WhenGridAreaOwnershipAssignedTests.cs
+++ b/source/IntegrationTests/Infrastructure/IntegrationEvents/WhenGridAreaOwnershipAssignedTests.cs
@@ -29,6 +29,7 @@ using Energinet.DataHub.MarketParticipant.Infrastructure.Model.Contracts;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.IntegrationEvents;
 
@@ -37,8 +38,8 @@ public class WhenGridAreaOwnershipAssignedTests : TestBase
     private readonly IDatabaseConnectionFactory _connectionFactory;
     private readonly GridAreaOwnershipAssignedEventBuilder _gridAreaOwnershipAssignedEventBuilder = new();
 
-    public WhenGridAreaOwnershipAssignedTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenGridAreaOwnershipAssignedTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _connectionFactory = GetService<IDatabaseConnectionFactory>();
     }

--- a/source/IntegrationTests/Infrastructure/IntegrationEvents/WhenProcessDelegationIsAvailableTests.cs
+++ b/source/IntegrationTests/Infrastructure/IntegrationEvents/WhenProcessDelegationIsAvailableTests.cs
@@ -24,6 +24,7 @@ using Energinet.DataHub.EDI.IntegrationTests.Factories;
 using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.MarketParticipant.Infrastructure.Model.Contracts;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.IntegrationEvents;
 
@@ -31,8 +32,8 @@ public class WhenProcessDelegationIsAvailableTests : TestBase
 {
     private readonly IDatabaseConnectionFactory _connectionFactory;
 
-    public WhenProcessDelegationIsAvailableTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public WhenProcessDelegationIsAvailableTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _connectionFactory = GetService<IDatabaseConnectionFactory>();
     }

--- a/source/IntegrationTests/Infrastructure/Retention/RemoveInternalCommandsWhenADayHasPassedTests.cs
+++ b/source/IntegrationTests/Infrastructure/Retention/RemoveInternalCommandsWhenADayHasPassedTests.cs
@@ -23,6 +23,7 @@ using Energinet.DataHub.EDI.Process.Infrastructure.Configuration.DataAccess;
 using Energinet.DataHub.EDI.Process.Infrastructure.InternalCommands;
 using Microsoft.Extensions.Logging;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.Retention;
 
@@ -33,8 +34,8 @@ public class RemoveInternalCommandsWhenADayHasPassedTests : TestBase
     private readonly InternalCommandsRetention _sut;
 
     public RemoveInternalCommandsWhenADayHasPassedTests(
-        IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+        IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _processContext = GetService<ProcessContext>();
         _systemDateTimeProvider = GetService<ISystemDateTimeProvider>();

--- a/source/IntegrationTests/Infrastructure/Retention/RemoveOldGridAreaOwnersWhenADayHasPassedTests.cs
+++ b/source/IntegrationTests/Infrastructure/Retention/RemoveOldGridAreaOwnersWhenADayHasPassedTests.cs
@@ -26,6 +26,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.Retention;
 
@@ -33,8 +34,8 @@ public class RemoveOldGridAreaOwnersWhenADayHasPassedTests : TestBase
 {
     private readonly IMasterDataClient _masterDataClient;
 
-    public RemoveOldGridAreaOwnersWhenADayHasPassedTests(IntegrationTestFixture integrationTestFixture)
-        : base(integrationTestFixture)
+    public RemoveOldGridAreaOwnersWhenADayHasPassedTests(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
+        : base(integrationTestFixture, testOutputHelper)
     {
         _masterDataClient = GetService<IMasterDataClient>();
     }

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -60,11 +60,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Configuration;
-using NodaTime;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Sdk;
 using SampleData = Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.SampleData;
 
 namespace Energinet.DataHub.EDI.IntegrationTests
@@ -78,7 +75,7 @@ namespace Energinet.DataHub.EDI.IntegrationTests
         private ServiceCollection? _services;
         private bool _disposed;
 
-        protected TestBase(IntegrationTestFixture integrationTestFixture, ITestOutputHelper? testOutputHelper = null)
+        protected TestBase(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
         {
             ArgumentNullException.ThrowIfNull(integrationTestFixture);
             IntegrationTestFixture.CleanupDatabase();

--- a/source/IntegrationTests/TestDoubles/TestLogger.cs
+++ b/source/IntegrationTests/TestDoubles/TestLogger.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Energinet.DataHub.EDI.IntegrationTests.TestDoubles;
+
+public class TestLogger<T> : ILogger<T>
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+    private readonly ILogger<T>? _logger;
+
+    public TestLogger(ITestOutputHelper testOutputHelper, Logger<T>? logger)
+    {
+        _testOutputHelper = testOutputHelper;
+        _logger = logger;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
+    {
+        return null;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return true;
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        if (logLevel == LogLevel.Error || logLevel == LogLevel.Critical)
+        {
+            var logOutput = formatter(state, exception);
+            _testOutputHelper.WriteLine("[{0}] {1}", logLevel.ToString().ToUpperInvariant(), logOutput);
+
+            if (exception != null)
+            {
+                _testOutputHelper.WriteLine("Test logger found an exception: {0}", exception);
+            }
+        }
+
+        _logger?.Log(logLevel, eventId, state, exception, formatter);
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Integration Tests now output errors to the tests output, if the error is logged. Right now internal command exceptions are caught (and logged) in our external command process, but that log isn't added to the test output, so it is never shown.

## References
`ITestOutputHelper`: https://xunit.net/docs/capturing-output