### PR TITLE
test: Add behaviour test for delegation synchronous error

### DIFF
--- a/source/B2BApi/IncomingMessages/IncomingMessageReceiver.cs
+++ b/source/B2BApi/IncomingMessages/IncomingMessageReceiver.cs
@@ -90,8 +90,9 @@ public class IncomingMessageReceiver
         var responseMessage = await _incomingMessageClient
             .RegisterAndSendAsync(
                 new IncomingMessageStream(request.Body),
-                documentFormat,
+                documentFormat: documentFormat,
                 incomingDocumentType,
+                responseFormat: documentFormat,
                 cancellationToken)
             .ConfigureAwait(false);
 

--- a/source/B2BApi/IncomingMessages/IncomingMessageReceiver.cs
+++ b/source/B2BApi/IncomingMessages/IncomingMessageReceiver.cs
@@ -90,9 +90,9 @@ public class IncomingMessageReceiver
         var responseMessage = await _incomingMessageClient
             .RegisterAndSendAsync(
                 new IncomingMessageStream(request.Body),
-                documentFormat: documentFormat,
+                incomingDocumentFormat: documentFormat,
                 incomingDocumentType,
-                responseFormat: documentFormat,
+                responseDocumentFormat: documentFormat,
                 cancellationToken)
             .ConfigureAwait(false);
 

--- a/source/B2CWebApi/Controllers/RequestAggregatedMeasureDataController.cs
+++ b/source/B2CWebApi/Controllers/RequestAggregatedMeasureDataController.cs
@@ -68,8 +68,8 @@ public class RequestAggregatedMeasureDataController : ControllerBase
                 GenerateStreamFromString(_serializer.Serialize(message)),
                 DocumentFormat.Json,
                 IncomingDocumentType.B2CRequestAggregatedMeasureData,
-                cancellationToken,
-                DocumentFormat.Json)
+                DocumentFormat.Json,
+                cancellationToken)
             .ConfigureAwait(false);
 
         if (responseMessage.IsErrorResponse)

--- a/source/IncomingMessages.Application/IncomingMessageClient.cs
+++ b/source/IncomingMessages.Application/IncomingMessageClient.cs
@@ -69,8 +69,8 @@ public class IncomingMessageClient : IIncomingMessageClient
         IIncomingMessageStream incomingMessageStream,
         DocumentFormat documentFormat,
         IncomingDocumentType documentType,
-        CancellationToken cancellationToken,
-        DocumentFormat responseFormat = null!)
+        DocumentFormat responseFormat,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(documentType);
         ArgumentNullException.ThrowIfNull(incomingMessageStream);
@@ -87,7 +87,7 @@ public class IncomingMessageClient : IIncomingMessageClient
                 "Failed to parse incoming message {DocumentType}. Errors: {Errors}",
                 documentType,
                 res.Errors);
-            return _responseFactory.From(res, responseFormat ?? documentFormat);
+            return _responseFactory.From(res, responseFormat);
         }
 
         await ArchiveIncomingMessageAsync(
@@ -120,7 +120,7 @@ public class IncomingMessageClient : IIncomingMessageClient
                 "Failed to validate incoming message: {MessageId}. Errors: {Errors}",
                 incomingMarketMessageParserResult.IncomingMessage?.MessageId,
                 incomingMarketMessageParserResult.Errors);
-            return _responseFactory.From(validationResult, responseFormat ?? documentFormat);
+            return _responseFactory.From(validationResult, responseFormat);
         }
 
         var result = await _incomingMessageReceiver
@@ -138,7 +138,7 @@ public class IncomingMessageClient : IIncomingMessageClient
             "Failed to save incoming message: {MessageId}. Errors: {Errors}",
             incomingMarketMessageParserResult.IncomingMessage!.MessageId,
             incomingMarketMessageParserResult.Errors);
