### PR TITLE
bug: ensure outgoing message file storage reference is updated to match delegation

### DIFF
--- a/source/IntegrationTests/Assertions/AssertOutgoingMessage.cs
+++ b/source/IntegrationTests/Assertions/AssertOutgoingMessage.cs
@@ -60,6 +60,7 @@ public class AssertOutgoingMessage
         ((object?)outgoingMessage).Should().NotBeNull("because an outgoing message should have been added to the database");
         var outgoingMessageFileStorageReference = (string?)outgoingMessage!.FileStorageReference;
         outgoingMessageFileStorageReference.Should().NotBeNull("because an outgoing message should always have a file storage reference");
+        outgoingMessageFileStorageReference.Should().Contain(outgoingMessage.ReceiverNumber);
 
         var fileStorageFile = await fileStorageClient.DownloadAsync(new FileStorageReference(FileStorageCategory.OutgoingMessage(), outgoingMessageFileStorageReference!));
 

--- a/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
+++ b/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
@@ -41,7 +41,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.OutgoingMessages
             ActorNumber senderId,
             ActorRole senderRole,
             string serializedContent,
-            Instant timestamp,
+            Instant createdAt,
             ProcessType messageCreatedFromProcess,
             MessageId? relatedToMessageId,
             string? gridAreaCode)
@@ -60,7 +60,8 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.OutgoingMessages
             RelatedToMessageId = relatedToMessageId;
             DocumentReceiver = Receiver.Create(receiverId, receiverRole);
             Receiver = Receiver.Create(receiverId, receiverRole);
-            FileStorageReference = CreateFileStorageReference(Receiver.Number, timestamp, Id);
+            CreatedAt = createdAt;
+            FileStorageReference = CreateFileStorageReference(Receiver.Number, createdAt, Id);
         }
 
         /// <summary>
@@ -77,6 +78,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.OutgoingMessages
             ActorRole senderRole,
             FileStorageReference fileStorageReference,
             ProcessType messageCreatedFromProcess,
+            Instant createdAt,
             string? gridAreaCode)
         {
             Id = OutgoingMessageId.New();
@@ -89,6 +91,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.OutgoingMessages
             FileStorageReference = fileStorageReference;
             MessageCreatedFromProcess = messageCreatedFromProcess;
             GridAreaCode = gridAreaCode;
+            CreatedAt = createdAt;
             // DocumentReceiver, EF will set this after the constructor
             // Receiver, EF will set this after the constructor
             // _serializedContent is set later in OutgoingMessageRepository, by getting the message from File Storage
@@ -119,6 +122,8 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.OutgoingMessages
         public Receiver DocumentReceiver { get; }
 
         public BundleId? AssignedBundleId { get; private set; }
+
+        public Instant CreatedAt { get; private set; }
 
         public FileStorageReference FileStorageReference { get; private set; }
 
@@ -353,6 +358,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.OutgoingMessages
         public void DelegateTo(Receiver delegatedToReceiver)
         {
             Receiver = delegatedToReceiver;
+            FileStorageReference = CreateFileStorageReference(Receiver.Number, CreatedAt, Id);
         }
 
         private static bool DocumentIsAggregatedMeasureData(DocumentType documentType)

--- a/source/OutgoingMessages.Infrastructure/OutgoingMessages/OutgoingMessageEntityConfiguration.cs
+++ b/source/OutgoingMessages.Infrastructure/OutgoingMessages/OutgoingMessageEntityConfiguration.cs
@@ -116,6 +116,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.OutgoingMessages
                 });
 
             builder.Property(x => x.CreatedAt);
+
             builder.Property<string>("CreatedBy");
             builder.Property<string?>("ModifiedBy");
             builder.Property<Instant?>("ModifiedAt");

--- a/source/OutgoingMessages.Infrastructure/OutgoingMessages/OutgoingMessageEntityConfiguration.cs
+++ b/source/OutgoingMessages.Infrastructure/OutgoingMessages/OutgoingMessageEntityConfiguration.cs
@@ -115,8 +115,8 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.OutgoingMessages
                         .HasColumnName("ReceiverRole");
                 });
 
-            builder.Property<string>("CreatedBy");
             builder.Property(x => x.CreatedAt);
+            builder.Property<string>("CreatedBy");
             builder.Property<string?>("ModifiedBy");
             builder.Property<Instant?>("ModifiedAt");
         }

--- a/source/OutgoingMessages.Infrastructure/OutgoingMessages/OutgoingMessageEntityConfiguration.cs
+++ b/source/OutgoingMessages.Infrastructure/OutgoingMessages/OutgoingMessageEntityConfiguration.cs
@@ -116,7 +116,7 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.OutgoingMessages
                 });
 
             builder.Property<string>("CreatedBy");
-            builder.Property<Instant>("CreatedAt");
+            builder.Property(x => x.CreatedAt);
             builder.Property<string?>("ModifiedBy");
             builder.Property<Instant?>("ModifiedAt");
         }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
We should ensure that the file storage reference for outgoing messages is matching the receiver. 

## References
