### PR TITLE
feat: Add event id to outgoing messages

### DIFF
--- a/source/Api/EventListeners/InboxEventListener.cs
+++ b/source/Api/EventListeners/InboxEventListener.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BuildingBlocks.Application.Extensions.Options;
 using Energinet.DataHub.EDI.Api.Configuration;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Interfaces;
 using Energinet.DataHub.EDI.Process.Infrastructure.Configuration.Options;
 using Energinet.DataHub.EDI.Process.Interfaces;
@@ -58,7 +59,7 @@ public class InboxEventListener
 
         var referenceId = GetReferenceId(context);
         await _inboxEventReceiver.ReceiveAsync(
-            (string)eventId,
+            EventId.From((string)eventId),
             (string)eventName,
             referenceId,
             message).ConfigureAwait(false);

--- a/source/ApplyDBMigrationsApp/ApplyDBMigrationsApp.csproj
+++ b/source/ApplyDBMigrationsApp/ApplyDBMigrationsApp.csproj
@@ -170,6 +170,8 @@ limitations under the License.
     <EmbeddedResource Include="Scripts\Model\202403251343 Add processType column to OutgoingMessages.sql" />
     <EmbeddedResource Include="Scripts\Model\202404081346 Update unique key constraint on BusinessTransactionId in AggregatedMeasureDataProcesses.sql" />
     <EmbeddedResource Include="Scripts\Model\202404081352 Add unique key constraint on BusinessTransactionId in WholesaleServicesProcesses.sql" />
+    <EmbeddedResource Include="Scripts\Model\202404121517 Add [OutgoingMessages].[EventId] column.sql" />
+    <EmbeddedResource Include="Scripts\Model\202404121518 Update [OutgoingMessages].[ProcessId] column to nullable.sql" />
     <None Remove="Scripts\Model\202227101333 Add AggregatedTimeSeriesTransactions table.sql" />
     <None Remove="Scripts\Model\202310201142 resize ActorNumber nvarchar on Actor.sql" />
     <None Remove="Scripts\Model\202310231329 Alter Bundles1.sql" />

--- a/source/ApplyDBMigrationsApp/Scripts/Model/202404121517 Add [OutgoingMessages].[EventId] column.sql
+++ b/source/ApplyDBMigrationsApp/Scripts/Model/202404121517 Add [OutgoingMessages].[EventId] column.sql
@@ -1,0 +1,12 @@
+ALTER TABLE [dbo].[OutgoingMessages] 
+    ADD [EventId] NVARCHAR(100) NULL;
+GO
+
+UPDATE [dbo].[OutgoingMessages]
+    SET [EventId] = 'UNKNOWN-BECAUSE-OLD'
+    WHERE [EventId] IS NULL
+GO
+
+ALTER TABLE [dbo].[OutgoingMessages]
+    ALTER COLUMN [EventId] NVARCHAR(100) NOT NULL;
+GO

--- a/source/ApplyDBMigrationsApp/Scripts/Model/202404121518 Update [OutgoingMessages].[ProcessId] column to nullable.sql
+++ b/source/ApplyDBMigrationsApp/Scripts/Model/202404121518 Update [OutgoingMessages].[ProcessId] column to nullable.sql
@@ -1,0 +1,3 @@
+ALTER TABLE [dbo].[OutgoingMessages]
+    ALTER COLUMN [ProcessId] UNIQUEIDENTIFIER NULL;
+GO

--- a/source/BuildingBlocks.Domain/Models/EventId.cs
+++ b/source/BuildingBlocks.Domain/Models/EventId.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Text.Json.Serialization;
 
 namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 
@@ -22,12 +23,13 @@ namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 /// </summary>
 public record EventId
 {
+    [JsonConstructor]
     private EventId(string value)
     {
         Value = value;
     }
 
-    public string Value { get; init; }
+    public string Value { get; }
 
     public static EventId From(Guid eventIdentification) => new(eventIdentification.ToString());
 

--- a/source/BuildingBlocks.Domain/Models/EventId.cs
+++ b/source/BuildingBlocks.Domain/Models/EventId.cs
@@ -13,18 +13,23 @@
 // limitations under the License.
 
 using System;
-using System.Threading.Tasks;
-using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 
-namespace Energinet.DataHub.EDI.Process.Interfaces;
+namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 
 /// <summary>
-/// Responsible for receiving all types inbox events
+/// An EventId symbolises a tracking id, typically received from a ServiceBusMessage's MessageId,
+///     or in case of our IntegrationEvents, this is also the EventIdentifier
 /// </summary>
-public interface IInboxEventReceiver
+public record EventId
 {
-    /// <summary>
-    /// Receives an inbox event
-    /// </summary>
-    Task ReceiveAsync(EventId eventId, string eventType, Guid referenceId, byte[] eventPayload);
+    private EventId(string value)
+    {
+        Value = value;
+    }
+
+    public string Value { get; init; }
+
+    public static EventId From(Guid eventIdentification) => new(eventIdentification.ToString());
+
+    public static EventId From(string eventId) => new(eventId);
 }

--- a/source/BuildingBlocks.Domain/Models/EventId.cs
+++ b/source/BuildingBlocks.Domain/Models/EventId.cs
@@ -21,6 +21,7 @@ namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 /// An EventId symbolises a tracking id, typically received from a ServiceBusMessage's MessageId,
 ///     or in case of our IntegrationEvents, this is also the EventIdentifier
 /// </summary>
+[Serializable]
 public record EventId
 {
     [JsonConstructor]

--- a/source/IntegrationEvents.Infrastructure/EventProcessors/AmountPerChargeResultProducedV1Processor.cs
+++ b/source/IntegrationEvents.Infrastructure/EventProcessors/AmountPerChargeResultProducedV1Processor.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.EDI.IntegrationEvents.Infrastructure.Factories;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
 using Energinet.DataHub.Wholesale.Contracts.IntegrationEvents;
 using Microsoft.Extensions.Logging;
+using EventId = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.EventId;
 
 namespace Energinet.DataHub.EDI.IntegrationEvents.Infrastructure.EventProcessors;
 
@@ -66,7 +67,7 @@ public class AmountPerChargeResultProducedV1Processor : IIntegrationEventProcess
         }
 
         var message = await _wholesaleServicesMessageFactory
-            .CreateMessageAsync(integrationEvent.EventIdentification.ToString(), amountPerChargeResultProducedV1)
+            .CreateMessageAsync(EventId.From(integrationEvent.EventIdentification), amountPerChargeResultProducedV1)
             .ConfigureAwait(false);
 
         await _outgoingMessagesClient.EnqueueAndCommitAsync(message, cancellationToken).ConfigureAwait(false);

--- a/source/IntegrationEvents.Infrastructure/EventProcessors/AmountPerChargeResultProducedV1Processor.cs
+++ b/source/IntegrationEvents.Infrastructure/EventProcessors/AmountPerChargeResultProducedV1Processor.cs
@@ -66,7 +66,7 @@ public class AmountPerChargeResultProducedV1Processor : IIntegrationEventProcess
         }
 
         var message = await _wholesaleServicesMessageFactory
-            .CreateMessageAsync(amountPerChargeResultProducedV1)
+            .CreateMessageAsync(integrationEvent.EventIdentification.ToString(), amountPerChargeResultProducedV1)
             .ConfigureAwait(false);
 
         await _outgoingMessagesClient.EnqueueAndCommitAsync(message, cancellationToken).ConfigureAwait(false);

--- a/source/IntegrationEvents.Infrastructure/EventProcessors/EnergyResultProducedV2Processor.cs
+++ b/source/IntegrationEvents.Infrastructure/EventProcessors/EnergyResultProducedV2Processor.cs
@@ -57,7 +57,7 @@ public sealed class EnergyResultProducedV2Processor : IIntegrationEventProcessor
         }
 
         var message = await _energyResultMessageResultFactory
-            .CreateAsync(energyResultProducedV2, CancellationToken.None)
+            .CreateAsync(integrationEvent.EventIdentification.ToString(), energyResultProducedV2, CancellationToken.None)
             .ConfigureAwait(false);
 
         await _outgoingMessagesClient.EnqueueAndCommitAsync(message, cancellationToken).ConfigureAwait(false);

--- a/source/IntegrationEvents.Infrastructure/EventProcessors/EnergyResultProducedV2Processor.cs
+++ b/source/IntegrationEvents.Infrastructure/EventProcessors/EnergyResultProducedV2Processor.cs
@@ -21,6 +21,7 @@ using Energinet.DataHub.EDI.IntegrationEvents.Infrastructure.Factories;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
 using Energinet.DataHub.Wholesale.Contracts.IntegrationEvents;
 using Microsoft.Extensions.Logging;
+using EventId = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.EventId;
 
 namespace Energinet.DataHub.EDI.IntegrationEvents.Infrastructure.EventProcessors;
 
@@ -57,7 +58,7 @@ public sealed class EnergyResultProducedV2Processor : IIntegrationEventProcessor
         }
 
         var message = await _energyResultMessageResultFactory
-            .CreateAsync(integrationEvent.EventIdentification.ToString(), energyResultProducedV2, CancellationToken.None)
+            .CreateAsync(EventId.From(integrationEvent.EventIdentification), energyResultProducedV2, CancellationToken.None)
             .ConfigureAwait(false);
 
         await _outgoingMessagesClient.EnqueueAndCommitAsync(message, cancellationToken).ConfigureAwait(false);

--- a/source/IntegrationEvents.Infrastructure/EventProcessors/MonthlyAmountPerChargeResultProducedV1Processor.cs
+++ b/source/IntegrationEvents.Infrastructure/EventProcessors/MonthlyAmountPerChargeResultProducedV1Processor.cs
@@ -20,6 +20,7 @@ using Energinet.DataHub.Core.Messaging.Communication;
 using Energinet.DataHub.EDI.IntegrationEvents.Infrastructure.Factories;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
 using Energinet.DataHub.Wholesale.Contracts.IntegrationEvents;
+using EventId = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.EventId;
 
 namespace Energinet.DataHub.EDI.IntegrationEvents.Infrastructure.EventProcessors;
 
@@ -51,7 +52,7 @@ public class MonthlyAmountPerChargeResultProducedV1Processor : IIntegrationEvent
         }
 
         var monthlyAmountPerChargeResultProducedV1 = (MonthlyAmountPerChargeResultProducedV1)integrationEvent.Message;
-        var message = await _wholesaleServicesMessageFactory.CreateMessageAsync(integrationEvent.EventIdentification.ToString(), monthlyAmountPerChargeResultProducedV1)
+        var message = await _wholesaleServicesMessageFactory.CreateMessageAsync(EventId.From(integrationEvent.EventIdentification), monthlyAmountPerChargeResultProducedV1)
             .ConfigureAwait(false);
 
         await _outgoingMessagesClient.EnqueueAndCommitAsync(message, cancellationToken).ConfigureAwait(false);

--- a/source/IntegrationEvents.Infrastructure/EventProcessors/MonthlyAmountPerChargeResultProducedV1Processor.cs
+++ b/source/IntegrationEvents.Infrastructure/EventProcessors/MonthlyAmountPerChargeResultProducedV1Processor.cs
@@ -51,7 +51,7 @@ public class MonthlyAmountPerChargeResultProducedV1Processor : IIntegrationEvent
         }
 
         var monthlyAmountPerChargeResultProducedV1 = (MonthlyAmountPerChargeResultProducedV1)integrationEvent.Message;
-        var message = await _wholesaleServicesMessageFactory.CreateMessageAsync(monthlyAmountPerChargeResultProducedV1)
+        var message = await _wholesaleServicesMessageFactory.CreateMessageAsync(integrationEvent.EventIdentification.ToString(), monthlyAmountPerChargeResultProducedV1)
             .ConfigureAwait(false);
 
         await _outgoingMessagesClient.EnqueueAndCommitAsync(message, cancellationToken).ConfigureAwait(false);