-        return _responseFactory.From(result, responseFormat ?? documentFormat);
+        return _responseFactory.From(result, responseFormat);
     }
 
     private async Task ArchiveIncomingMessageAsync(

--- a/source/IncomingMessages.Application/IncomingMessageClient.cs
+++ b/source/IncomingMessages.Application/IncomingMessageClient.cs
@@ -67,16 +67,16 @@ public class IncomingMessageClient : IIncomingMessageClient
 
     public async Task<ResponseMessage> RegisterAndSendAsync(
         IIncomingMessageStream incomingMessageStream,
-        DocumentFormat documentFormat,
+        DocumentFormat incomingDocumentFormat,
         IncomingDocumentType documentType,
-        DocumentFormat responseFormat,
+        DocumentFormat responseDocumentFormat,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(documentType);
         ArgumentNullException.ThrowIfNull(incomingMessageStream);
 
         var incomingMarketMessageParserResult =
-            await _marketMessageParser.ParseAsync(incomingMessageStream, documentFormat, documentType, cancellationToken)
+            await _marketMessageParser.ParseAsync(incomingMessageStream, incomingDocumentFormat, documentType, cancellationToken)
                 .ConfigureAwait(false);
 
         if (incomingMarketMessageParserResult.Errors.Count != 0
@@ -87,7 +87,7 @@ public class IncomingMessageClient : IIncomingMessageClient
                 "Failed to parse incoming message {DocumentType}. Errors: {Errors}",
                 documentType,
                 res.Errors);
-            return _responseFactory.From(res, responseFormat);
+            return _responseFactory.From(res, responseDocumentFormat);
         }
 
         await ArchiveIncomingMessageAsync(
@@ -120,7 +120,7 @@ public class IncomingMessageClient : IIncomingMessageClient
                 "Failed to validate incoming message: {MessageId}. Errors: {Errors}",
                 incomingMarketMessageParserResult.IncomingMessage?.MessageId,
                 incomingMarketMessageParserResult.Errors);
-            return _responseFactory.From(validationResult, responseFormat);
+            return _responseFactory.From(validationResult, responseDocumentFormat);
         }
 
         var result = await _incomingMessageReceiver
@@ -138,7 +138,7 @@ public class IncomingMessageClient : IIncomingMessageClient
             "Failed to save incoming message: {MessageId}. Errors: {Errors}",
             incomingMarketMessageParserResult.IncomingMessage!.MessageId,
             incomingMarketMessageParserResult.Errors);
-        return _responseFactory.From(result, responseFormat);
+        return _responseFactory.From(result, responseDocumentFormat);
     }
 
     private async Task ArchiveIncomingMessageAsync(

--- a/source/IncomingMessages.Interfaces/IIncomingMessageClient.cs
+++ b/source/IncomingMessages.Interfaces/IIncomingMessageClient.cs
@@ -24,8 +24,8 @@ public interface IIncomingMessageClient
 {
     Task<ResponseMessage> RegisterAndSendAsync(
         IIncomingMessageStream incomingMessageStream,
-        DocumentFormat documentFormat,
+        DocumentFormat incomingDocumentFormat,
         IncomingDocumentType documentType,
-        DocumentFormat responseFormat,
+        DocumentFormat responseDocumentFormat,
         CancellationToken cancellationToken);
 }

--- a/source/IncomingMessages.Interfaces/IIncomingMessageClient.cs
+++ b/source/IncomingMessages.Interfaces/IIncomingMessageClient.cs
@@ -22,5 +22,10 @@ namespace Energinet.DataHub.EDI.IncomingMessages.Interfaces;
 #pragma warning disable SA1600
 public interface IIncomingMessageClient
 {
-    Task<ResponseMessage> RegisterAndSendAsync(IIncomingMessageStream incomingMessageStream, DocumentFormat documentFormat, IncomingDocumentType documentType, CancellationToken cancellationToken, DocumentFormat responseFormat = null!);
+    Task<ResponseMessage> RegisterAndSendAsync(
+        IIncomingMessageStream incomingMessageStream,
+        DocumentFormat documentFormat,
+        IncomingDocumentType documentType,
+        DocumentFormat responseFormat,
+        CancellationToken cancellationToken);
 }

--- a/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using AutoFixture;
 using Azure.Messaging.ServiceBus;
 using Dapper;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Authentication;
@@ -91,6 +92,7 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
           incomingMessageStream,
           format,
           incomingDocumentType,
+          format,
           CancellationToken.None);
 
       // Assert
