### PR TITLE
feat: metered data responsible should also check delegation relations as grid operator

### DIFF
--- a/source/BuildingBlocks.Domain/Models/ActorRole.cs
+++ b/source/BuildingBlocks.Domain/Models/ActorRole.cs
@@ -56,6 +56,20 @@ public class ActorRole : DataHubType<ActorRole>
     /// </summary>
     public ActorRole ForActorMessageQueue()
     {
+        return HackForMeteredDataResponsible();
+    }
+
+    /// <summary>
+    /// The ActorRole for a ActorMessageDelegation. This is implemented to support the "hack" where
+    ///     a MeteredDataResponsible uses the GridOperator
+    /// </summary>
+    public ActorRole ForActorMessageDelegation()
+    {
+        return HackForMeteredDataResponsible();
+    }
+
+    private ActorRole HackForMeteredDataResponsible()
+    {
         if (WorkaroundFlags.MeteredDataResponsibleToGridOperatorHack && Equals(MeteredDataResponsible))
             return GridOperator;
 

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageWithDelegationTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageWithDelegationTests.cs
@@ -55,6 +55,10 @@ public class WhenEnqueueingOutgoingMessageWithDelegationTests : TestBase
         _dateTimeProvider = (SystemDateTimeProviderStub)GetService<ISystemDateTimeProvider>();
     }
 
+    /// <summary>
+    /// This is implemented to support the "hack" where
+    ///     MeteredDataResponsible is working as GridOperator.
+    /// </summary>
     [Fact]
     public async Task
         Given_OutgoingEnergyResultMessageToMeteredDataResponsible_When_DelegatedByIsGridOperator_Then_GridOperatorReceivesMessage()

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageWithDelegationTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageWithDelegationTests.cs
@@ -57,23 +57,23 @@ public class WhenEnqueueingOutgoingMessageWithDelegationTests : TestBase
 
     [Fact]
     public async Task
-        Given_GridOperatorIsDelegatedBy_When_OutgoingEnergyResultMessageToMeteredDataResponsible_Then_DelegatedToReceivesMessage()
+        Given_OutgoingEnergyResultMessageToMeteredDataResponsible_When_DelegatedByIsGridOperator_Then_GridOperatorReceivesMessage()
     {
         // Arrange
-        var documentReceiver = CreateActorNumberAndRole(ActorNumber.Create("1234567891234"), actorRole: ActorRole.MeteredDataResponsible);
+        var outgoingEnergyResultMessageReceiver = CreateActorNumberAndRole(ActorNumber.Create("1234567891234"), actorRole: ActorRole.MeteredDataResponsible);
         var message = _energyResultMessageDtoBuilder
-            .WithReceiverNumber(documentReceiver.ActorNumber.Value)
-            .WithReceiverRole(documentReceiver.ActorRole)
+            .WithReceiverNumber(outgoingEnergyResultMessageReceiver.ActorNumber.Value)
+            .WithReceiverRole(outgoingEnergyResultMessageReceiver.ActorRole)
             .Build();
 
-        _delegatedBy = CreateActorNumberAndRole(documentReceiver.ActorNumber, actorRole: ActorRole.GridOperator);
+        _delegatedBy = CreateActorNumberAndRole(outgoingEnergyResultMessageReceiver.ActorNumber, actorRole: ActorRole.GridOperator);
         await AddDelegationAsync(_delegatedBy, _delegatedTo, message.Series.GridAreaCode);
 
         // Act
         var createdId = await EnqueueAndCommitAsync(message);
 
         // Assert
-        await AssertEnqueuedOutgoingMessage(createdId, _delegatedTo, documentReceiver);
+        await AssertEnqueuedOutgoingMessage(createdId, _delegatedTo, outgoingEnergyResultMessageReceiver);
     }
 
     [Fact]

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageWithDelegationTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageWithDelegationTests.cs
@@ -61,7 +61,7 @@ public class WhenEnqueueingOutgoingMessageWithDelegationTests : TestBase
     /// </summary>
     [Fact]
     public async Task
-        Given_OutgoingEnergyResultMessageToMeteredDataResponsible_When_DelegatedByIsGridOperator_Then_GridOperatorReceivesMessage()
+        Given_DelegatedByIsGridOperator_When_EnqueuingOutgoingEnergyResultMessageToMeteredDataResponsible_Then_GridOperatorReceivesMessage()
     {
         // Arrange
         var outgoingEnergyResultMessageReceiver = CreateActorNumberAndRole(ActorNumber.Create("1234567891234"), actorRole: ActorRole.MeteredDataResponsible);

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageWithDelegationTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageWithDelegationTests.cs
@@ -56,6 +56,27 @@ public class WhenEnqueueingOutgoingMessageWithDelegationTests : TestBase
     }
 
     [Fact]