--- a/source/IntegrationEvents.Infrastructure/Factories/EnergyResultMessageResultFactory.cs
+++ b/source/IntegrationEvents.Infrastructure/Factories/EnergyResultMessageResultFactory.cs
@@ -35,7 +35,7 @@ public class EnergyResultMessageResultFactory
     }
 
     public async Task<EnergyResultMessageDto> CreateAsync(
-        string eventId,
+        EventId eventId,
         EnergyResultProducedV2 integrationEvent,
         CancellationToken cancellationToken)
     {

--- a/source/IntegrationEvents.Infrastructure/Factories/EnergyResultMessageResultFactory.cs
+++ b/source/IntegrationEvents.Infrastructure/Factories/EnergyResultMessageResultFactory.cs
@@ -35,6 +35,7 @@ public class EnergyResultMessageResultFactory
     }
 
     public async Task<EnergyResultMessageDto> CreateAsync(
+        string eventId,
         EnergyResultProducedV2 integrationEvent,
         CancellationToken cancellationToken)
     {
@@ -44,9 +45,9 @@ public class EnergyResultMessageResultFactory
             await GetAggregationLevelDataAsync(integrationEvent, cancellationToken).ConfigureAwait(false);
 
         return EnergyResultMessageDto.Create(
+            eventId,
             receiverNumber: aggregationData.ReceiverNumber,
             receiverRole: aggregationData.ReceiverRole,
-            processId: Guid.NewGuid(),
             gridAreaCode: aggregationData.GridAreaCode,
             meteringPointType: MeteringPointTypeMapper.Map(integrationEvent.TimeSeriesType).Name,
             settlementMethod: SettlementMethodMapper.Map(integrationEvent.TimeSeriesType)?.Name,

--- a/source/IntegrationEvents.Infrastructure/Factories/WholesaleServicesMessageFactory.cs
+++ b/source/IntegrationEvents.Infrastructure/Factories/WholesaleServicesMessageFactory.cs
@@ -35,6 +35,7 @@ public sealed class WholesaleServicesMessageFactory
     }
 
     public async Task<WholesaleServicesMessageDto> CreateMessageAsync(
+        string eventId,
         MonthlyAmountPerChargeResultProducedV1 monthlyAmountPerChargeResultProducedV1)
     {
         ArgumentNullException.ThrowIfNull(monthlyAmountPerChargeResultProducedV1);
@@ -43,15 +44,16 @@ public sealed class WholesaleServicesMessageFactory
             .ConfigureAwait(false);
 
         return WholesaleServicesMessageDto.Create(
+            eventId,
             message.EnergySupplier,
             ActorRole.EnergySupplier,
             message.ChargeOwner,
-            Guid.NewGuid(),
             BusinessReasonMapper.Map(monthlyAmountPerChargeResultProducedV1.CalculationType).Name,
             message);
     }
 
     public async Task<WholesaleServicesMessageDto> CreateMessageAsync(
+        string eventId,
         AmountPerChargeResultProducedV1 amountPerChargeResultProducedV1)
     {
         ArgumentNullException.ThrowIfNull(amountPerChargeResultProducedV1);
@@ -59,10 +61,10 @@ public sealed class WholesaleServicesMessageFactory
         var message = await CreateWholesaleResultSeriesAsync(amountPerChargeResultProducedV1).ConfigureAwait(false);
 
         return WholesaleServicesMessageDto.Create(
+            eventId,
             receiverNumber: message.EnergySupplier,
             receiverRole: ActorRole.EnergySupplier,
             chargeOwnerId: message.ChargeOwner,
-            processId: Guid.NewGuid(),
             businessReason: BusinessReasonMapper.Map(amountPerChargeResultProducedV1.CalculationType).Name,
             wholesaleSeries: message);
     }

--- a/source/IntegrationEvents.Infrastructure/Factories/WholesaleServicesMessageFactory.cs
+++ b/source/IntegrationEvents.Infrastructure/Factories/WholesaleServicesMessageFactory.cs
@@ -35,7 +35,7 @@ public sealed class WholesaleServicesMessageFactory
     }
 
     public async Task<WholesaleServicesMessageDto> CreateMessageAsync(
-        string eventId,
+        EventId eventId,
         MonthlyAmountPerChargeResultProducedV1 monthlyAmountPerChargeResultProducedV1)
     {
         ArgumentNullException.ThrowIfNull(monthlyAmountPerChargeResultProducedV1);
@@ -53,7 +53,7 @@ public sealed class WholesaleServicesMessageFactory
     }
 
     public async Task<WholesaleServicesMessageDto> CreateMessageAsync(
-        string eventId,
+        EventId eventId,
         AmountPerChargeResultProducedV1 amountPerChargeResultProducedV1)
     {
         ArgumentNullException.ThrowIfNull(amountPerChargeResultProducedV1);

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageTests.cs
@@ -103,6 +103,7 @@ public class WhenEnqueueingOutgoingMessageTests : TestBase
             () => Assert.Equal(expectedFileStorageReference, result!.FileStorageReference),
             () => Assert.Equal("OutgoingMessage", result!.Discriminator),
             () => Assert.Equal(message.RelatedToMessageId?.Value, result!.RelatedToMessageId),
+            () => Assert.Equal(message.EventId, result!.EventId),
             () => Assert.NotNull(result!.AssignedBundleId),
         };
 

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageTests.cs
@@ -103,7 +103,7 @@ public class WhenEnqueueingOutgoingMessageTests : TestBase
             () => Assert.Equal(expectedFileStorageReference, result!.FileStorageReference),
             () => Assert.Equal("OutgoingMessage", result!.Discriminator),
             () => Assert.Equal(message.RelatedToMessageId?.Value, result!.RelatedToMessageId),
-            () => Assert.Equal(message.EventId, result!.EventId),
+            () => Assert.Equal(message.EventId.Value, result!.EventId),
             () => Assert.NotNull(result!.AssignedBundleId),
         };
 

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/AggregatedTimeSeriesRequestAcceptedToAggregationResultTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/AggregatedTimeSeriesRequestAcceptedToAggregationResultTests.cs
@@ -394,7 +394,7 @@ public sealed class AggregatedTimeSeriesRequestAcceptedToAggregationResultTests 
 
         await _inboxEventReceiver
             .ReceiveAsync(
-                Guid.NewGuid().ToString(),
+                EventId.From(Guid.NewGuid()),
                 nameof(AggregatedTimeSeriesRequestAccepted),
                 process.ProcessId.Id,
                 requestAccepted.ToByteArray());

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/AggregatedTimeSeriesRequestAcceptedToAggregationResultTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/AggregatedTimeSeriesRequestAcceptedToAggregationResultTests.cs
@@ -392,9 +392,10 @@ public sealed class AggregatedTimeSeriesRequestAcceptedToAggregationResultTests 
         var process = BuildProcess();
         var requestAccepted = CreateEventWithQuantityQuality(quantityQuality);
 
+        var eventId = EventId.From(Guid.NewGuid());
         await _inboxEventReceiver
             .ReceiveAsync(
-                EventId.From(Guid.NewGuid()),
+                eventId,
                 nameof(AggregatedTimeSeriesRequestAccepted),
                 process.ProcessId.Id,
                 requestAccepted.ToByteArray());
@@ -402,7 +403,8 @@ public sealed class AggregatedTimeSeriesRequestAcceptedToAggregationResultTests 
         await HavingReceivedInboxEventAsync(
             nameof(AggregatedTimeSeriesRequestAccepted),
             requestAccepted,
-            process.ProcessId.Id);
+            process.ProcessId.Id,
+            eventId.Value);
 
         return await OutgoingMessageAsync();
     }

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/EnergyResultResponseFromWholesaleTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/EnergyResultResponseFromWholesaleTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -173,6 +174,7 @@ public class EnergyResultResponseFromWholesaleTests : TestBase
             process.RequestedByActorId,
             ActorRole.FromCode(process.RequestedByActorRoleCode),
             process.ProcessId.Id,
+            Guid.NewGuid().ToString(),
             gridarea,
             MeteringPointType.Production.Name,
             process.SettlementMethod,
@@ -195,7 +197,7 @@ public class EnergyResultResponseFromWholesaleTests : TestBase
         {
             new("E86", "Invalid request"),
         };
-        return new RejectedAggregatedMeasureDataRequest(rejectReasons, BusinessReason.BalanceFixing);
+        return new RejectedAggregatedMeasureDataRequest(Guid.NewGuid().ToString(), rejectReasons, BusinessReason.BalanceFixing);
     }
 
     private static void AssertProcessState(AggregatedMeasureDataProcess process, AggregatedMeasureDataProcess.State state)

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/EnergyResultResponseFromWholesaleTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/EnergyResultResponseFromWholesaleTests.cs
@@ -174,7 +174,7 @@ public class EnergyResultResponseFromWholesaleTests : TestBase
             process.RequestedByActorId,
             ActorRole.FromCode(process.RequestedByActorRoleCode),
             process.ProcessId.Id,
-            Guid.NewGuid().ToString(),
+            EventId.From(Guid.NewGuid()),
             gridarea,
             MeteringPointType.Production.Name,
             process.SettlementMethod,
@@ -197,7 +197,7 @@ public class EnergyResultResponseFromWholesaleTests : TestBase
         {
             new("E86", "Invalid request"),
         };
-        return new RejectedAggregatedMeasureDataRequest(Guid.NewGuid().ToString(), rejectReasons, BusinessReason.BalanceFixing);
+        return new RejectedAggregatedMeasureDataRequest(EventId.From(Guid.NewGuid()), rejectReasons, BusinessReason.BalanceFixing);
     }
 
     private static void AssertProcessState(AggregatedMeasureDataProcess process, AggregatedMeasureDataProcess.State state)

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenARejectedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenARejectedResultIsAvailableTests.cs
@@ -48,6 +48,7 @@ public class WhenARejectedResultIsAvailableTests : TestBase
     public async Task Aggregated_measure_data_response_is_rejected()
     {
         // Arrange
+        var expectedEventId = "expected-event-id";
         var process = BuildProcess();
         var rejectReason = new RejectReason()
         {
@@ -63,11 +64,13 @@ public class WhenARejectedResultIsAvailableTests : TestBase
         };
 
         // Act
-        await HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestRejected), rejectEvent, process.ProcessId.Id);
+        await HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestRejected), rejectEvent, process.ProcessId.Id, expectedEventId);
 
         // Assert
         var outgoingMessage = await OutgoingMessageAsync(ActorRole.BalanceResponsibleParty, BusinessReason.BalanceFixing);
         outgoingMessage
+            .HasEventId(expectedEventId)
+            .HasProcessId(process.ProcessId)
             .HasBusinessReason(process.BusinessReason)
             .HasReceiverId(process.RequestedByActorId.Value)
             .HasReceiverRole(process.RequestedByActorRoleCode)

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
@@ -62,6 +62,7 @@ public class WhenAnAcceptedResultIsAvailableTests : TestBase
     public async Task Aggregated_measure_data_response_is_accepted()
     {
         // Arrange
+        var expectedEventId = "expected-event-id";
         await _gridAreaBuilder
             .WithGridAreaCode(SampleData.GridAreaCode)
             .StoreAsync(GetService<IMasterDataClient>());
@@ -70,12 +71,14 @@ public class WhenAnAcceptedResultIsAvailableTests : TestBase
         var acceptedEvent = GetAcceptedEvent(process);
 
         // Act
-        await HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestAccepted), acceptedEvent, process.ProcessId.Id);
+        await HavingReceivedInboxEventAsync(nameof(AggregatedTimeSeriesRequestAccepted), acceptedEvent, process.ProcessId.Id, expectedEventId);
 
         // Assert
         var outgoingMessage = await OutgoingMessageAsync(ActorRole.BalanceResponsibleParty, BusinessReason.BalanceFixing);
 
         outgoingMessage
+            .HasProcessId(process.ProcessId)
+            .HasEventId(expectedEventId)
             .HasBusinessReason(process.BusinessReason)
             .HasReceiverId(process.RequestedByActorId.Value)
             .HasReceiverRole(process.RequestedByActorRoleCode)

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
@@ -201,7 +201,7 @@ public class WhenAnAcceptedResultIsAvailableTests : TestBase
     {
         await GetService<IInboxEventReceiver>()
             .ReceiveAsync(
-                Guid.NewGuid().ToString(),
+                EventId.From(Guid.NewGuid()),
                 nameof(AggregatedTimeSeriesRequestAccepted),
                 process.ProcessId.Id,
                 acceptedEvent.ToByteArray());

--- a/source/IntegrationTests/Application/Transactions/WholesaleCalculations/AmountPerChargeResultProducedV1Tests.cs
+++ b/source/IntegrationTests/Application/Transactions/WholesaleCalculations/AmountPerChargeResultProducedV1Tests.cs
@@ -203,6 +203,7 @@ public class AmountPerChargeResultProducedV1Tests : TestBase
         var chargeOwner = "9876543216543";
         var isTax = false;
         var calculationVersion = 3;
+        var eventId = Guid.NewGuid();
 
         // Arrange
         var amountPerChargeEvent = _amountPerChargeEventBuilder
@@ -222,12 +223,14 @@ public class AmountPerChargeResultProducedV1Tests : TestBase
             .Build();
 
         // Act
-        await HandleIntegrationEventAsync(amountPerChargeEvent);
+        await HandleIntegrationEventAsync(amountPerChargeEvent, eventId);
 
         // Assert
         var message = await AssertOutgoingMessageAsync(businessReason: BusinessReason.WholesaleFixing);
 
         message
+            .HasProcessId(null)
+            .HasEventId(eventId.ToString())
             .HasReceiverId(energySupplier)
             .HasReceiverRole(ActorRole.EnergySupplier.Code)
             .HasSenderId(DataHubDetails.DataHubActorNumber.Value)
@@ -252,10 +255,10 @@ public class AmountPerChargeResultProducedV1Tests : TestBase
             .HasMessageRecordValue<WholesaleServicesSeries>(wholesaleCalculation => wholesaleCalculation.Resolution, Resolution.Hourly);
     }
 
-    private async Task HandleIntegrationEventAsync(AmountPerChargeResultProducedV1 @event)
+    private async Task HandleIntegrationEventAsync(AmountPerChargeResultProducedV1 @event, Guid? eventId = null)
     {
         var integrationEvent = new IntegrationEvent(
-            Guid.NewGuid(),
+            eventId ?? Guid.NewGuid(),
             @event.GetType().Name,
             1,
             @event);

--- a/source/IntegrationTests/Application/Transactions/WholesaleCalculations/MonthlyAmountPerChargeResultProducedV1Tests.cs
+++ b/source/IntegrationTests/Application/Transactions/WholesaleCalculations/MonthlyAmountPerChargeResultProducedV1Tests.cs
@@ -130,6 +130,7 @@ public class MonthlyAmountPerChargeResultProducedV1Tests : TestBase
         var isTax = false;
         var calculationVersion = 3;
         var amount = new DecimalValue { Units = 100, Nanos = 0 };
+        var eventId = Guid.NewGuid();
 
         // Arrange
         var monthlyPerChargeEvent = _monthlyPerChargeEventBuilder
@@ -149,12 +150,14 @@ public class MonthlyAmountPerChargeResultProducedV1Tests : TestBase
             .Build();
 
         // Act
-        await HandleIntegrationEventAsync(monthlyPerChargeEvent);
+        await HandleIntegrationEventAsync(monthlyPerChargeEvent, eventId);
 
         // Assert
         var message = await AssertOutgoingMessageAsync(businessReason: BusinessReason.WholesaleFixing);
 
         message
+            .HasProcessId(null)
+            .HasEventId(eventId.ToString())
             .HasReceiverId(energySupplier)
             .HasReceiverRole(ActorRole.EnergySupplier.Code)
             .HasSenderId(DataHubDetails.DataHubActorNumber.Value)
@@ -271,10 +274,10 @@ public class MonthlyAmountPerChargeResultProducedV1Tests : TestBase
             .WithMessage("Sequence contains no elements.");
     }
 