@@ -117,6 +119,7 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
             ReadJsonFile("Application\\IncomingMessages\\RequestAggregatedMeasureDataAsMdr.json"),
             DocumentFormat.Json,
             IncomingDocumentType.RequestAggregatedMeasureData,
+            DocumentFormat.Json,
             CancellationToken.None);
 
         // Assert
@@ -145,6 +148,7 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
             incomingMessageStream,
             format,
             incomingDocumentType,
+            format,
             CancellationToken.None));
 
         var transactionIds = await GetTransactionIdsAsync(senderActorNumber);
@@ -180,11 +184,13 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
             incomingMessageStream,
             format,
             incomingDocumentType,
+            format,
             CancellationToken.None);
         var task02 = secondParser.RegisterAndSendAsync(
             incomingMessageStream,
             format,
             incomingDocumentType,
+            format,
             CancellationToken.None);
 
         // Act
@@ -225,11 +231,13 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
             incomingMessageStream,
             format,
             incomingDocumentType,
+            format,
             CancellationToken.None);
         var task02 = secondParser.RegisterAndSendAsync(
             incomingMessageStream,
             format,
             incomingDocumentType,
+            format,
             CancellationToken.None);
 
         // Act
@@ -258,6 +266,7 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
             incomingMessageStream,
             format,
             incomingDocumentType,
+            format,
             CancellationToken.None);
 
         // Assert
@@ -285,6 +294,7 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
             messageStream,
             DocumentFormat.Json,
             IncomingDocumentType.RequestAggregatedMeasureData,
+            DocumentFormat.Json,
             CancellationToken.None);
 
         // Assert
@@ -328,6 +338,7 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
             messageStream,
             DocumentFormat.Json,
             incomingDocumentType,
+            DocumentFormat.Json,
             CancellationToken.None);
 
         // Assert

--- a/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
@@ -19,7 +19,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using AutoFixture;
 using Azure.Messaging.ServiceBus;
 using Dapper;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Authentication;

--- a/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
+++ b/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
@@ -295,7 +295,7 @@ public class BehavioursTestBase : IDisposable
                 CancellationToken.None);
     }
 
-    protected async Task GivenReceivedAggregatedMeasureDataRequest(
+    protected async Task<ResponseMessage> GivenReceivedAggregatedMeasureDataRequest(
         DocumentFormat documentFormat,
         ActorNumber senderActorNumber,
         ActorRole senderActorRole,
@@ -305,7 +305,8 @@ public class BehavioursTestBase : IDisposable
         (int Year, int Month, int Day) periodEnd,
         ActorNumber? energySupplier,
         ActorNumber? balanceResponsibleParty,
-        IReadOnlyCollection<(string? GridArea, string TransactionId)> series)
+        IReadOnlyCollection<(string? GridArea, string TransactionId)> series,
+        bool assertRequestWasSuccessful = true)
     {
         var incomingMessageClient = GetService<IIncomingMessageClient>();
 
@@ -329,11 +330,16 @@ public class BehavioursTestBase : IDisposable
                 documentFormat,
                 CancellationToken.None);
 
-        using (new AssertionScope())
+        if (assertRequestWasSuccessful)
         {
-            response.IsErrorResponse.Should().BeFalse("because the response should not have an error. Actual response: {0}", response.MessageBody);
-            response.MessageBody.Should().BeEmpty();
+            using (new AssertionScope())
+            {
+                response.IsErrorResponse.Should().BeFalse("because the response should not have an error. Actual response: {0}", response.MessageBody);
+                response.MessageBody.Should().BeEmpty();
+            }
         }
+
+        return response;
     }
 
     protected async Task GivenReceivedWholesaleServicesRequest(

--- a/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
+++ b/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
@@ -332,28 +332,27 @@ public class BehavioursTestBase : IDisposable
 
         if (assertRequestWasSuccessful)
         {
-            using (new AssertionScope())
-            {
-                response.IsErrorResponse.Should().BeFalse("because the response should not have an error. Actual response: {0}", response.MessageBody);
-                response.MessageBody.Should().BeEmpty();
-            }
+            using var scope = new AssertionScope();
+            response.IsErrorResponse.Should().BeFalse("because the response should not have an error. Actual response: {0}", response.MessageBody);
+            response.MessageBody.Should().BeEmpty();
         }
 
         return response;
     }
 