+    public async Task
+        Given_GridOperatorIsDelegatedBy_When_OutgoingEnergyResultMessageToMeteredDataResponsible_Then_DelegatedToReceivesMessage()
+    {
+        // Arrange
+        var documentReceiver = CreateActorNumberAndRole(ActorNumber.Create("1234567891234"), actorRole: ActorRole.MeteredDataResponsible);
+        var message = _energyResultMessageDtoBuilder
+            .WithReceiverNumber(documentReceiver.ActorNumber.Value)
+            .WithReceiverRole(documentReceiver.ActorRole)
+            .Build();
+
+        _delegatedBy = CreateActorNumberAndRole(documentReceiver.ActorNumber, actorRole: ActorRole.GridOperator);
+        await AddDelegationAsync(_delegatedBy, _delegatedTo, message.Series.GridAreaCode);
+
+        // Act
+        var createdId = await EnqueueAndCommitAsync(message);
+
+        // Assert
+        await AssertEnqueuedOutgoingMessage(createdId, _delegatedTo, documentReceiver);
+    }
+
+    [Fact]
     public async Task Enqueue_message_to_delegated()
     {
         // Arrange

--- a/source/IntegrationTests/IntegrationTests.csproj
+++ b/source/IntegrationTests/IntegrationTests.csproj
@@ -133,9 +133,5 @@ limitations under the License.
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
     </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="DocumentAsserters\"/>
-  </ItemGroup>
   
 </Project>

--- a/source/MasterData.Application/MasterDataClient.cs
+++ b/source/MasterData.Application/MasterDataClient.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.MasterData.Domain.ActorCertificates;
 using Energinet.DataHub.EDI.MasterData.Domain.Actors;
@@ -179,6 +180,17 @@ internal sealed class MasterDataClient : IMasterDataClient
             gridAreaCode,
             processType,
             cancellationToken).ConfigureAwait(false);
+
+        if (processDelegation is null
+            && WorkaroundFlags.MeteredDataResponsibleToGridOperatorHack)
+        {
+            processDelegation = await _processDelegationRepository.GetAsync(
+                delegatedByActorNumber,
+                delegatedByActorRole.ForActorMessageQueue(),
+                gridAreaCode,
+                processType,
+                cancellationToken).ConfigureAwait(false);
+        }
 
         if (processDelegation is null)
             return null;

--- a/source/MasterData.Application/MasterDataClient.cs
+++ b/source/MasterData.Application/MasterDataClient.cs
@@ -176,22 +176,10 @@ internal sealed class MasterDataClient : IMasterDataClient
     {
         var processDelegation = await _processDelegationRepository.GetAsync(
             delegatedByActorNumber,
-            delegatedByActorRole,
+            delegatedByActorRole.ForActorMessageDelegation(),
             gridAreaCode,
             processType,
             cancellationToken).ConfigureAwait(false);
-
-        if (processDelegation is null
-            && WorkaroundFlags.MeteredDataResponsibleToGridOperatorHack
-            && delegatedByActorRole.Equals(ActorRole.MeteredDataResponsible))
-        {
-            processDelegation = await _processDelegationRepository.GetAsync(
-                delegatedByActorNumber,
-                delegatedByActorRole.ForActorMessageQueue(),
-                gridAreaCode,
-                processType,
-                cancellationToken).ConfigureAwait(false);
-        }
 
         if (processDelegation is null)
             return null;

--- a/source/MasterData.Application/MasterDataClient.cs
+++ b/source/MasterData.Application/MasterDataClient.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.MasterData.Domain.ActorCertificates;
 using Energinet.DataHub.EDI.MasterData.Domain.Actors;

--- a/source/MasterData.Application/MasterDataClient.cs
+++ b/source/MasterData.Application/MasterDataClient.cs
@@ -182,7 +182,8 @@ internal sealed class MasterDataClient : IMasterDataClient
             cancellationToken).ConfigureAwait(false);
 
         if (processDelegation is null
-            && WorkaroundFlags.MeteredDataResponsibleToGridOperatorHack)
+            && WorkaroundFlags.MeteredDataResponsibleToGridOperatorHack
+            && delegatedByActorRole.Equals(ActorRole.MeteredDataResponsible))
         {
             processDelegation = await _processDelegationRepository.GetAsync(
                 delegatedByActorNumber,


### PR DESCRIPTION
We need to ensure that messages to metered data repsonsible is also delageted to a new receiver if there is a delegation relationship setup for the actor as a grid operator.

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

## References