-    private async Task HandleIntegrationEventAsync(MonthlyAmountPerChargeResultProducedV1 @event)
+    private async Task HandleIntegrationEventAsync(MonthlyAmountPerChargeResultProducedV1 @event, Guid? eventId = null)
     {
         var integrationEvent = new IntegrationEvent(
-            Guid.NewGuid(),
+            eventId ?? Guid.NewGuid(),
             @event.GetType().Name,
             1,
             @event);

--- a/source/IntegrationTests/Application/Transactions/WholesaleServices/WhenARejectedWholesaleServicesIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/WholesaleServices/WhenARejectedWholesaleServicesIsAvailableTests.cs
@@ -50,6 +50,7 @@ public sealed class WhenARejectedWholesaleServicesIsAvailableTests : TestBase
     public async Task Wholesale_services_response_is_rejected()
     {
         // Arrange
+        var expectedEventId = Guid.NewGuid().ToString();
         var process = BuildProcess();
         var rejectReason = new RejectReason { ErrorCode = "ER0" };
         var rejectReason2 = new RejectReason { ErrorCode = "ER1" };
@@ -59,13 +60,16 @@ public sealed class WhenARejectedWholesaleServicesIsAvailableTests : TestBase
         await HavingReceivedInboxEventAsync(
             nameof(WholesaleServicesRequestRejected),
             rejectEvent,
-            process.ProcessId.Id);
+            process.ProcessId.Id,
+            expectedEventId);
 
         // Assert
         var outgoingMessage = await OutgoingMessageAsync(
             ActorRole.EnergySupplier,
             BusinessReason.WholesaleFixing);
         outgoingMessage
+            .HasProcessId(process.ProcessId)
+            .HasEventId(expectedEventId)
             .HasBusinessReason(process.BusinessReason)
             .HasReceiverId(process.RequestedByActorId.Value)
             .HasReceiverRole(process.RequestedByActorRoleCode)

--- a/source/IntegrationTests/Application/Transactions/WholesaleServices/WhenAnAcceptedWholesaleServicesResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/WholesaleServices/WhenAnAcceptedWholesaleServicesResultIsAvailableTests.cs
@@ -50,6 +50,7 @@ public class WhenAnAcceptedWholesaleServicesResultIsAvailableTests : TestBase
     public async Task Received_accepted_wholesale_services_event_enqueues_message()
     {
         // Arrange
+        var eventId = Guid.NewGuid().ToString();
         var process = WholesaleServicesProcessBuilder()
             .SetState(WholesaleServicesProcess.State.Sent)
             .Build();
@@ -58,12 +59,14 @@ public class WhenAnAcceptedWholesaleServicesResultIsAvailableTests : TestBase
             .Build();
 
         // Act
-        await HavingReceivedInboxEventAsync(nameof(WholesaleServicesRequestAccepted), acceptedEvent, process.ProcessId.Id);
+        await HavingReceivedInboxEventAsync(nameof(WholesaleServicesRequestAccepted), acceptedEvent, process.ProcessId.Id, eventId);
 
         // Assert
         var outgoingMessage = await OutgoingMessageAsync(ActorRole.EnergySupplier, BusinessReason.WholesaleFixing);
         outgoingMessage.Should().NotBeNull();
         outgoingMessage
+            .HasProcessId(process.ProcessId)
+            .HasEventId(eventId)
             .HasReceiverId(process.RequestedByActorId.Value)
             .HasDocumentReceiverId(process.RequestedByActorId.Value)
             .HasReceiverRole(process.RequestedByActorRoleCode)

--- a/source/IntegrationTests/Assertions/AssertOutgoingMessage.cs
+++ b/source/IntegrationTests/Assertions/AssertOutgoingMessage.cs
@@ -51,7 +51,7 @@ public class AssertOutgoingMessage
 
         using var connection = await connectionFactoryFactory.GetConnectionAndOpenAsync(CancellationToken.None).ConfigureAwait(false);
         var outgoingMessage = await connection.QuerySingleOrDefaultAsync(
-            $"SELECT m.Id, m.RecordId, m.DocumentType, m.DocumentReceiverNumber, m.DocumentReceiverRole, m.ReceiverNumber, m.ProcessId, m.BusinessReason," +
+            $"SELECT m.Id, m.RecordId, m.DocumentType, m.DocumentReceiverNumber, m.DocumentReceiverRole, m.ReceiverNumber, m.ProcessId, m.EventId, m.BusinessReason," +
             $"m.ReceiverRole, m.SenderId, m.SenderRole, m.FileStorageReference, m.RelatedToMessageId, m.MessageCreatedFromProcess, m.GridAreaCode " +
             $" FROM [dbo].[OutgoingMessages] m" +
             $" WHERE m.DocumentType = '{messageType}' AND m.BusinessReason = '{businessReason}' AND m.ReceiverRole = '{receiverRole.Code}'");

--- a/source/IntegrationTests/Assertions/AssertOutgoingMessage.cs
+++ b/source/IntegrationTests/Assertions/AssertOutgoingMessage.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.DataAccess;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.FileStorage;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Serialization;
+using Energinet.DataHub.EDI.Process.Domain.Transactions;
 using Energinet.DataHub.Edi.Responses;
 using FluentAssertions;
 using Xunit;
@@ -178,6 +179,23 @@ public class AssertOutgoingMessage
                 .Be(decimal.Parse($"{expectedPointsInRightOrder[i].Quantity.Units}.{expectedPointsInRightOrder[i].Quantity.Nanos}", CultureInfo.InvariantCulture));
         }
 
+        return this;
+    }
+
+    public AssertOutgoingMessage HasProcessId(ProcessId? processId)
+    {
+        if (processId == null)
+            Assert.Null(_message.ProcessId);
+        else
+            Assert.Equal(processId.Id, _message.ProcessId);
+
+        return this;
+    }
+
+    public AssertOutgoingMessage HasEventId(string eventId)
+    {
+        ArgumentNullException.ThrowIfNull(eventId);
+        Assert.Equal(eventId, _message.EventId);
         return this;
     }
 }