-    protected async Task GivenReceivedWholesaleServicesRequest(
+    protected async Task<ResponseMessage> GivenReceivedWholesaleServicesRequest(
         DocumentFormat documentFormat,
         ActorNumber senderActorNumber,
         ActorRole senderActorRole,
         (int Year, int Month, int Day) periodStart,
         (int Year, int Month, int Day) periodEnd,
-        ActorNumber energySupplierActorNumber,
-        ActorNumber chargeOwnerActorNumber,
-        string chargeCode,
-        ChargeType chargeType,
+        ActorNumber? energySupplierActorNumber,
+        ActorNumber? chargeOwnerActorNumber,
+        string? chargeCode,
+        ChargeType? chargeType,
         bool isMonthly,
-        IReadOnlyCollection<(string? GridArea, string TransactionId)> series)
+        IReadOnlyCollection<(string? GridArea, string TransactionId)> series,
+        bool assertRequestWasSuccessful = true)
     {
         var incomingMessageClient = GetService<IIncomingMessageClient>();
 
@@ -378,11 +377,14 @@ public class BehavioursTestBase : IDisposable
                 documentFormat,
                 CancellationToken.None);
 
-        using (new AssertionScope())
+        if (assertRequestWasSuccessful)
         {
+            using var scope = new AssertionScope();
             response.IsErrorResponse.Should().BeFalse();
             response.MessageBody.Should().BeEmpty();
         }
+
+        return response;
     }
 
     protected async Task GivenInitializeAggregatedMeasureDataProcessDtoIsHandledAsync(

--- a/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
+++ b/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
@@ -326,6 +326,7 @@ public class BehavioursTestBase : IDisposable
                 incomingMessageStream,
                 documentFormat,
                 IncomingDocumentType.RequestAggregatedMeasureData,
+                documentFormat,
                 CancellationToken.None);
 
         using (new AssertionScope())
@@ -368,6 +369,7 @@ public class BehavioursTestBase : IDisposable
                 incomingMessageStream,
                 documentFormat,
                 IncomingDocumentType.RequestWholesaleSettlement,
+                documentFormat,
                 CancellationToken.None);
 
         using (new AssertionScope())

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenAggregatedMeasureDataRequestWithDelegationTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenAggregatedMeasureDataRequestWithDelegationTests.cs
@@ -931,7 +931,7 @@ public class GivenAggregatedMeasureDataRequestWithDelegationTests : BehavioursTe
     [InlineData("Json", DataHubNames.ActorRole.EnergySupplier, DataHubNames.ActorRole.Delegated)]
     [InlineData("Xml", DataHubNames.ActorRole.BalanceResponsibleParty, DataHubNames.ActorRole.Delegated)]
     [InlineData("Json", DataHubNames.ActorRole.BalanceResponsibleParty, DataHubNames.ActorRole.Delegated)]
-    public async Task AndGiven_RequestDoesNotContainOriginalActorNumber_When_DelegatedActorPeeksAllMessages_Then_DelegationIsUnsuccessfulSoDRequestIsRejectedWithCorrectInvalidRoleError(string incomingDocumentFormatName, string originalActorRoleName, string delegatedToRoleName)
+    public async Task AndGiven_RequestDoesNotContainOriginalActorNumber_When_DelegatedActorPeeksAllMessages_Then_DelegationIsUnsuccessfulSoRequestIsRejectedWithCorrectInvalidRoleError(string incomingDocumentFormatName, string originalActorRoleName, string delegatedToRoleName)
     {
         var incomingDocumentFormat = DocumentFormat.FromName(incomingDocumentFormatName);
         var originalActorRole = ActorRole.FromName(originalActorRoleName);

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenAggregatedMeasureDataRequestWithDelegationTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenAggregatedMeasureDataRequestWithDelegationTests.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.IntegrationTests.DocumentAsserters;
 using Energinet.DataHub.EDI.IntegrationTests.EventBuilders;
@@ -923,7 +924,57 @@ public class GivenAggregatedMeasureDataRequestWithDelegationTests : BehavioursTe
         resultGridAreas.Should().BeEquivalentTo("106", "512", "804");
     }
 
