### PR TITLE
feat: Add multiple grid areas to AggregatedTimeSeriesRequest

### DIFF
--- a/source/IntegrationTests/Application/IncomingMessages/RequestAggregatedMeasureData/InitializeAggregatedMeasureDataProcessesCommandTests.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/RequestAggregatedMeasureData/InitializeAggregatedMeasureDataProcessesCommandTests.cs
@@ -136,7 +136,7 @@ public class InitializeAggregatedMeasureDataProcessesCommandTests : TestBase
         message.Should().NotBeNull();
         var aggregatedTimeSeriesRequest = AggregatedTimeSeriesRequest.Parser.ParseFrom(message!.Body);
 
-        aggregatedTimeSeriesRequest.RequestedByActorRole.Should().NotBeCimCode();
+        aggregatedTimeSeriesRequest.RequestedForActorRole.Should().NotBeCimCode();
         aggregatedTimeSeriesRequest.BusinessReason.Should().NotBeCimCode();
         aggregatedTimeSeriesRequest.SettlementVersion.Should().NotBeCimCode();
         aggregatedTimeSeriesRequest.SettlementMethod.Should().NotBeCimCode();

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenAggregatedMeasureDataRequestTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenAggregatedMeasureDataRequestTests.cs
@@ -73,9 +73,9 @@ public class GivenAggregatedMeasureDataRequestTests : BehavioursTestBase
         var aggregatedTimeSeriesRequestMessage = AggregatedTimeSeriesRequest.Parser.ParseFrom(serviceBusMessage.Body);
 
         aggregatedTimeSeriesRequestMessage.Should().NotBeNull();
-        aggregatedTimeSeriesRequestMessage.GridAreaCode.Should().Be("512");
-        aggregatedTimeSeriesRequestMessage.RequestedByActorId.Should().Be("2111111111111");
-        aggregatedTimeSeriesRequestMessage.RequestedByActorRole.Should().Be("EnergySupplier");
+        aggregatedTimeSeriesRequestMessage.GridAreaCodes.Should().Equal("512");
+        aggregatedTimeSeriesRequestMessage.RequestedForActorNumber.Should().Be("2111111111111");
+        aggregatedTimeSeriesRequestMessage.RequestedForActorRole.Should().Be("EnergySupplier");
         aggregatedTimeSeriesRequestMessage.EnergySupplierId.Should().Be("2111111111111");
     }
 

--- a/source/IntegrationTests/EventBuilders/AggregatedTimeSeriesRequestAcceptedEventBuilder.cs
+++ b/source/IntegrationTests/EventBuilders/AggregatedTimeSeriesRequestAcceptedEventBuilder.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Linq;
 using Energinet.DataHub.Edi.Requests;
 using Energinet.DataHub.Edi.Responses;
 using Google.Protobuf.WellKnownTypes;
@@ -26,28 +27,29 @@ internal static class AggregatedTimeSeriesRequestAcceptedEventBuilder
     {
         var @event = new AggregatedTimeSeriesRequestAccepted();
 
-        var series = new Series
-        {
-            GridArea = aggregatedTimeSeriesRequest.GridAreaCode,
-            QuantityUnit = QuantityUnit.Kwh,
-            TimeSeriesType = TimeSeriesType.Production,
-            Resolution = Resolution.Pt1H,
-            CalculationResultVersion = 1024,
-            Period = new Period
+        var series = aggregatedTimeSeriesRequest.GridAreaCodes
+            .Select(gridArea => new Series
             {
-                StartOfPeriod = new Timestamp { Seconds = 512, Nanos = 256 },
-                EndOfPeriod = new Timestamp { Seconds = 1024, Nanos = 512 },
-            },
-            TimeSeriesPoints =
-            {
-                new TimeSeriesPoint
+                GridArea = gridArea,
+                QuantityUnit = QuantityUnit.Kwh,
+                TimeSeriesType = TimeSeriesType.Production,
+                Resolution = Resolution.Pt1H,
+                CalculationResultVersion = 1024,
+                Period = new Period
                 {
-                    Quantity = new DecimalValue { Units = 32, Nanos = 64 },
-                    Time = new Timestamp { Seconds = 128, Nanos = 256 },
-                    QuantityQualities = { QuantityQuality.Calculated, QuantityQuality.Measured },
+                    StartOfPeriod = new Timestamp { Seconds = 512, Nanos = 256 },
+                    EndOfPeriod = new Timestamp { Seconds = 1024, Nanos = 512 },
                 },
-            },
-        };
+                TimeSeriesPoints =
+                {
+                    new TimeSeriesPoint
+                    {
+                        Quantity = new DecimalValue { Units = 32, Nanos = 64 },
+                        Time = new Timestamp { Seconds = 128, Nanos = 256 },
+                        QuantityQualities = { QuantityQuality.Calculated, QuantityQuality.Measured },
+                    },
+                },
+            });
 
         @event.Series.Add(series);
 

--- a/source/Process.Infrastructure/Transactions/AggregatedMeasureData/AggregatedMeasureDataRequestFactory.cs
+++ b/source/Process.Infrastructure/Transactions/AggregatedMeasureData/AggregatedMeasureDataRequestFactory.cs
@@ -60,8 +60,8 @@ public static class AggregatedMeasureDataRequestFactory
         var request = new AggregatedTimeSeriesRequest()
         {
             Period = MapPeriod(process),
-            RequestedByActorId = process.RequestedByActorId.Value,
-            RequestedByActorRole = ActorRole.TryGetNameFromCode(process.RequestedByActorRoleCode, fallbackValue: process.RequestedByActorRoleCode),
+            RequestedForActorNumber = process.RequestedByActorId.Value,
+            RequestedForActorRole = ActorRole.TryGetNameFromCode(process.RequestedByActorRoleCode, fallbackValue: process.RequestedByActorRoleCode),
             BusinessReason = process.BusinessReason.Name,
         };
 
@@ -75,16 +75,13 @@ public static class AggregatedMeasureDataRequestFactory
             request.EnergySupplierId = process.EnergySupplierId;
 
         if (process.MeteringGridAreaDomainId != null)
-            request.GridAreaCode = process.MeteringGridAreaDomainId;
+            request.GridAreaCodes.Add(process.MeteringGridAreaDomainId);
 
         if (process.BalanceResponsibleId != null)
             request.BalanceResponsibleId = process.BalanceResponsibleId;
 
         if (process.SettlementVersion != null)
             request.SettlementVersion = process.SettlementVersion.Name;
-
-        if (process.MeteringGridAreaDomainId != null)
-            request.GridAreaCode = process.MeteringGridAreaDomainId;
 
         return request;
     }

--- a/source/RequestResponse/source/RequestResponse/Requests/AggregatedTimeSeries/AggregatedTimeSeriesRequest.proto
+++ b/source/RequestResponse/source/RequestResponse/Requests/AggregatedTimeSeries/AggregatedTimeSeriesRequest.proto
@@ -22,11 +22,11 @@ message AggregatedTimeSeriesRequest {
   string metering_point_type = 2;
   optional string settlement_method = 3;
   optional string energy_supplier_id = 4;
-  string requested_by_actor_id = 5;
-  string requested_by_actor_role = 6;
+  string requested_for_actor_number = 5;
+  string requested_for_actor_role = 6;
   optional string balance_responsible_id = 7;
   optional string settlement_version = 8;
-  optional string grid_area_code = 9;
+  repeated string grid_area_codes = 9;
   string business_reason = 10;
 }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Allow multiple grid areas when sending a `AggregatedTimeSeriesRequest`, in preparation for using delegation for the request

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/148