--- a/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
+++ b/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
@@ -178,7 +178,7 @@ public class BehavioursTestBase : IDisposable
     {
         await GetService<IInboxEventReceiver>().
             ReceiveAsync(
-                Guid.NewGuid().ToString(),
+                EventId.From(Guid.NewGuid()),
                 eventType,
                 processId,
                 eventPayload.ToByteArray())

--- a/source/IntegrationTests/Factories/EnergyResultMessageDtoBuilder.cs
+++ b/source/IntegrationTests/Factories/EnergyResultMessageDtoBuilder.cs
@@ -25,7 +25,7 @@ namespace Energinet.DataHub.EDI.IntegrationTests.Factories;
 public class EnergyResultMessageDtoBuilder
 {
     private const string GridAreaCode = "805";
-    private readonly Guid _processId = ProcessId.Create(Guid.NewGuid()).Id;
+    private readonly string _eventId = Guid.NewGuid().ToString();
     private readonly IReadOnlyCollection<EnergyResultMessagePoint> _points = new List<EnergyResultMessagePoint>();
     private BusinessReason _businessReason = BusinessReason.BalanceFixing;
     private SettlementVersion? _settlementVersion;
@@ -37,9 +37,9 @@ public class EnergyResultMessageDtoBuilder
 #pragma warning restore CA1822
     {
         return EnergyResultMessageDto.Create(
+            _eventId,
             _receiverNumber,
             _receiverRole,
-            _processId,
             GridAreaCode,
             MeteringPointType.Consumption.Name,
             SettlementMethod.NonProfiled.Name,

--- a/source/IntegrationTests/Factories/EnergyResultMessageDtoBuilder.cs
+++ b/source/IntegrationTests/Factories/EnergyResultMessageDtoBuilder.cs
@@ -32,9 +32,7 @@ public class EnergyResultMessageDtoBuilder
     private ActorNumber _receiverNumber = ActorNumber.Create("1234567891912");
     private ActorRole _receiverRole = ActorRole.MeteredDataAdministrator;
 
-#pragma warning disable CA1822
     public EnergyResultMessageDto Build()
-#pragma warning restore CA1822
     {
         return EnergyResultMessageDto.Create(
             _eventId,

--- a/source/IntegrationTests/Factories/EnergyResultMessageDtoBuilder.cs
+++ b/source/IntegrationTests/Factories/EnergyResultMessageDtoBuilder.cs
@@ -25,7 +25,7 @@ namespace Energinet.DataHub.EDI.IntegrationTests.Factories;
 public class EnergyResultMessageDtoBuilder
 {
     private const string GridAreaCode = "805";
-    private readonly string _eventId = Guid.NewGuid().ToString();
+    private static readonly EventId _eventId = EventId.From(Guid.NewGuid());
     private readonly IReadOnlyCollection<EnergyResultMessagePoint> _points = new List<EnergyResultMessagePoint>();
     private BusinessReason _businessReason = BusinessReason.BalanceFixing;
     private SettlementVersion? _settlementVersion;

--- a/source/IntegrationTests/Factories/RejectedEnergyResultMessageDtoBuilder.cs
+++ b/source/IntegrationTests/Factories/RejectedEnergyResultMessageDtoBuilder.cs
@@ -21,7 +21,7 @@ namespace Energinet.DataHub.EDI.IntegrationTests.Factories;
 
 public class RejectedEnergyResultMessageDtoBuilder
 {
-    private static readonly string _eventId = Guid.NewGuid().ToString();
+    private static readonly EventId _eventId = EventId.From(Guid.NewGuid());
     private static readonly Guid _processId = Guid.NewGuid();
     private static readonly string _businessReason = BusinessReason.BalanceFixing.Name;
     private static readonly RejectedEnergyResultMessageSerie _series = new(

--- a/source/IntegrationTests/Factories/RejectedEnergyResultMessageDtoBuilder.cs
+++ b/source/IntegrationTests/Factories/RejectedEnergyResultMessageDtoBuilder.cs
@@ -21,6 +21,7 @@ namespace Energinet.DataHub.EDI.IntegrationTests.Factories;
 
 public class RejectedEnergyResultMessageDtoBuilder
 {
+    private static readonly string _eventId = Guid.NewGuid().ToString();
     private static readonly Guid _processId = Guid.NewGuid();
     private static readonly string _businessReason = BusinessReason.BalanceFixing.Name;
     private static readonly RejectedEnergyResultMessageSerie _series = new(
@@ -39,6 +40,7 @@ public class RejectedEnergyResultMessageDtoBuilder
         return new RejectedEnergyResultMessageDto(
             _receiverNumber,
             _processId,
+            _eventId,
             _businessReason,
             _receiverRole,
             _relatedToMessageId,

--- a/source/IntegrationTests/Infrastructure/Configuration/InternalCommands/TestCreateOutgoingCommandHandler.cs
+++ b/source/IntegrationTests/Infrastructure/Configuration/InternalCommands/TestCreateOutgoingCommandHandler.cs
@@ -43,7 +43,7 @@ public class TestCreateOutgoingCommandHandler : IRequestHandler<TestCreateOutgoi
                 ActorNumber.Create("1234567891234"),
                 ActorRole.EnergySupplier,
                 ProcessId.New().Id,
-                Guid.NewGuid().ToString(),
+                EventId.From(Guid.NewGuid()),
                 "123",
                 MeteringPointType.Consumption.Name,
                 SettlementMethod.Flex.Name,

--- a/source/IntegrationTests/Infrastructure/Configuration/InternalCommands/TestCreateOutgoingCommandHandler.cs
+++ b/source/IntegrationTests/Infrastructure/Configuration/InternalCommands/TestCreateOutgoingCommandHandler.cs
@@ -43,6 +43,7 @@ public class TestCreateOutgoingCommandHandler : IRequestHandler<TestCreateOutgoi
                 ActorNumber.Create("1234567891234"),
                 ActorRole.EnergySupplier,
                 ProcessId.New().Id,
+                Guid.NewGuid().ToString(),
                 "123",
                 MeteringPointType.Consumption.Name,
                 SettlementMethod.Flex.Name,

--- a/source/IntegrationTests/Infrastructure/InboxEvents/TestInboxEventMapper.cs
+++ b/source/IntegrationTests/Infrastructure/InboxEvents/TestInboxEventMapper.cs
@@ -16,6 +16,7 @@ using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.Process.Infrastructure.InboxEvents;
 using MediatR;
 
@@ -23,7 +24,7 @@ namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.InboxEvents;
 
 public class TestInboxEventMapper : IInboxEventMapper
 {
-    public Task<INotification> MapFromAsync(byte[] payload, string eventId, Guid referenceId, CancellationToken cancellationToken)
+    public Task<INotification> MapFromAsync(byte[] payload, EventId eventId, Guid referenceId, CancellationToken cancellationToken)
     {
         return Task.FromResult(new TestNotification(Encoding.ASCII.GetString(payload)) as INotification);
     }

--- a/source/IntegrationTests/Infrastructure/InboxEvents/TestInboxEventMapper.cs
+++ b/source/IntegrationTests/Infrastructure/InboxEvents/TestInboxEventMapper.cs
@@ -23,8 +23,7 @@ namespace Energinet.DataHub.EDI.IntegrationTests.Infrastructure.InboxEvents;
 
 public class TestInboxEventMapper : IInboxEventMapper
 {
-    #pragma warning disable // Method cannot be static since inherited from the interface
-    public Task<INotification> MapFromAsync(byte[] payload, Guid referenceId, CancellationToken cancellationToken)
+    public Task<INotification> MapFromAsync(byte[] payload, string eventId, Guid referenceId, CancellationToken cancellationToken)
     {
         return Task.FromResult(new TestNotification(Encoding.ASCII.GetString(payload)) as INotification);
     }

--- a/source/IntegrationTests/Infrastructure/InboxEvents/WhenAnInboxEventIsReceivedTests.cs
+++ b/source/IntegrationTests/Infrastructure/InboxEvents/WhenAnInboxEventIsReceivedTests.cs
@@ -18,6 +18,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.DataAccess;
 using Energinet.DataHub.EDI.BuildingBlocks.Interfaces;
 using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
@@ -97,7 +98,7 @@ public class WhenAnInboxEventIsReceivedTests : TestBase
 
     private Task EventIsReceived(string eventId)
     {
-        return _receiver.ReceiveAsync(eventId, _eventType, _referenceId, _eventPayload);
+        return _receiver.ReceiveAsync(EventId.From(eventId), _eventType, _referenceId, _eventPayload);
     }
 
     private async Task EventIsRegisteredWithInbox(string eventId, int expectedNumberOfRegisteredEvents = 1)

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -67,6 +67,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
+using EventId = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.EventId;
 using SampleData = Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.SampleData;
 
 namespace Energinet.DataHub.EDI.IntegrationTests
@@ -229,7 +230,7 @@ namespace Energinet.DataHub.EDI.IntegrationTests
         {
             await GetService<IInboxEventReceiver>().
                 ReceiveAsync(
-                    eventId ?? Guid.NewGuid().ToString(),
+                    EventId.From(eventId ?? Guid.NewGuid().ToString()),
                     eventType,
                     processId,
                     eventPayload.ToByteArray())

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -225,11 +225,11 @@ namespace Energinet.DataHub.EDI.IntegrationTests
             return GetService<IMasterDataClient>().CreateActorIfNotExistAsync(createActorDto, CancellationToken.None);
         }
 
-        protected async Task HavingReceivedInboxEventAsync(string eventType, IMessage eventPayload, Guid processId)
+        protected async Task HavingReceivedInboxEventAsync(string eventType, IMessage eventPayload, Guid processId, string? eventId = null)
         {
             await GetService<IInboxEventReceiver>().
                 ReceiveAsync(
-                    Guid.NewGuid().ToString(),
+                    eventId ?? Guid.NewGuid().ToString(),
                     eventType,
                     processId,
                     eventPayload.ToByteArray())

--- a/source/OutgoingMessages.Domain/OutgoingMessages/Queueing/OutgoingMessage.cs
+++ b/source/OutgoingMessages.Domain/OutgoingMessages/Queueing/OutgoingMessage.cs
@@ -30,9 +30,10 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
         private string? _serializedContent;
 
         public OutgoingMessage(
+            string eventId,
             DocumentType documentType,
             ActorNumber receiverId,
-            Guid processId,
+            Guid? processId,
             string businessReason,
             ActorRole receiverRole,
             ActorNumber senderId,
@@ -45,6 +46,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
         {
             ArgumentNullException.ThrowIfNull(receiverId);
             Id = OutgoingMessageId.New();
+            EventId = eventId;
             DocumentType = documentType;
             ProcessId = processId;
             BusinessReason = businessReason;
@@ -66,7 +68,8 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         private OutgoingMessage(
             DocumentType documentType,
-            Guid processId,
+            string eventId,
+            Guid? processId,
             string businessReason,
             ActorNumber senderId,
             ActorRole senderRole,
@@ -76,6 +79,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
         {
             Id = OutgoingMessageId.New();
             DocumentType = documentType;
+            EventId = eventId;
             ProcessId = processId;
             BusinessReason = businessReason;
             SenderId = senderId;
@@ -93,7 +97,9 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
 
         public DocumentType DocumentType { get; }
 
-        public Guid ProcessId { get; }
+        public string EventId { get; }
+
+        public Guid? ProcessId { get; }
 
         public string BusinessReason { get; }
 
@@ -137,6 +143,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
             ArgumentNullException.ThrowIfNull(acceptedEnergyResultMessage);
 
             return new OutgoingMessage(
+                acceptedEnergyResultMessage.EventId,
                 acceptedEnergyResultMessage.DocumentType,
                 acceptedEnergyResultMessage.ReceiverNumber,
                 acceptedEnergyResultMessage.ProcessId,
@@ -163,6 +170,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
             ArgumentNullException.ThrowIfNull(rejectedEnergyResultMessage);
 
             return new OutgoingMessage(
+                rejectedEnergyResultMessage.EventId,
                 rejectedEnergyResultMessage.DocumentType,
                 rejectedEnergyResultMessage.ReceiverNumber,
                 rejectedEnergyResultMessage.ProcessId,
@@ -189,6 +197,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
             ArgumentNullException.ThrowIfNull(energyResultMessage);
 
             return new OutgoingMessage(
+                energyResultMessage.EventId,
                 energyResultMessage.DocumentType,
                 energyResultMessage.ReceiverNumber,
                 energyResultMessage.ProcessId,
@@ -217,6 +226,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
             return new List<OutgoingMessage>()
             {
                 new(
+                    wholesaleServicesMessageDto.EventId,
                     wholesaleServicesMessageDto.DocumentType,
                     wholesaleServicesMessageDto.ReceiverNumber,
                     wholesaleServicesMessageDto.ProcessId,
@@ -230,6 +240,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
                     wholesaleServicesMessageDto.RelatedToMessageId,
                     wholesaleServicesMessageDto.Series.GridAreaCode),
                 new(
+                    wholesaleServicesMessageDto.EventId,
                     wholesaleServicesMessageDto.DocumentType,
                     wholesaleServicesMessageDto.ChargeOwnerId,
                     wholesaleServicesMessageDto.ProcessId,
@@ -257,6 +268,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
             ArgumentNullException.ThrowIfNull(rejectedWholesaleServicesMessage);
 
             return new OutgoingMessage(
+                rejectedWholesaleServicesMessage.EventId,
                 rejectedWholesaleServicesMessage.DocumentType,
                 rejectedWholesaleServicesMessage.ReceiverNumber,
                 rejectedWholesaleServicesMessage.ProcessId,
@@ -280,6 +292,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
             ArgumentNullException.ThrowIfNull(acceptedWholesaleServicesMessage);
 
             return new OutgoingMessage(
+                acceptedWholesaleServicesMessage.EventId,
                 acceptedWholesaleServicesMessage.DocumentType,
                 acceptedWholesaleServicesMessage.ReceiverNumber,
                 acceptedWholesaleServicesMessage.ProcessId,

--- a/source/OutgoingMessages.Domain/OutgoingMessages/Queueing/OutgoingMessage.cs
+++ b/source/OutgoingMessages.Domain/OutgoingMessages/Queueing/OutgoingMessage.cs
@@ -30,7 +30,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
         private string? _serializedContent;
 
         public OutgoingMessage(
-            string eventId,
+            EventId eventId,
             DocumentType documentType,
             ActorNumber receiverId,
             Guid? processId,
@@ -68,7 +68,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         private OutgoingMessage(
             DocumentType documentType,
-            string eventId,
+            EventId eventId,
             Guid? processId,
             string businessReason,
             ActorNumber senderId,
@@ -97,7 +97,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queuein
 
         public DocumentType DocumentType { get; }
 
-        public string EventId { get; }
+        public EventId EventId { get; }
 
         public Guid? ProcessId { get; }
 

--- a/source/OutgoingMessages.Infrastructure/OutgoingMessages/OutgoingMessageEntityConfiguration.cs
+++ b/source/OutgoingMessages.Infrastructure/OutgoingMessages/OutgoingMessageEntityConfiguration.cs
@@ -47,6 +47,8 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.OutgoingMessages
 
             builder.Property(x => x.GridAreaCode);
 
+            builder.Property(x => x.EventId);
+
             builder.Property(x => x.SenderId)
                 .HasConversion(
                     toDbValue => toDbValue.Value,

--- a/source/OutgoingMessages.Infrastructure/OutgoingMessages/OutgoingMessageEntityConfiguration.cs
+++ b/source/OutgoingMessages.Infrastructure/OutgoingMessages/OutgoingMessageEntityConfiguration.cs
@@ -47,7 +47,10 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.OutgoingMessages
 
             builder.Property(x => x.GridAreaCode);
 
-            builder.Property(x => x.EventId);
+            builder.Property(x => x.EventId)
+                .HasConversion(
+                    eventId => eventId.Value,
+                    dbValue => EventId.From(dbValue));
 
             builder.Property(x => x.SenderId)
                 .HasConversion(

--- a/source/OutgoingMessages.Interfaces/Models/AcceptedEnergyResultMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/AcceptedEnergyResultMessageDto.cs
@@ -25,6 +25,7 @@ public class AcceptedEnergyResultMessageDto : OutgoingMessageDto
     private AcceptedEnergyResultMessageDto(
         ActorNumber receiverNumber,
         Guid processId,
+        string eventId,
         string businessReason,
         ActorRole receiverRole,
         AcceptedEnergyResultMessageTimeSeries series,
@@ -33,6 +34,7 @@ public class AcceptedEnergyResultMessageDto : OutgoingMessageDto
             DocumentType.NotifyAggregatedMeasureData,
             receiverNumber,
             processId,
+            eventId,
             businessReason,
             receiverRole,
             DataHubDetails.DataHubActorNumber,
@@ -48,6 +50,7 @@ public class AcceptedEnergyResultMessageDto : OutgoingMessageDto
         ActorNumber receiverNumber,
         ActorRole receiverRole,
         Guid processId,
+        string eventId,
         string gridAreaCode,
         string meteringPointType,
         string? settlementMethod,
@@ -81,6 +84,7 @@ public class AcceptedEnergyResultMessageDto : OutgoingMessageDto
         return new AcceptedEnergyResultMessageDto(
             receiverNumber,
             processId,
+            eventId,
             businessReasonName,
             receiverRole,
             series,

--- a/source/OutgoingMessages.Interfaces/Models/AcceptedEnergyResultMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/AcceptedEnergyResultMessageDto.cs
@@ -25,7 +25,7 @@ public class AcceptedEnergyResultMessageDto : OutgoingMessageDto
     private AcceptedEnergyResultMessageDto(
         ActorNumber receiverNumber,
         Guid processId,
-        string eventId,
+        EventId eventId,
         string businessReason,
         ActorRole receiverRole,
         AcceptedEnergyResultMessageTimeSeries series,
@@ -50,7 +50,7 @@ public class AcceptedEnergyResultMessageDto : OutgoingMessageDto
         ActorNumber receiverNumber,
         ActorRole receiverRole,
         Guid processId,
-        string eventId,
+        EventId eventId,
         string gridAreaCode,
         string meteringPointType,
         string? settlementMethod,

--- a/source/OutgoingMessages.Interfaces/Models/AcceptedWholesaleServicesMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/AcceptedWholesaleServicesMessageDto.cs
@@ -23,6 +23,7 @@ public class AcceptedWholesaleServicesMessageDto : WholesaleServicesMessageDto
     protected AcceptedWholesaleServicesMessageDto(
         ActorNumber receiverNumber,
         Guid processId,
+        string eventId,
         string businessReason,
         ActorRole receiverRole,
         ActorNumber chargeOwnerId,
@@ -31,6 +32,7 @@ public class AcceptedWholesaleServicesMessageDto : WholesaleServicesMessageDto
         : base(
         receiverNumber,
         processId,
+        eventId,
         businessReason,
         receiverRole,
         chargeOwnerId,
@@ -44,6 +46,7 @@ public class AcceptedWholesaleServicesMessageDto : WholesaleServicesMessageDto
         ActorRole receiverRole,
         ActorNumber chargeOwnerId,
         Guid processId,
+        string eventId,
         string businessReason,
         AcceptedWholesaleServicesSeries wholesaleSeries,
         MessageId relatedToMessageId)
@@ -55,6 +58,7 @@ public class AcceptedWholesaleServicesMessageDto : WholesaleServicesMessageDto
             receiverNumber: receiverNumber,
             receiverRole: receiverRole,
             processId: processId,
+            eventId: eventId,
             businessReason: businessReason,
             series: wholesaleSeries,
             chargeOwnerId: chargeOwnerId,

--- a/source/OutgoingMessages.Interfaces/Models/AcceptedWholesaleServicesMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/AcceptedWholesaleServicesMessageDto.cs
@@ -23,7 +23,7 @@ public class AcceptedWholesaleServicesMessageDto : WholesaleServicesMessageDto
     protected AcceptedWholesaleServicesMessageDto(
         ActorNumber receiverNumber,
         Guid processId,
-        string eventId,
+        EventId eventId,
         string businessReason,
         ActorRole receiverRole,
         ActorNumber chargeOwnerId,
@@ -46,7 +46,7 @@ public class AcceptedWholesaleServicesMessageDto : WholesaleServicesMessageDto
         ActorRole receiverRole,
         ActorNumber chargeOwnerId,
         Guid processId,
-        string eventId,
+        EventId eventId,
         string businessReason,
         AcceptedWholesaleServicesSeries wholesaleSeries,
         MessageId relatedToMessageId)

--- a/source/OutgoingMessages.Interfaces/Models/EnergyResultMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/EnergyResultMessageDto.cs
@@ -24,7 +24,7 @@ public class EnergyResultMessageDto : OutgoingMessageDto
 {
     private EnergyResultMessageDto(
         ActorNumber receiverNumber,
-        string eventId,
+        EventId eventId,
         string businessReason,
         ActorRole receiverRole,
         EnergyResultMessageTimeSeries series,
@@ -46,7 +46,7 @@ public class EnergyResultMessageDto : OutgoingMessageDto
     public EnergyResultMessageTimeSeries Series { get; }
 
     public static EnergyResultMessageDto Create(
-        string eventId,
+        EventId eventId,
         ActorNumber receiverNumber,
         ActorRole receiverRole,
         string gridAreaCode,

--- a/source/OutgoingMessages.Interfaces/Models/EnergyResultMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/EnergyResultMessageDto.cs
@@ -24,7 +24,7 @@ public class EnergyResultMessageDto : OutgoingMessageDto
 {
     private EnergyResultMessageDto(
         ActorNumber receiverNumber,
-        Guid processId,
+        string eventId,
         string businessReason,
         ActorRole receiverRole,
         EnergyResultMessageTimeSeries series,
@@ -32,7 +32,8 @@ public class EnergyResultMessageDto : OutgoingMessageDto
         : base(
             DocumentType.NotifyAggregatedMeasureData,
             receiverNumber,
-            processId,
+            null,
+            eventId,
             businessReason,
             receiverRole,
             DataHubDetails.DataHubActorNumber,
@@ -45,9 +46,9 @@ public class EnergyResultMessageDto : OutgoingMessageDto
     public EnergyResultMessageTimeSeries Series { get; }
 
     public static EnergyResultMessageDto Create(
+        string eventId,
         ActorNumber receiverNumber,
         ActorRole receiverRole,
-        Guid processId,
         string gridAreaCode,
         string meteringPointType,
         string? settlementMethod,
@@ -62,7 +63,7 @@ public class EnergyResultMessageDto : OutgoingMessageDto
         string? settlementVersion = null)
     {
         var series = new EnergyResultMessageTimeSeries(
-            processId,
+            Guid.NewGuid(),
             gridAreaCode,
             meteringPointType,
             null,
@@ -78,7 +79,7 @@ public class EnergyResultMessageDto : OutgoingMessageDto
             settlementVersion);
         return new EnergyResultMessageDto(
             receiverNumber,
-            processId,
+            eventId,
             businessReasonName,
             receiverRole,
             series);

--- a/source/OutgoingMessages.Interfaces/Models/OutgoingMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/OutgoingMessageDto.cs
@@ -25,7 +25,8 @@ public abstract class OutgoingMessageDto
     protected OutgoingMessageDto(
         DocumentType documentType,
         ActorNumber receiverNumber,
-        Guid processId,
+        Guid? processId,
+        string eventId,
         string businessReason,
         ActorRole receiverRole,
         ActorNumber senderId,
@@ -35,6 +36,7 @@ public abstract class OutgoingMessageDto
         DocumentType = documentType;
         ReceiverNumber = receiverNumber;
         ProcessId = processId;
+        EventId = eventId;
         BusinessReason = businessReason;
         ReceiverRole = receiverRole;
         SenderId = senderId;
@@ -46,7 +48,13 @@ public abstract class OutgoingMessageDto
 
     public ActorNumber ReceiverNumber { get; }
 
-    public Guid ProcessId { get; }
+    public Guid? ProcessId { get; }
+
+    /// <summary>
+    /// Stores the id of the service bus message that created the OutgoingMessage
+    ///     Useful for tracking and debugging purposes.
+    /// </summary>
+    public string EventId { get; }
 
     public string BusinessReason { get; }
 

--- a/source/OutgoingMessages.Interfaces/Models/OutgoingMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/OutgoingMessageDto.cs
@@ -26,7 +26,7 @@ public abstract class OutgoingMessageDto
         DocumentType documentType,
         ActorNumber receiverNumber,
         Guid? processId,
-        string eventId,
+        EventId eventId,
         string businessReason,
         ActorRole receiverRole,
         ActorNumber senderId,
@@ -54,7 +54,7 @@ public abstract class OutgoingMessageDto
     /// Stores the id of the service bus message that created the OutgoingMessage
     ///     Useful for tracking and debugging purposes.
     /// </summary>
-    public string EventId { get; }
+    public EventId EventId { get; }
 
     public string BusinessReason { get; }
 

--- a/source/OutgoingMessages.Interfaces/Models/RejectedEnergyResultMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/RejectedEnergyResultMessageDto.cs
@@ -24,6 +24,7 @@ public class RejectedEnergyResultMessageDto : OutgoingMessageDto
     public RejectedEnergyResultMessageDto(
         ActorNumber receiverNumber,
         Guid processId,
+        string eventId,
         string businessReason,
         ActorRole receiverRole,
         MessageId relatedToMessageId,
@@ -32,6 +33,7 @@ public class RejectedEnergyResultMessageDto : OutgoingMessageDto
             DocumentType.RejectRequestAggregatedMeasureData,
             receiverNumber,
             processId,
+            eventId,
             businessReason,
             receiverRole,
             DataHubDetails.DataHubActorNumber,

--- a/source/OutgoingMessages.Interfaces/Models/RejectedEnergyResultMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/RejectedEnergyResultMessageDto.cs
@@ -24,7 +24,7 @@ public class RejectedEnergyResultMessageDto : OutgoingMessageDto
     public RejectedEnergyResultMessageDto(
         ActorNumber receiverNumber,
         Guid processId,
-        string eventId,
+        EventId eventId,
         string businessReason,
         ActorRole receiverRole,
         MessageId relatedToMessageId,

--- a/source/OutgoingMessages.Interfaces/Models/RejectedWholesaleServicesMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/RejectedWholesaleServicesMessageDto.cs
@@ -24,7 +24,7 @@ public sealed class RejectedWholesaleServicesMessageDto : OutgoingMessageDto
     public RejectedWholesaleServicesMessageDto(
         ActorNumber receiverNumber,
         Guid processId,
-        string eventId,
+        EventId eventId,
         string businessReason,
         ActorRole receiverRole,
         MessageId relatedToMessageId,

--- a/source/OutgoingMessages.Interfaces/Models/RejectedWholesaleServicesMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/RejectedWholesaleServicesMessageDto.cs
@@ -24,6 +24,7 @@ public sealed class RejectedWholesaleServicesMessageDto : OutgoingMessageDto
     public RejectedWholesaleServicesMessageDto(
         ActorNumber receiverNumber,
         Guid processId,
+        string eventId,
         string businessReason,
         ActorRole receiverRole,
         MessageId relatedToMessageId,
@@ -32,6 +33,7 @@ public sealed class RejectedWholesaleServicesMessageDto : OutgoingMessageDto
             DocumentType.RejectRequestWholesaleSettlement,
             receiverNumber,
             processId,
+            eventId,
             businessReason,
             receiverRole,
             DataHubDetails.DataHubActorNumber,

--- a/source/OutgoingMessages.Interfaces/Models/WholesaleServicesMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/WholesaleServicesMessageDto.cs
@@ -23,7 +23,8 @@ public class WholesaleServicesMessageDto : OutgoingMessageDto
 {
     protected WholesaleServicesMessageDto(
         ActorNumber receiverNumber,
-        Guid processId,
+        Guid? processId,
+        string eventId,
         string businessReason,
         ActorRole receiverRole,
         ActorNumber chargeOwnerId,
@@ -33,6 +34,7 @@ public class WholesaleServicesMessageDto : OutgoingMessageDto
             DocumentType.NotifyWholesaleServices,
             receiverNumber,
             processId,
+            eventId,
             businessReason,
             receiverRole,
             DataHubDetails.DataHubActorNumber,
@@ -48,20 +50,21 @@ public class WholesaleServicesMessageDto : OutgoingMessageDto
     public WholesaleServicesSeries Series { get; }
 
     public static WholesaleServicesMessageDto Create(
+        string eventId,
         ActorNumber receiverNumber,
         ActorRole receiverRole,
         ActorNumber chargeOwnerId,
-        Guid processId,
         string businessReason,
         WholesaleServicesSeries wholesaleSeries)
     {
-        ArgumentNullException.ThrowIfNull(processId);
+        ArgumentNullException.ThrowIfNull(eventId);
         ArgumentNullException.ThrowIfNull(businessReason);
 
         return new WholesaleServicesMessageDto(
             receiverNumber: receiverNumber,
             receiverRole: receiverRole,
-            processId: processId,
+            processId: null,
+            eventId: eventId,
             businessReason: businessReason,
             series: wholesaleSeries,
             chargeOwnerId: chargeOwnerId);

--- a/source/OutgoingMessages.Interfaces/Models/WholesaleServicesMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/WholesaleServicesMessageDto.cs
@@ -24,7 +24,7 @@ public class WholesaleServicesMessageDto : OutgoingMessageDto
     protected WholesaleServicesMessageDto(
         ActorNumber receiverNumber,
         Guid? processId,
-        string eventId,
+        EventId eventId,
         string businessReason,
         ActorRole receiverRole,
         ActorNumber chargeOwnerId,
@@ -50,7 +50,7 @@ public class WholesaleServicesMessageDto : OutgoingMessageDto
     public WholesaleServicesSeries Series { get; }
 
     public static WholesaleServicesMessageDto Create(
-        string eventId,
+        EventId eventId,
         ActorNumber receiverNumber,
         ActorRole receiverRole,
         ActorNumber chargeOwnerId,

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Commands/AcceptedEnergyResultTimeSerieCommand.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Commands/AcceptedEnergyResultTimeSerieCommand.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.Process.Domain.Commands;
 using Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData;
 
@@ -23,14 +24,14 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasu
 public class AcceptedEnergyResultTimeSerieCommand : InternalCommand
 {
     [JsonConstructor]
-    public AcceptedEnergyResultTimeSerieCommand(string eventId, Guid processId, IReadOnlyCollection<AcceptedEnergyResultTimeSerie> aggregatedTimeSeries)
+    public AcceptedEnergyResultTimeSerieCommand(EventId eventId, Guid processId, IReadOnlyCollection<AcceptedEnergyResultTimeSerie> aggregatedTimeSeries)
     {
         EventId = eventId;
         ProcessId = processId;
         AggregatedTimeSeries = aggregatedTimeSeries;
     }
 
-    public string EventId { get; }
+    public EventId EventId { get; }
 
     public Guid ProcessId { get; }
 

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Commands/AcceptedEnergyResultTimeSerieCommand.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Commands/AcceptedEnergyResultTimeSerieCommand.cs
@@ -23,11 +23,14 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasu
 public class AcceptedEnergyResultTimeSerieCommand : InternalCommand
 {
     [JsonConstructor]
-    public AcceptedEnergyResultTimeSerieCommand(Guid processId, IReadOnlyCollection<AcceptedEnergyResultTimeSerie> aggregatedTimeSeries)
+    public AcceptedEnergyResultTimeSerieCommand(string eventId, Guid processId, IReadOnlyCollection<AcceptedEnergyResultTimeSerie> aggregatedTimeSeries)
     {
+        EventId = eventId;
         ProcessId = processId;
         AggregatedTimeSeries = aggregatedTimeSeries;
     }
+
+    public string EventId { get; }
 
     public Guid ProcessId { get; }
 

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Commands/AcceptedEnergyResultTimeSeriesCommand.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Commands/AcceptedEnergyResultTimeSeriesCommand.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.Process.Domain.Commands;
 using Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData;
 
@@ -23,14 +24,14 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasu
 public class AcceptedEnergyResultTimeSeriesCommand : InternalCommand
 {
     [JsonConstructor]
-    public AcceptedEnergyResultTimeSeriesCommand(string eventId, Guid processId, IReadOnlyCollection<AcceptedEnergyResultTimeSeries> aggregatedTimeSeries)
+    public AcceptedEnergyResultTimeSeriesCommand(EventId eventId, Guid processId, IReadOnlyCollection<AcceptedEnergyResultTimeSeries> aggregatedTimeSeries)
     {
         EventId = eventId;
         ProcessId = processId;
         AggregatedTimeSeries = aggregatedTimeSeries;
     }
 
-    public string EventId { get; }
+    public EventId EventId { get; }
 
     public Guid ProcessId { get; }
 

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Commands/AcceptedEnergyResultTimeSeriesCommand.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Commands/AcceptedEnergyResultTimeSeriesCommand.cs
@@ -23,11 +23,14 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasu
 public class AcceptedEnergyResultTimeSeriesCommand : InternalCommand
 {
     [JsonConstructor]
-    public AcceptedEnergyResultTimeSeriesCommand(Guid processId, IReadOnlyCollection<AcceptedEnergyResultTimeSeries> aggregatedTimeSeries)
+    public AcceptedEnergyResultTimeSeriesCommand(string eventId, Guid processId, IReadOnlyCollection<AcceptedEnergyResultTimeSeries> aggregatedTimeSeries)
     {
+        EventId = eventId;
         ProcessId = processId;
         AggregatedTimeSeries = aggregatedTimeSeries;
     }
+
+    public string EventId { get; }
 
     public Guid ProcessId { get; }
 

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Commands/Handlers/AcceptProcessWhenAcceptedEnergyResultTimeSerieIsAvailable.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Commands/Handlers/AcceptProcessWhenAcceptedEnergyResultTimeSerieIsAvailable.cs
@@ -45,7 +45,7 @@ public class AcceptProcessWhenAcceptedEnergyResultTimeSerieIsAvailable : IReques
         foreach (var aggregatedTimeSerie in request.AggregatedTimeSeries)
         {
             var message = AcceptedEnergyResultMessageDtoFactory
-                .Create(process, aggregatedTimeSerie);
+                .Create(request.EventId, process, aggregatedTimeSerie);
             energyResultMessageDtos.Add(message);
         }
 

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Commands/Handlers/AcceptProcessWhenAcceptedEnergyResultTimeSeriesIsAvailable.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Commands/Handlers/AcceptProcessWhenAcceptedEnergyResultTimeSeriesIsAvailable.cs
@@ -45,7 +45,7 @@ public class AcceptProcessWhenAcceptedEnergyResultTimeSeriesIsAvailable : IReque
         foreach (var aggregatedTimeSeries in request.AggregatedTimeSeries)
         {
             var message = AcceptedEnergyResultMessageDtoFactory
-                .Create(process, aggregatedTimeSeries);
+                .Create(request.EventId, process, aggregatedTimeSeries);
             energyResultMessageDtos.Add(message);
         }
 

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Commands/Handlers/RejectProcessWhenRejectedAggregatedTimeSeriesIsAvailable.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Commands/Handlers/RejectProcessWhenRejectedAggregatedTimeSeriesIsAvailable.cs
@@ -38,7 +38,7 @@ public class RejectProcessWhenRejectedAggregatedTimeSeriesIsAvailable : IRequest
         var process = await _aggregatedMeasureDataProcessRepository
             .GetAsync(ProcessId.Create(request.ProcessId), cancellationToken).ConfigureAwait(false);
 
-        process.IsRejected(new RejectedAggregatedMeasureDataRequest(request.RejectReasons, process.BusinessReason));
+        process.IsRejected(new RejectedAggregatedMeasureDataRequest(request.EventId, request.RejectReasons, process.BusinessReason));
 
         return Unit.Value;
     }

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Commands/RejectedAggregatedTimeSeries.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Commands/RejectedAggregatedTimeSeries.cs
@@ -24,14 +24,14 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasu
 public class RejectedAggregatedTimeSeries : InternalCommand
 {
     [JsonConstructor]
-    public RejectedAggregatedTimeSeries(string eventId, Guid processId, IReadOnlyCollection<RejectReason> rejectReasons)
+    public RejectedAggregatedTimeSeries(EventId eventId, Guid processId, IReadOnlyCollection<RejectReason> rejectReasons)
     {
         EventId = eventId;
         ProcessId = processId;
         RejectReasons = rejectReasons;
     }
 
-    public string EventId { get; }
+    public EventId EventId { get; }
 
     public Guid ProcessId { get; }
 

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Commands/RejectedAggregatedTimeSeries.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Commands/RejectedAggregatedTimeSeries.cs
@@ -24,11 +24,14 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasu
 public class RejectedAggregatedTimeSeries : InternalCommand
 {
     [JsonConstructor]
-    public RejectedAggregatedTimeSeries(Guid processId, IReadOnlyCollection<RejectReason> rejectReasons)
+    public RejectedAggregatedTimeSeries(string eventId, Guid processId, IReadOnlyCollection<RejectReason> rejectReasons)
     {
+        EventId = eventId;
         ProcessId = processId;
         RejectReasons = rejectReasons;
     }
+
+    public string EventId { get; }
 
     public Guid ProcessId { get; }
 

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Notifications/AggregatedTimeSeriesRequestWasAccepted.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Notifications/AggregatedTimeSeriesRequestWasAccepted.cs
@@ -14,13 +14,14 @@
 
 using System;
 using System.Collections.Generic;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData;
 using MediatR;
 
 namespace Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasureData.Notifications;
 
 public record AggregatedTimeSeriesRequestWasAccepted(
-    string EventId,
+    EventId EventId,
     Guid ProcessId,
     IReadOnlyCollection<AcceptedEnergyResultTimeSeries> AggregatedTimeSeries)
     : INotification;

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Notifications/AggregatedTimeSeriesRequestWasAccepted.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Notifications/AggregatedTimeSeriesRequestWasAccepted.cs
@@ -19,15 +19,8 @@ using MediatR;
 
 namespace Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasureData.Notifications;
 
-public class AggregatedTimeSeriesRequestWasAccepted : INotification
-{
-    public AggregatedTimeSeriesRequestWasAccepted(Guid processId, IReadOnlyCollection<AcceptedEnergyResultTimeSeries> aggregatedTimeSeries)
-    {
-        ProcessId = processId;
-        AggregatedTimeSeries = aggregatedTimeSeries;
-    }
-
-    public Guid ProcessId { get; }
-
-    public IReadOnlyCollection<AcceptedEnergyResultTimeSeries> AggregatedTimeSeries { get; }
-}
+public record AggregatedTimeSeriesRequestWasAccepted(
+    string EventId,
+    Guid ProcessId,
+    IReadOnlyCollection<AcceptedEnergyResultTimeSeries> AggregatedTimeSeries)
+    : INotification;

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Notifications/AggregatedTimeSeriesRequestWasRejected.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Notifications/AggregatedTimeSeriesRequestWasRejected.cs
@@ -19,4 +19,4 @@ using MediatR;
 
 namespace Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasureData.Notifications;
 
-public record AggregatedTimeSeriesRequestWasRejected(Guid ReferenceId, IReadOnlyCollection<RejectReason> RejectReasons) : INotification;
+public record AggregatedTimeSeriesRequestWasRejected(string EventId, Guid ReferenceId, IReadOnlyCollection<RejectReason> RejectReasons) : INotification;

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Notifications/AggregatedTimeSeriesRequestWasRejected.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Notifications/AggregatedTimeSeriesRequestWasRejected.cs
@@ -14,9 +14,10 @@
 
 using System;
 using System.Collections.Generic;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData;
 using MediatR;
 
 namespace Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasureData.Notifications;
 
-public record AggregatedTimeSeriesRequestWasRejected(string EventId, Guid ReferenceId, IReadOnlyCollection<RejectReason> RejectReasons) : INotification;
+public record AggregatedTimeSeriesRequestWasRejected(EventId EventId, Guid ReferenceId, IReadOnlyCollection<RejectReason> RejectReasons) : INotification;

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Notifications/Handlers/WhenAnAcceptedAggregatedTimeSeriesRequestIsAvailable.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Notifications/Handlers/WhenAnAcceptedAggregatedTimeSeriesRequestIsAvailable.cs
@@ -34,6 +34,6 @@ public class WhenAnAcceptedAggregatedTimeSeriesRequestIsAvailable : INotificatio
     {
         ArgumentNullException.ThrowIfNull(notification);
         return _commandSchedulerFacade.EnqueueAsync(
-            new AcceptedEnergyResultTimeSeriesCommand(notification.ProcessId, notification.AggregatedTimeSeries));
+            new AcceptedEnergyResultTimeSeriesCommand(notification.EventId, notification.ProcessId, notification.AggregatedTimeSeries));
     }
 }

--- a/source/Process.Application/Transactions/AggregatedMeasureData/Notifications/Handlers/WhenAnRejectedAggregatedTimeSeriesRequestIsAvailable.cs
+++ b/source/Process.Application/Transactions/AggregatedMeasureData/Notifications/Handlers/WhenAnRejectedAggregatedTimeSeriesRequestIsAvailable.cs
@@ -33,6 +33,6 @@ public class WhenAnRejectedAggregatedTimeSeriesRequestIsAvailable : INotificatio
     public Task Handle(AggregatedTimeSeriesRequestWasRejected notification, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(notification);
-        return _commandSchedulerFacade.EnqueueAsync(new RejectedAggregatedTimeSeries(notification.ReferenceId, notification.RejectReasons));
+        return _commandSchedulerFacade.EnqueueAsync(new RejectedAggregatedTimeSeries(notification.EventId, notification.ReferenceId, notification.RejectReasons));
     }
 }

--- a/source/Process.Application/Transactions/Aggregations/AcceptedEnergyResultMessageDtoFactory.cs
+++ b/source/Process.Application/Transactions/Aggregations/AcceptedEnergyResultMessageDtoFactory.cs
@@ -25,7 +25,7 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.Aggregations;
 public static class AcceptedEnergyResultMessageDtoFactory
 {
     public static AcceptedEnergyResultMessageDto Create(
-        string eventId,
+        EventId eventId,
         AggregatedMeasureDataProcess aggregatedMeasureDataProcess,
         AcceptedEnergyResultTimeSerie acceptedEnergyResultTimeSerie)
     {
@@ -54,7 +54,7 @@ public static class AcceptedEnergyResultMessageDtoFactory
     }
 
     public static AcceptedEnergyResultMessageDto Create(
-        string eventId,
+        EventId eventId,
         AggregatedMeasureDataProcess aggregatedMeasureDataProcess,
         AcceptedEnergyResultTimeSeries acceptedEnergyResultTimeSerie)
     {

--- a/source/Process.Application/Transactions/Aggregations/AcceptedEnergyResultMessageDtoFactory.cs
+++ b/source/Process.Application/Transactions/Aggregations/AcceptedEnergyResultMessageDtoFactory.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models;
 using Energinet.DataHub.EDI.Process.Application.Transactions.Mappers;
@@ -24,6 +25,7 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.Aggregations;
 public static class AcceptedEnergyResultMessageDtoFactory
 {
     public static AcceptedEnergyResultMessageDto Create(
+        string eventId,
         AggregatedMeasureDataProcess aggregatedMeasureDataProcess,
         AcceptedEnergyResultTimeSerie acceptedEnergyResultTimeSerie)
     {
@@ -34,6 +36,7 @@ public static class AcceptedEnergyResultMessageDtoFactory
             receiverNumber: aggregatedMeasureDataProcess.RequestedByActorId,
             receiverRole: ActorRole.FromCode(aggregatedMeasureDataProcess.RequestedByActorRoleCode),
             processId: aggregatedMeasureDataProcess.ProcessId.Id,
+            eventId: eventId,
             gridAreaCode: acceptedEnergyResultTimeSerie.GridAreaDetails.GridAreaCode,
             meteringPointType: acceptedEnergyResultTimeSerie.MeteringPointType,
             settlementMethod: aggregatedMeasureDataProcess.SettlementMethod,
@@ -51,6 +54,7 @@ public static class AcceptedEnergyResultMessageDtoFactory
     }
 
     public static AcceptedEnergyResultMessageDto Create(
+        string eventId,
         AggregatedMeasureDataProcess aggregatedMeasureDataProcess,
         AcceptedEnergyResultTimeSeries acceptedEnergyResultTimeSerie)
     {
@@ -61,6 +65,7 @@ public static class AcceptedEnergyResultMessageDtoFactory
             receiverNumber: aggregatedMeasureDataProcess.RequestedByActorId,
             receiverRole: ActorRole.FromCode(aggregatedMeasureDataProcess.RequestedByActorRoleCode),
             processId: aggregatedMeasureDataProcess.ProcessId.Id,
+            eventId: eventId,
             gridAreaCode: acceptedEnergyResultTimeSerie.GridAreaDetails.GridAreaCode,
             meteringPointType: acceptedEnergyResultTimeSerie.MeteringPointType.Name,
             settlementMethod: acceptedEnergyResultTimeSerie.SettlementMethod?.Name,

--- a/source/Process.Application/Transactions/Aggregations/AggregatedTimeSeriesRequestRejectedMapper.cs
+++ b/source/Process.Application/Transactions/Aggregations/AggregatedTimeSeriesRequestRejectedMapper.cs
@@ -28,14 +28,13 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.Aggregations;
 
 public class AggregatedTimeSeriesRequestRejectedMapper : IInboxEventMapper
 {
-#pragma warning disable CA1822
-    public Task<INotification> MapFromAsync(byte[] payload, Guid referenceId, CancellationToken cancellationToken)
-#pragma warning restore CA1822
+    public Task<INotification> MapFromAsync(byte[] payload, string eventId, Guid referenceId, CancellationToken cancellationToken)
     {
         var inboxEvent =
             AggregatedTimeSeriesRequestRejected.Parser.ParseFrom(payload);
         return Task.FromResult<INotification>(
             new AggregatedTimeSeriesRequestWasRejected(
+                eventId,
                 referenceId,
                 MapRejectReasons(inboxEvent.RejectReasons)));
     }

--- a/source/Process.Application/Transactions/Aggregations/AggregatedTimeSeriesRequestRejectedMapper.cs
+++ b/source/Process.Application/Transactions/Aggregations/AggregatedTimeSeriesRequestRejectedMapper.cs
@@ -17,6 +17,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasureData.Notifications;
 using Energinet.DataHub.EDI.Process.Infrastructure.InboxEvents;
 using Energinet.DataHub.Edi.Responses;
@@ -28,7 +29,7 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.Aggregations;
 
 public class AggregatedTimeSeriesRequestRejectedMapper : IInboxEventMapper
 {
-    public Task<INotification> MapFromAsync(byte[] payload, string eventId, Guid referenceId, CancellationToken cancellationToken)
+    public Task<INotification> MapFromAsync(byte[] payload, EventId eventId, Guid referenceId, CancellationToken cancellationToken)
     {
         var inboxEvent =
             AggregatedTimeSeriesRequestRejected.Parser.ParseFrom(payload);

--- a/source/Process.Application/Transactions/Aggregations/EnergyResultTimeSeriesRequestAcceptedEventMapper.cs
+++ b/source/Process.Application/Transactions/Aggregations/EnergyResultTimeSeriesRequestAcceptedEventMapper.cs
@@ -42,7 +42,7 @@ public class EnergyResultTimeSeriesRequestAcceptedEventMapper : IInboxEventMappe
         _masterDataClient = masterDataClient;
     }
 
-    public async Task<INotification> MapFromAsync(byte[] payload, string eventId, Guid referenceId, CancellationToken cancellationToken)
+    public async Task<INotification> MapFromAsync(byte[] payload, EventId eventId, Guid referenceId, CancellationToken cancellationToken)
     {
         var aggregations =
             AggregatedTimeSeriesRequestAccepted.Parser.ParseFrom(payload);

--- a/source/Process.Application/Transactions/Aggregations/EnergyResultTimeSeriesRequestAcceptedEventMapper.cs
+++ b/source/Process.Application/Transactions/Aggregations/EnergyResultTimeSeriesRequestAcceptedEventMapper.cs
@@ -42,7 +42,7 @@ public class EnergyResultTimeSeriesRequestAcceptedEventMapper : IInboxEventMappe
         _masterDataClient = masterDataClient;
     }
 
-    public async Task<INotification> MapFromAsync(byte[] payload, Guid referenceId, CancellationToken cancellationToken)
+    public async Task<INotification> MapFromAsync(byte[] payload, string eventId, Guid referenceId, CancellationToken cancellationToken)
     {
         var aggregations =
             AggregatedTimeSeriesRequestAccepted.Parser.ParseFrom(payload);
@@ -65,6 +65,7 @@ public class EnergyResultTimeSeriesRequestAcceptedEventMapper : IInboxEventMappe
         }
 
         return new AggregatedTimeSeriesRequestWasAccepted(
+            eventId,
             referenceId,
             acceptedEnergyResultTimeSeries);
     }

--- a/source/Process.Application/Transactions/WholesaleServices/AcceptedWholesaleServiceMessageDtoFactory.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/AcceptedWholesaleServiceMessageDtoFactory.cs
@@ -23,7 +23,7 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServic
 public static class AcceptedWholesaleServiceMessageDtoFactory
 {
     public static AcceptedWholesaleServicesMessageDto Create(
-        string eventId,
+        EventId eventId,
         WholesaleServicesProcess process,
         AcceptedWholesaleServicesSerieDto acceptedWholesaleServices)
     {

--- a/source/Process.Application/Transactions/WholesaleServices/AcceptedWholesaleServiceMessageDtoFactory.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/AcceptedWholesaleServiceMessageDtoFactory.cs
@@ -23,6 +23,7 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServic
 public static class AcceptedWholesaleServiceMessageDtoFactory
 {
     public static AcceptedWholesaleServicesMessageDto Create(
+        string eventId,
         WholesaleServicesProcess process,
         AcceptedWholesaleServicesSerieDto acceptedWholesaleServices)
     {
@@ -36,6 +37,7 @@ public static class AcceptedWholesaleServiceMessageDtoFactory
             ActorRole.FromCode(process.RequestedByActorRoleCode),
             message.ChargeOwner,
             process.ProcessId.Id,
+            eventId,
             process.BusinessReason.Name,
             message,
             process.InitiatedByMessageId);

--- a/source/Process.Application/Transactions/WholesaleServices/Commands/AcceptedWholesaleServices.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Commands/AcceptedWholesaleServices.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.Process.Domain.Commands;
 
 namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServices.Commands;
@@ -22,14 +23,14 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServic
 public class AcceptedWholesaleServices : InternalCommand
 {
     [JsonConstructor]
-    public AcceptedWholesaleServices(string eventId, Guid processId, IReadOnlyCollection<AcceptedWholesaleServicesSerieDto> acceptedWholesaleServicesSerie)
+    public AcceptedWholesaleServices(EventId eventId, Guid processId, IReadOnlyCollection<AcceptedWholesaleServicesSerieDto> acceptedWholesaleServicesSerie)
     {
         EventId = eventId;
         ProcessId = processId;
         AcceptedWholesaleServicesSerie = acceptedWholesaleServicesSerie;
     }
 
-    public string EventId { get; }
+    public EventId EventId { get; }
 
     public Guid ProcessId { get; }
 

--- a/source/Process.Application/Transactions/WholesaleServices/Commands/AcceptedWholesaleServices.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Commands/AcceptedWholesaleServices.cs
@@ -22,11 +22,14 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServic
 public class AcceptedWholesaleServices : InternalCommand
 {
     [JsonConstructor]
-    public AcceptedWholesaleServices(Guid processId, IReadOnlyCollection<AcceptedWholesaleServicesSerieDto> acceptedWholesaleServicesSerie)
+    public AcceptedWholesaleServices(string eventId, Guid processId, IReadOnlyCollection<AcceptedWholesaleServicesSerieDto> acceptedWholesaleServicesSerie)
     {
+        EventId = eventId;
         ProcessId = processId;
         AcceptedWholesaleServicesSerie = acceptedWholesaleServicesSerie;
     }
+
+    public string EventId { get; }
 
     public Guid ProcessId { get; }
 

--- a/source/Process.Application/Transactions/WholesaleServices/Commands/Handlers/AcceptWholesaleServicesWhenAnAcceptedWholesaleServicesRequestIsAvailable.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Commands/Handlers/AcceptWholesaleServicesWhenAnAcceptedWholesaleServicesRequestIsAvailable.cs
@@ -43,7 +43,7 @@ public class AcceptWholesaleServicesWhenAnAcceptedWholesaleServicesRequestIsAvai
         foreach (var acceptedWholesaleServices in request.AcceptedWholesaleServicesSerie)
         {
             var message = AcceptedWholesaleServiceMessageDtoFactory
-                .Create(process, acceptedWholesaleServices);
+                .Create(request.EventId, process, acceptedWholesaleServices);
             acceptedWholesaleServicesMessageDtos.Add(message);
         }
 

--- a/source/Process.Application/Transactions/WholesaleServices/Commands/Handlers/RejectProcessWhenRejectedWholesaleServicesIsAvailable.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Commands/Handlers/RejectProcessWhenRejectedWholesaleServicesIsAvailable.cs
@@ -51,7 +51,7 @@ public sealed class
     }
 
     private static RejectedWholesaleServicesMessageDto CreateRejectedWholesaleServicesResultMessage(
-        string eventId,
+        EventId eventId,
         WholesaleServicesProcess process,
         IReadOnlyCollection<RejectReasonDto> rejectReasons)
     {

--- a/source/Process.Application/Transactions/WholesaleServices/Commands/Handlers/RejectProcessWhenRejectedWholesaleServicesIsAvailable.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Commands/Handlers/RejectProcessWhenRejectedWholesaleServicesIsAvailable.cs
@@ -45,12 +45,13 @@ public sealed class
             .GetAsync(ProcessId.Create(request.ProcessId), cancellationToken)
             .ConfigureAwait(false);
 
-        process.IsRejected(CreateRejectedWholesaleServicesResultMessage(process, request.RejectReasons));
+        process.IsRejected(CreateRejectedWholesaleServicesResultMessage(request.EventId, process, request.RejectReasons));
 
         return Unit.Value;
     }
 
     private static RejectedWholesaleServicesMessageDto CreateRejectedWholesaleServicesResultMessage(
+        string eventId,
         WholesaleServicesProcess process,
         IReadOnlyCollection<RejectReasonDto> rejectReasons)
     {
@@ -67,6 +68,7 @@ public sealed class
         return new RejectedWholesaleServicesMessageDto(
             process.RequestedByActorId,
             process.ProcessId.Id,
+            eventId,
             process.BusinessReason.Name,
             ActorRole.FromCode(process.RequestedByActorRoleCode),
             process.InitiatedByMessageId,

--- a/source/Process.Application/Transactions/WholesaleServices/Commands/RejectedWholesaleServices.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Commands/RejectedWholesaleServices.cs
@@ -23,11 +23,14 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServic
 public sealed class RejectedWholesaleServices : InternalCommand
 {
     [JsonConstructor]
-    public RejectedWholesaleServices(Guid processId, IReadOnlyCollection<RejectReasonDto> rejectReasons)
+    public RejectedWholesaleServices(string eventId, Guid processId, IReadOnlyCollection<RejectReasonDto> rejectReasons)
     {
+        EventId = eventId;
         ProcessId = processId;
         RejectReasons = rejectReasons;
     }
+
+    public string EventId { get; }
 
     public Guid ProcessId { get; }
 

--- a/source/Process.Application/Transactions/WholesaleServices/Commands/RejectedWholesaleServices.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Commands/RejectedWholesaleServices.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.Process.Domain.Commands;
 using Energinet.DataHub.EDI.Process.Domain.Transactions.WholesaleServices;
 
@@ -23,14 +24,14 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServic
 public sealed class RejectedWholesaleServices : InternalCommand
 {
     [JsonConstructor]
-    public RejectedWholesaleServices(string eventId, Guid processId, IReadOnlyCollection<RejectReasonDto> rejectReasons)
+    public RejectedWholesaleServices(EventId eventId, Guid processId, IReadOnlyCollection<RejectReasonDto> rejectReasons)
     {
         EventId = eventId;
         ProcessId = processId;
         RejectReasons = rejectReasons;
     }
 
-    public string EventId { get; }
+    public EventId EventId { get; }
 
     public Guid ProcessId { get; }
 

--- a/source/Process.Application/Transactions/WholesaleServices/Notifications/Handlers/WhenAnAcceptedWholesaleServicesRequestIsAvailable.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Notifications/Handlers/WhenAnAcceptedWholesaleServicesRequestIsAvailable.cs
@@ -33,6 +33,6 @@ public class WhenAnAcceptedWholesaleServicesRequestIsAvailable : INotificationHa
     public Task Handle(WholesaleServicesRequestWasAccepted notification, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(notification);
-        return _commandSchedulerFacade.EnqueueAsync(new AcceptedWholesaleServices(notification.ProcessId, notification.AcceptedWholesaleServicesSerie));
+        return _commandSchedulerFacade.EnqueueAsync(new AcceptedWholesaleServices(notification.EventId, notification.ProcessId, notification.AcceptedWholesaleServicesSerie));
     }
 }

--- a/source/Process.Application/Transactions/WholesaleServices/Notifications/Handlers/WhenAnRejectedWholesaleServicesRequestIsAvailable.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Notifications/Handlers/WhenAnRejectedWholesaleServicesRequestIsAvailable.cs
@@ -35,6 +35,6 @@ public sealed class
     {
         ArgumentNullException.ThrowIfNull(notification);
         return _commandSchedulerFacade.EnqueueAsync(
-            new RejectedWholesaleServices(notification.ReferenceId, notification.RejectReasons));
+            new RejectedWholesaleServices(notification.EventId, notification.ReferenceId, notification.RejectReasons));
     }
 }

--- a/source/Process.Application/Transactions/WholesaleServices/Notifications/WholesaleServicesRequestWasAccepted.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Notifications/WholesaleServicesRequestWasAccepted.cs
@@ -14,12 +14,13 @@
 
 using System;
 using System.Collections.Generic;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using MediatR;
 
 namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServices.Notifications;
 
 public record WholesaleServicesRequestWasAccepted(
-    string EventId,
+    EventId EventId,
     Guid ProcessId,
     IReadOnlyCollection<AcceptedWholesaleServicesSerieDto> AcceptedWholesaleServicesSerie)
     : INotification;

--- a/source/Process.Application/Transactions/WholesaleServices/Notifications/WholesaleServicesRequestWasAccepted.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Notifications/WholesaleServicesRequestWasAccepted.cs
@@ -18,15 +18,8 @@ using MediatR;
 
 namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServices.Notifications;
 
-public class WholesaleServicesRequestWasAccepted : INotification
-{
-    public WholesaleServicesRequestWasAccepted(Guid processId, IReadOnlyCollection<AcceptedWholesaleServicesSerieDto> acceptedWholesaleServicesSerie)
-    {
-        ProcessId = processId;
-        AcceptedWholesaleServicesSerie = acceptedWholesaleServicesSerie;
-    }
-
-    public Guid ProcessId { get; }
-
-    public IReadOnlyCollection<AcceptedWholesaleServicesSerieDto> AcceptedWholesaleServicesSerie { get; }
-}
+public record WholesaleServicesRequestWasAccepted(
+    string EventId,
+    Guid ProcessId,
+    IReadOnlyCollection<AcceptedWholesaleServicesSerieDto> AcceptedWholesaleServicesSerie)
+    : INotification;

--- a/source/Process.Application/Transactions/WholesaleServices/Notifications/WholesaleServicesRequestWasRejected.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Notifications/WholesaleServicesRequestWasRejected.cs
@@ -19,5 +19,6 @@ using MediatR;
 namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServices.Notifications;
 
 public sealed record WholesaleServicesRequestWasRejected(
+    string EventId,
     Guid ReferenceId,
     IReadOnlyCollection<RejectReasonDto> RejectReasons) : INotification;

--- a/source/Process.Application/Transactions/WholesaleServices/Notifications/WholesaleServicesRequestWasRejected.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Notifications/WholesaleServicesRequestWasRejected.cs
@@ -14,11 +14,12 @@
 
 using System;
 using System.Collections.Generic;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using MediatR;
 
 namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServices.Notifications;
 
 public sealed record WholesaleServicesRequestWasRejected(
-    string EventId,
+    EventId EventId,
     Guid ReferenceId,
     IReadOnlyCollection<RejectReasonDto> RejectReasons) : INotification;

--- a/source/Process.Application/Transactions/WholesaleServices/WholesaleServicesRequestAcceptedMapper.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/WholesaleServicesRequestAcceptedMapper.cs
@@ -39,7 +39,7 @@ public class WholesaleServicesRequestAcceptedMapper : IInboxEventMapper
         return eventType.Equals(nameof(WholesaleServicesRequestAccepted), StringComparison.OrdinalIgnoreCase);
     }
 
-    public Task<INotification> MapFromAsync(byte[] payload, string eventId, Guid referenceId, CancellationToken cancellationToken)
+    public Task<INotification> MapFromAsync(byte[] payload, EventId eventId, Guid referenceId, CancellationToken cancellationToken)
     {
         var wholesaleServicesRequestAccepted =
             WholesaleServicesRequestAccepted.Parser.ParseFrom(payload);

--- a/source/Process.Application/Transactions/WholesaleServices/WholesaleServicesRequestAcceptedMapper.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/WholesaleServicesRequestAcceptedMapper.cs
@@ -39,7 +39,7 @@ public class WholesaleServicesRequestAcceptedMapper : IInboxEventMapper
         return eventType.Equals(nameof(WholesaleServicesRequestAccepted), StringComparison.OrdinalIgnoreCase);
     }
 
-    public Task<INotification> MapFromAsync(byte[] payload, Guid referenceId, CancellationToken cancellationToken)
+    public Task<INotification> MapFromAsync(byte[] payload, string eventId, Guid referenceId, CancellationToken cancellationToken)
     {
         var wholesaleServicesRequestAccepted =
             WholesaleServicesRequestAccepted.Parser.ParseFrom(payload);
@@ -68,6 +68,7 @@ public class WholesaleServicesRequestAcceptedMapper : IInboxEventMapper
         }
 
         return Task.FromResult<INotification>(new WholesaleServicesRequestWasAccepted(
+            eventId,
             referenceId,
             acceptedWholesaleServicesSeries));
     }

--- a/source/Process.Application/Transactions/WholesaleServices/WholesaleServicesRequestRejectedMapper.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/WholesaleServicesRequestRejectedMapper.cs
@@ -28,7 +28,7 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServic
 public sealed class WholesaleServicesRequestRejectedMapper : IInboxEventMapper
 {
 #pragma warning disable CA1822
-    public Task<INotification> MapFromAsync(byte[] payload, Guid referenceId, CancellationToken cancellationToken)
+    public Task<INotification> MapFromAsync(byte[] payload, string eventId, Guid referenceId, CancellationToken cancellationToken)
 #pragma warning restore CA1822
     {
         var inboxEvent =
@@ -36,6 +36,7 @@ public sealed class WholesaleServicesRequestRejectedMapper : IInboxEventMapper
 
         return Task.FromResult<INotification>(
             new WholesaleServicesRequestWasRejected(
+                eventId,
                 referenceId,
                 MapRejectReasons(inboxEvent.RejectReasons)));
     }

--- a/source/Process.Application/Transactions/WholesaleServices/WholesaleServicesRequestRejectedMapper.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/WholesaleServicesRequestRejectedMapper.cs
@@ -17,6 +17,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServices.Notifications;
 using Energinet.DataHub.EDI.Process.Infrastructure.InboxEvents;
 using Energinet.DataHub.Edi.Responses;
@@ -28,7 +29,7 @@ namespace Energinet.DataHub.EDI.Process.Application.Transactions.WholesaleServic
 public sealed class WholesaleServicesRequestRejectedMapper : IInboxEventMapper
 {
 #pragma warning disable CA1822
-    public Task<INotification> MapFromAsync(byte[] payload, string eventId, Guid referenceId, CancellationToken cancellationToken)
+    public Task<INotification> MapFromAsync(byte[] payload, EventId eventId, Guid referenceId, CancellationToken cancellationToken)
 #pragma warning restore CA1822
     {
         var inboxEvent =

--- a/source/Process.Domain/Transactions/AggregatedMeasureData/AggregatedMeasureDataProcess.cs
+++ b/source/Process.Domain/Transactions/AggregatedMeasureData/AggregatedMeasureDataProcess.cs
@@ -170,6 +170,7 @@ namespace Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureDat
             return new RejectedEnergyResultMessageDto(
                 RequestedByActorId,
                 ProcessId.Id,
+                rejectedAggregatedMeasureDataRequest.EventId,
                 rejectedAggregatedMeasureDataRequest.BusinessReason.Name,
                 ActorRole.FromCode(RequestedByActorRoleCode),
                 InitiatedByMessageId,

--- a/source/Process.Domain/Transactions/AggregatedMeasureData/RejectedAggregatedMeasureDataRequest.cs
+++ b/source/Process.Domain/Transactions/AggregatedMeasureData/RejectedAggregatedMeasureDataRequest.cs
@@ -17,6 +17,6 @@ using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 
 namespace Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData;
 
-public record RejectedAggregatedMeasureDataRequest(IReadOnlyCollection<RejectReason> RejectReasons, BusinessReason BusinessReason);
+public record RejectedAggregatedMeasureDataRequest(string EventId, IReadOnlyCollection<RejectReason> RejectReasons, BusinessReason BusinessReason);
 
 public record RejectReason(string ErrorCode, string ErrorMessage);

--- a/source/Process.Domain/Transactions/AggregatedMeasureData/RejectedAggregatedMeasureDataRequest.cs
+++ b/source/Process.Domain/Transactions/AggregatedMeasureData/RejectedAggregatedMeasureDataRequest.cs
@@ -17,6 +17,6 @@ using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 
 namespace Energinet.DataHub.EDI.Process.Domain.Transactions.AggregatedMeasureData;
 
-public record RejectedAggregatedMeasureDataRequest(string EventId, IReadOnlyCollection<RejectReason> RejectReasons, BusinessReason BusinessReason);
+public record RejectedAggregatedMeasureDataRequest(EventId EventId, IReadOnlyCollection<RejectReason> RejectReasons, BusinessReason BusinessReason);
 
 public record RejectReason(string ErrorCode, string ErrorMessage);

--- a/source/Process.Infrastructure/InboxEvents/IInboxEventMapper.cs
+++ b/source/Process.Infrastructure/InboxEvents/IInboxEventMapper.cs
@@ -28,10 +28,11 @@ public interface IInboxEventMapper
     /// Map payload to a notification
     /// </summary>
     /// <param name="payload"></param>
+    /// <param name="eventId"></param>
     /// <param name="referenceId"></param>
     /// <param name="cancellationToken"></param>
     /// <returns><see cref="INotification"/></returns>
-    Task<INotification> MapFromAsync(byte[] payload, Guid referenceId, CancellationToken cancellationToken);
+    Task<INotification> MapFromAsync(byte[] payload, string eventId, Guid referenceId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Determines whether the specified event type can be handled by the mapper

--- a/source/Process.Infrastructure/InboxEvents/IInboxEventMapper.cs
+++ b/source/Process.Infrastructure/InboxEvents/IInboxEventMapper.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using MediatR;
 
 namespace Energinet.DataHub.EDI.Process.Infrastructure.InboxEvents;
@@ -32,7 +33,7 @@ public interface IInboxEventMapper
     /// <param name="referenceId"></param>
     /// <param name="cancellationToken"></param>
     /// <returns><see cref="INotification"/></returns>
-    Task<INotification> MapFromAsync(byte[] payload, string eventId, Guid referenceId, CancellationToken cancellationToken);
+    Task<INotification> MapFromAsync(byte[] payload, EventId eventId, Guid referenceId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Determines whether the specified event type can be handled by the mapper

--- a/source/Process.Infrastructure/InboxEvents/InboxEventsProcessor.cs
+++ b/source/Process.Infrastructure/InboxEvents/InboxEventsProcessor.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.DataAccess;
 using Energinet.DataHub.EDI.BuildingBlocks.Interfaces;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using EventId = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.EventId;
 
 namespace Energinet.DataHub.EDI.Process.Infrastructure.InboxEvents;
 
@@ -56,7 +57,7 @@ public class InboxEventsProcessor
             try
             {
                 var notification = await MapperFor(inboxEvent.EventType)
-                    .MapFromAsync(inboxEvent.EventPayload, inboxEvent.Id, inboxEvent.ReferenceId, cancellationToken).ConfigureAwait(false);
+                    .MapFromAsync(inboxEvent.EventPayload, EventId.From(inboxEvent.Id), inboxEvent.ReferenceId, cancellationToken).ConfigureAwait(false);
 
                 await _mediator.Publish(
                         notification,

--- a/source/Process.Infrastructure/InboxEvents/InboxEventsProcessor.cs
+++ b/source/Process.Infrastructure/InboxEvents/InboxEventsProcessor.cs
@@ -56,7 +56,7 @@ public class InboxEventsProcessor
             try
             {
                 var notification = await MapperFor(inboxEvent.EventType)
-                    .MapFromAsync(inboxEvent.EventPayload, inboxEvent.ReferenceId, cancellationToken).ConfigureAwait(false);
+                    .MapFromAsync(inboxEvent.EventPayload, inboxEvent.Id, inboxEvent.ReferenceId, cancellationToken).ConfigureAwait(false);
 
                 await _mediator.Publish(
                         notification,

--- a/source/Process.Interfaces/Process.Interfaces.csproj
+++ b/source/Process.Interfaces/Process.Interfaces.csproj
@@ -5,6 +5,10 @@
     <RootNamespace>Energinet.DataHub.EDI.Process.Interfaces</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\BuildingBlocks.Domain\BuildingBlocks.Domain.csproj" />
+  </ItemGroup>
+
   <ItemDefinitionGroup>
     <ProjectReference>
       <PrivateAssets>all</PrivateAssets>

--- a/source/Tests/Domain/OutgoingMessages/Queueing/ActorMessageQueueTests.cs
+++ b/source/Tests/Domain/OutgoingMessages/Queueing/ActorMessageQueueTests.cs
@@ -18,6 +18,7 @@ using Energinet.DataHub.EDI.OutgoingMessages.Domain.OutgoingMessages.Queueing;
 using Energinet.DataHub.EDI.Process.Domain.Transactions;
 using NodaTime;
 using Xunit;
+using EventId = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.EventId;
 
 namespace Energinet.DataHub.EDI.Tests.Domain.OutgoingMessages.Queueing;
 
@@ -172,7 +173,7 @@ public class ActorMessageQueueTests
             ActorRole.EnergySupplier);
 
         return new OutgoingMessage(
-            Guid.NewGuid().ToString(),
+            EventId.From(Guid.NewGuid()),
             messageType ?? DocumentType.NotifyAggregatedMeasureData,
             receiver.Number,
             ProcessId.New().Id,

--- a/source/Tests/Domain/OutgoingMessages/Queueing/ActorMessageQueueTests.cs
+++ b/source/Tests/Domain/OutgoingMessages/Queueing/ActorMessageQueueTests.cs
@@ -172,6 +172,7 @@ public class ActorMessageQueueTests
             ActorRole.EnergySupplier);
 
         return new OutgoingMessage(
+            Guid.NewGuid().ToString(),
             messageType ?? DocumentType.NotifyAggregatedMeasureData,
             receiver.Number,
             ProcessId.New().Id,

--- a/source/Tests/Factories/AcceptedEnergyResultMessageDtoBuilder.cs
+++ b/source/Tests/Factories/AcceptedEnergyResultMessageDtoBuilder.cs
@@ -52,6 +52,7 @@ public static class AcceptedEnergyResultMessageDtoBuilder
     private static readonly string? _originalTransactionIdReference = Guid.NewGuid().ToString();
     private static readonly string? _settlementVersion = SettlementVersion.FirstCorrection.Code;
     private static readonly MessageId? _relatedToMessageId = MessageId.New();
+    private static readonly string _eventId = Guid.NewGuid().ToString();
 
     public static AcceptedEnergyResultMessageDto Build()
     {
@@ -59,6 +60,7 @@ public static class AcceptedEnergyResultMessageDtoBuilder
             _receiverNumber,
             _receiverRole,
             _processId,
+            _eventId,
             GridAreaCode,
             _meteringPointType,
             _settlementMethod,

--- a/source/Tests/Factories/AcceptedEnergyResultMessageDtoBuilder.cs
+++ b/source/Tests/Factories/AcceptedEnergyResultMessageDtoBuilder.cs
@@ -52,7 +52,7 @@ public static class AcceptedEnergyResultMessageDtoBuilder
     private static readonly string? _originalTransactionIdReference = Guid.NewGuid().ToString();
     private static readonly string? _settlementVersion = SettlementVersion.FirstCorrection.Code;
     private static readonly MessageId? _relatedToMessageId = MessageId.New();
-    private static readonly string _eventId = Guid.NewGuid().ToString();
+    private static readonly EventId _eventId = EventId.From(Guid.NewGuid());
 
     public static AcceptedEnergyResultMessageDto Build()
     {

--- a/source/Tests/Factories/AcceptedWholesaleServicesMessageDtoBuilder.cs
+++ b/source/Tests/Factories/AcceptedWholesaleServicesMessageDtoBuilder.cs
@@ -26,6 +26,7 @@ public abstract class AcceptedWholesaleServicesMessageDtoBuilder
     private static readonly Guid _processId = Guid.NewGuid();
     private static readonly BusinessReason _businessReason = BusinessReason.BalanceFixing;
     private static readonly ActorRole _receiverRole = ActorRole.MeteredDataResponsible;
+    private static readonly string _eventId = Guid.NewGuid().ToString();
 
     public static AcceptedWholesaleServicesMessageDto Build()
     {
@@ -36,6 +37,7 @@ public abstract class AcceptedWholesaleServicesMessageDtoBuilder
             _receiverRole,
             _chargeOwner,
             _processId,
+            _eventId,
             _businessReason.Name,
             series,
             MessageId.New());

--- a/source/Tests/Factories/AcceptedWholesaleServicesMessageDtoBuilder.cs
+++ b/source/Tests/Factories/AcceptedWholesaleServicesMessageDtoBuilder.cs
@@ -26,7 +26,7 @@ public abstract class AcceptedWholesaleServicesMessageDtoBuilder
     private static readonly Guid _processId = Guid.NewGuid();
     private static readonly BusinessReason _businessReason = BusinessReason.BalanceFixing;
     private static readonly ActorRole _receiverRole = ActorRole.MeteredDataResponsible;
-    private static readonly string _eventId = Guid.NewGuid().ToString();
+    private static readonly EventId _eventId = EventId.From(Guid.NewGuid());
 
     public static AcceptedWholesaleServicesMessageDto Build()
     {

--- a/source/Tests/Factories/EnergyResultMessageDtoBuilder.cs
+++ b/source/Tests/Factories/EnergyResultMessageDtoBuilder.cs
@@ -26,7 +26,6 @@ public class EnergyResultMessageDtoBuilder
     private const long CalculationResultVersion = 1;
     private const string GridAreaCode = "804";
     private static readonly ActorNumber _receiverNumber = ActorNumber.Create("1234567890123");
-    private static readonly Guid _processId = Guid.NewGuid();
     private static readonly string _meteringPointType = MeteringPointType.Consumption.Name;
     private static readonly string? _settlementMethod = SettlementMethod.Flex.Name;
     private static readonly string _measureUnitType = MeasurementUnit.Kwh.Code;
@@ -49,15 +48,16 @@ public class EnergyResultMessageDtoBuilder
 
     private static readonly string _businessReasonName = BusinessReason.BalanceFixing.Code;
     private static readonly string? _settlementVersion = SettlementVersion.FirstCorrection.Name;
+    private static readonly string _eventId = Guid.NewGuid().ToString();
 
     private ActorRole _receiverRole = ActorRole.MeteredDataResponsible;
 
     public EnergyResultMessageDto Build()
     {
         return EnergyResultMessageDto.Create(
+            _eventId,
             _receiverNumber,
             _receiverRole,
-            _processId,
             GridAreaCode,
             _meteringPointType,
             _settlementMethod,

--- a/source/Tests/Factories/EnergyResultMessageDtoBuilder.cs
+++ b/source/Tests/Factories/EnergyResultMessageDtoBuilder.cs
@@ -48,8 +48,7 @@ public class EnergyResultMessageDtoBuilder
 
     private static readonly string _businessReasonName = BusinessReason.BalanceFixing.Code;
     private static readonly string? _settlementVersion = SettlementVersion.FirstCorrection.Name;
-    private static readonly string _eventId = Guid.NewGuid().ToString();
-
+    private static readonly EventId _eventId = EventId.From(Guid.NewGuid());
     private ActorRole _receiverRole = ActorRole.MeteredDataResponsible;
 
     public EnergyResultMessageDto Build()

--- a/source/Tests/Factories/RejectedEnergyResultMessageDtoBuilder.cs
+++ b/source/Tests/Factories/RejectedEnergyResultMessageDtoBuilder.cs
@@ -32,11 +32,14 @@ public static class RejectedEnergyResultMessageDtoBuilder
         new List<RejectedEnergyResultMessageRejectReason> { new(SampleData.SerieReasonCode, SampleData.SerieReasonMessage) },
         SampleData.OriginalTransactionId);
 
+    private static readonly string _eventId = Guid.NewGuid().ToString();
+
     public static RejectedEnergyResultMessageDto Build()
     {
         return new RejectedEnergyResultMessageDto(
             _receiverNumber,
             _processId,
+            _eventId,
             _businessReason,
             _receiverRole,
             _relatedToMessageId,

--- a/source/Tests/Factories/RejectedEnergyResultMessageDtoBuilder.cs
+++ b/source/Tests/Factories/RejectedEnergyResultMessageDtoBuilder.cs
@@ -32,7 +32,7 @@ public static class RejectedEnergyResultMessageDtoBuilder
         new List<RejectedEnergyResultMessageRejectReason> { new(SampleData.SerieReasonCode, SampleData.SerieReasonMessage) },
         SampleData.OriginalTransactionId);
 
-    private static readonly string _eventId = Guid.NewGuid().ToString();
+    private static readonly EventId _eventId = EventId.From(Guid.NewGuid().ToString());
 
     public static RejectedEnergyResultMessageDto Build()
     {

--- a/source/Tests/Factories/RejectedWholesaleServicesMessageDtoBuilder.cs
+++ b/source/Tests/Factories/RejectedWholesaleServicesMessageDtoBuilder.cs
@@ -32,7 +32,7 @@ public static class RejectedWholesaleServicesMessageDtoBuilder
         new List<RejectedWholesaleServicesMessageRejectReason> { new(SampleData.SerieReasonCode, SampleData.SerieReasonMessage) },
         SampleData.OriginalTransactionId);
 
-    private static readonly string _eventId = Guid.NewGuid().ToString();
+    private static readonly EventId _eventId = EventId.From(Guid.NewGuid());
 
     public static RejectedWholesaleServicesMessageDto Build()
     {

--- a/source/Tests/Factories/RejectedWholesaleServicesMessageDtoBuilder.cs
+++ b/source/Tests/Factories/RejectedWholesaleServicesMessageDtoBuilder.cs
@@ -32,11 +32,14 @@ public static class RejectedWholesaleServicesMessageDtoBuilder
         new List<RejectedWholesaleServicesMessageRejectReason> { new(SampleData.SerieReasonCode, SampleData.SerieReasonMessage) },
         SampleData.OriginalTransactionId);
 
+    private static readonly string _eventId = Guid.NewGuid().ToString();
+
     public static RejectedWholesaleServicesMessageDto Build()
     {
         return new RejectedWholesaleServicesMessageDto(
             _receiverNumber,
             _processId,
+            _eventId,
             _businessReason,
             _receiverRole,
             _relatedToMessageId,

--- a/source/Tests/Factories/WholesaleServicesMessageDtoBuilder.cs
+++ b/source/Tests/Factories/WholesaleServicesMessageDtoBuilder.cs
@@ -23,8 +23,8 @@ public class WholesaleServicesMessageDtoBuilder
 {
     private static readonly ActorNumber _receiverNumber = ActorNumber.Create("1234567890123");
     private static readonly ActorNumber _chargeOwner = DataHubDetails.DataHubActorNumber;
-    private static readonly Guid _processId = Guid.NewGuid();
     private static readonly BusinessReason _businessReason = BusinessReason.BalanceFixing;
+    private static readonly string _eventId = Guid.NewGuid().ToString();
 
     private ActorRole _receiverRole = ActorRole.MeteredDataResponsible;
 
@@ -33,10 +33,10 @@ public class WholesaleServicesMessageDtoBuilder
         var series = new WholesaleServicesSeriesBuilder().BuildWholesaleCalculation();
 
         return WholesaleServicesMessageDto.Create(
+            _eventId,
             _receiverNumber,
             _receiverRole,
             _chargeOwner,
-            _processId,
             _businessReason.Name,
             series);
     }

--- a/source/Tests/Factories/WholesaleServicesMessageDtoBuilder.cs
+++ b/source/Tests/Factories/WholesaleServicesMessageDtoBuilder.cs
@@ -24,7 +24,7 @@ public class WholesaleServicesMessageDtoBuilder
     private static readonly ActorNumber _receiverNumber = ActorNumber.Create("1234567890123");
     private static readonly ActorNumber _chargeOwner = DataHubDetails.DataHubActorNumber;
     private static readonly BusinessReason _businessReason = BusinessReason.BalanceFixing;
-    private static readonly string _eventId = Guid.NewGuid().ToString();
+    private static readonly EventId _eventId = EventId.From(Guid.NewGuid());
 
     private ActorRole _receiverRole = ActorRole.MeteredDataResponsible;
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Adds EventId column to OutgoingMessages, which holds the id of the ServiceBusMessage's MessageId that triggerede the outgoing message. This makes it easier to track and debug the application.

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/176