-    protected Task GivenAggregatedMeasureDataRequestRejectedIsReceived(Guid processId, AggregatedTimeSeriesRequestRejected rejectedMessage)
+    [Theory]
+    [InlineData("Xml", DataHubNames.ActorRole.GridOperator, DataHubNames.ActorRole.Delegated)]
+    [InlineData("Json", DataHubNames.ActorRole.GridOperator, DataHubNames.ActorRole.Delegated)]
+    [InlineData("Xml", DataHubNames.ActorRole.EnergySupplier, DataHubNames.ActorRole.Delegated)]
+    [InlineData("Json", DataHubNames.ActorRole.EnergySupplier, DataHubNames.ActorRole.Delegated)]
+    [InlineData("Xml", DataHubNames.ActorRole.BalanceResponsibleParty, DataHubNames.ActorRole.Delegated)]
+    [InlineData("Json", DataHubNames.ActorRole.BalanceResponsibleParty, DataHubNames.ActorRole.Delegated)]
+    public async Task AndGiven_RequestDoesNotContainOriginalActorNumber_When_DelegatedActorPeeksAllMessages_Then_DelegationIsUnsuccessfulSoDRequestIsRejectedWithCorrectInvalidRoleError(string incomingDocumentFormatName, string originalActorRoleName, string delegatedToRoleName)
+    {
+        var incomingDocumentFormat = DocumentFormat.FromName(incomingDocumentFormatName);
+        var originalActorRole = ActorRole.FromName(originalActorRoleName);
+        var delegatedToRole = ActorRole.FromName(delegatedToRoleName);
+
+        var senderSpy = CreateServiceBusSenderSpy();
+        var originalActor = new Actor(ActorNumber.Create("1111111111111"), ActorRole: originalActorRole);
+        var delegatedToActor = new Actor(ActorNumber: ActorNumber.Create("2222222222222"), ActorRole: delegatedToRole);
+
+        if (originalActor.ActorRole == ActorRole.GridOperator)
+            await GivenGridAreaOwnershipAsync("804", originalActor.ActorNumber);
+
+        GivenAuthenticatedActorIs(delegatedToActor.ActorNumber, delegatedToActor.ActorRole);
+        await GivenDelegation(
+            originalActor,
+            delegatedToActor,
+            "804",
+            ProcessType.RequestEnergyResults,
+            GetNow());
+
+        var response = await GivenReceivedAggregatedMeasureDataRequest(
+            incomingDocumentFormat,
+            delegatedToActor.ActorNumber,
+            originalActor.ActorRole,
+            MeteringPointType.Consumption,
+            SettlementMethod.Flex,
+            (2024, 1, 1),
+            (2023, 12, 31),
+            null,
+            null,
+            new (string? GridArea, string TransactionId)[]
+            {
+                (null, "123564789123564789123564789123564787"),
+            },
+            assertRequestWasSuccessful: false);
+
+        using var scope = new AssertionScope();
+        response.IsErrorResponse.Should().BeTrue("because a synchronous error should have occurred");
+        response.MessageBody.Should().ContainAll("The authenticated user does not hold the required role");
+        senderSpy.MessageSent.Should().BeFalse();
+    }
+
+    private Task GivenAggregatedMeasureDataRequestRejectedIsReceived(Guid processId, AggregatedTimeSeriesRequestRejected rejectedMessage)
     {
         return HavingReceivedInboxEventAsync(
             eventType: nameof(AggregatedTimeSeriesRequestRejected),

--- a/source/IntegrationTests/EventBuilders/RequestWholesaleServicesRequestBuilder.cs
+++ b/source/IntegrationTests/EventBuilders/RequestWholesaleServicesRequestBuilder.cs
@@ -36,10 +36,10 @@ internal static class RequestWholesaleServicesRequestBuilder
         ActorRole senderActorRole,
         Instant periodStart,
         Instant periodEnd,
-        ActorNumber energySupplierActorNumber,
-        ActorNumber chargeOwnerActorNumber,
-        string chargeCode,
-        ChargeType chargeType,
+        ActorNumber? energySupplierActorNumber,
+        ActorNumber? chargeOwnerActorNumber,
+        string? chargeCode,
+        ChargeType? chargeType,
         bool isMonthly,
         IReadOnlyCollection<(string? GridArea, string TransactionId)> series)
     {
@@ -51,10 +51,10 @@ internal static class RequestWholesaleServicesRequestBuilder
                 senderActorRole.Code,
                 periodStart.ToString(),
                 periodEnd.ToString(),
-                energySupplierActorNumber.Value,
-                chargeOwnerActorNumber.Value,
+                energySupplierActorNumber?.Value,
+                chargeOwnerActorNumber?.Value,
                 chargeCode,
-                chargeType.Code,
+                chargeType?.Code,
                 isMonthly,
                 series);
         }
