### PR TITLE
fix: Fix error when adding to actor message queue by awaiting immediately

### DIFF
--- a/source/OutgoingMessages.Application/MessageEnqueuer.cs
+++ b/source/OutgoingMessages.Application/MessageEnqueuer.cs
@@ -61,10 +61,12 @@ public class MessageEnqueuer
                 .ConfigureAwait(false);
         }
 
-        var addToRepositoryTask = _outgoingMessageRepository.AddAsync(messageToEnqueue);
-        var addToActorMessageQueueTask = AddToActorMessageQueueAsync(messageToEnqueue);
+        await AddToActorMessageQueueAsync(messageToEnqueue).ConfigureAwait(false);
 
-        await Task.WhenAll(addToRepositoryTask, addToActorMessageQueueTask).ConfigureAwait(false);
+        // Add to outgoing message repository (and upload to file storage) after adding actor message queue,
+        // to minimize the cases where a message is uploaded to file storage but adding actor message queue fails
+        await _outgoingMessageRepository.AddAsync(messageToEnqueue).ConfigureAwait(false);
+
         _logger.LogInformation("Message enqueued: {Message} for Actor: {ActorNumber}", messageToEnqueue.Id, messageToEnqueue.Receiver.Number.Value);
 
         return messageToEnqueue.Id;


### PR DESCRIPTION
## Description
Add to actor message queue before uploading outgoing message to file storage, to (hopefully) fix the `Collection was modified; enumeration operation may not execute` exception that happens when adding OutgoingMessage to DbContext and querying ActorMessageQueue's in parallel.

![image](https://github.com/Energinet-DataHub/opengeh-edi/assets/6283057/ef4e9a10-ef08-4e65-b14c-8603f92a1655)


## References
Task: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/176
Microsoft documentation: https://learn.microsoft.com/da-dk/ef/core/dbcontext-configuration/#avoiding-dbcontext-threading-issues