@@ -65,10 +65,10 @@ internal static class RequestWholesaleServicesRequestBuilder
                 senderActorRole.Code,
                 periodStart.ToString(),
                 periodEnd.ToString(),
-                energySupplierActorNumber.Value,
-                chargeOwnerActorNumber.Value,
+                energySupplierActorNumber?.Value,
+                chargeOwnerActorNumber?.Value,
                 chargeCode,
-                chargeType.Code,
+                chargeType?.Code,
                 isMonthly,
                 series);
         }
@@ -85,10 +85,10 @@ internal static class RequestWholesaleServicesRequestBuilder
         string senderActorRole,
         string periodStart,
         string periodEnd,
-        string energySupplierActorNumber,
-        string chargeOwnerActorNumber,
-        string chargeCode,
-        string chargeType,
+        string? energySupplierActorNumber,
+        string? chargeOwnerActorNumber,
+        string? chargeCode,
+        string? chargeType,
         bool isMonthly,
         IReadOnlyCollection<(string? GridArea, string TransactionId)> series)
     {
@@ -124,29 +124,57 @@ internal static class RequestWholesaleServicesRequestBuilder
         {{
             ""mRID"": ""{s.TransactionId}"",
             {GetCimJsonResolutionSection(isMonthly)}
-            ""chargeTypeOwner_MarketParticipant.mRID"": {{
-              ""codingScheme"": ""A10"",
-              ""value"": ""{chargeOwnerActorNumber}""
-            }},
+            {GetCimJsonChargeOwnerSection(chargeOwnerActorNumber)}
             ""end_DateAndOrTime.dateTime"": ""{periodEnd}"",
-            ""energySupplier_MarketParticipant.mRID"": {{
-              ""codingScheme"": ""A10"",
-              ""value"": ""{energySupplierActorNumber}""
-            }},
+            {GetCimJsonEnergySupplierSection(energySupplierActorNumber)}
             {GetCimJsonGridAreaElement(s.GridArea)}
             ""start_DateAndOrTime.dateTime"": ""{periodStart}"",
-            ""ChargeType"": [
-              {{
-                ""mRID"": ""{chargeCode}"",
-                ""type"": {{
-                  ""value"": ""{chargeType}""
-                }}
-              }}
-            ]
+            ""ChargeType"": {GetCimJsonChargeTypeSection(new() { (chargeCode, chargeType) })}
         }}"))}
     ]
   }}
 }}";
+    }
+
+    private static string GetCimJsonChargeOwnerSection(string? chargeOwnerActorNumber)
+    {
+        return chargeOwnerActorNumber != null
+            ? $@"
+                ""chargeTypeOwner_MarketParticipant.mRID"": {{
+                    ""codingScheme"": ""A10"",
+                    ""value"": ""{chargeOwnerActorNumber}""
+                }},"
+            : string.Empty;
+    }
+
+    private static string GetCimJsonChargeTypeSection(List<(string? ChargeCode, string? ChargeType)> chargeTypes)
+    {
+        var array = "[";
+
+        array += string.Join(",\n", chargeTypes
+            .Where(c => c.ChargeCode != null || c.ChargeType != null)
+            .Select((c) => $@"
+                {{
+                    ""mRID"": ""{c.ChargeCode}"",
+                    ""type"": {{
+                        ""value"": ""{c.ChargeType}""
+                    }}
+                }}"));
+
+        array += "]";
+
+        return array;
+    }
+
+    private static string GetCimJsonEnergySupplierSection(string? energySupplierActorNumber)
+    {
+        return energySupplierActorNumber != null
+            ? $@"
+                ""energySupplier_MarketParticipant.mRID"": {{
+                    ""codingScheme"": ""A10"",
+                    ""value"": ""{energySupplierActorNumber}""
+                }},"
+            : string.Empty;
     }
 
     private static string GetCimJsonResolutionSection(bool isMonthly)
@@ -175,10 +203,10 @@ internal static class RequestWholesaleServicesRequestBuilder
         string senderActorRole,
         string periodStart,
         string periodEnd,
-        string energySupplierActorNumber,
-        string chargeOwnerActorNumber,
-        string chargeCode,
-        string chargeType,
+        string? energySupplierActorNumber,
+        string? chargeOwnerActorNumber,
+        string? chargeCode,
+        string? chargeType,
         bool isMonthly,
         IReadOnlyCollection<(string? GridArea, string TransactionId)> series)
     {
@@ -201,15 +229,38 @@ internal static class RequestWholesaleServicesRequestBuilder
 		    <cim:start_DateAndOrTime.dateTime>{periodStart}</cim:start_DateAndOrTime.dateTime>
 		    <cim:end_DateAndOrTime.dateTime>{periodEnd}</cim:end_DateAndOrTime.dateTime>
 		    {GetCimXmlGridAreaSection(s.GridArea)}
-		    <cim:energySupplier_MarketParticipant.mRID codingScheme=""A10"">{energySupplierActorNumber}</cim:energySupplier_MarketParticipant.mRID>
-		    <cim:chargeTypeOwner_MarketParticipant.mRID codingScheme=""A10"">{chargeOwnerActorNumber}</cim:chargeTypeOwner_MarketParticipant.mRID>
+            {GetCimXmlEnergySupplierSection(energySupplierActorNumber)}
+            {GetCimXmlChargeOwnerSection(chargeOwnerActorNumber)}
 		    {GetCimXmlResolutionSection(isMonthly)}
-		    <cim:ChargeType>
-			    <cim:type>{chargeType}</cim:type>
-			    <cim:mRID>{chargeCode}</cim:mRID>
-		    </cim:ChargeType>
+            {GetCimXmlChargeTypesSection(new() { (chargeType, chargeCode) })}
 	    </cim:Series>"))}
 </cim:RequestWholesaleSettlement_MarketDocument>";
+    }
+
+    private static string GetCimXmlChargeTypesSection(List<(string? ChargeType, string? ChargeCode)> chargeTypes)
+    {
+        return string.Join("\n", chargeTypes
+            .Where(c => c.ChargeCode != null || c.ChargeType != null)
+            .Select(c => @$"
+                <cim:ChargeType>
+			        <cim:type>{c.ChargeType}</cim:type>
+			        <cim:mRID>{c.ChargeCode}</cim:mRID>
+		        </cim:ChargeType>
+            "));
+    }
+
+    private static string GetCimXmlChargeOwnerSection(string? chargeOwnerActorNumber)
+    {
+        return chargeOwnerActorNumber != null
+            ? $"<cim:chargeTypeOwner_MarketParticipant.mRID codingScheme=\"A10\">{{chargeOwnerActorNumber}}</cim:chargeTypeOwner_MarketParticipant.mRID>"
+            : string.Empty;
+    }
+
+    private static string GetCimXmlEnergySupplierSection(string? energySupplierActorNumber)
+    {
+        return energySupplierActorNumber != null
+            ? $"<cim:energySupplier_MarketParticipant.mRID codingScheme=\"A10\">{energySupplierActorNumber}</cim:energySupplier_MarketParticipant.mRID>"
+            : string.Empty;
     }
 
     private static string GetCimXmlResolutionSection(bool isMonthly)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

- Refactor `IncomingMessageClient.RegisterAndSendAsync()` `responseFormat` to make it more intuitive
- Add behaviour tests for synchronous validation error when delegation can't find the original actor number (for example if the role is energy supplier and energy supplier is not supplied in the message)

## References
