### PR TITLE
chore: Update c# language version to 12

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -446,7 +446,10 @@ dotnet_diagnostic.SA1312.severity = error
 dotnet_diagnostic.SA1313.severity = error
 dotnet_diagnostic.SA1400.severity = error
 dotnet_diagnostic.SA1401.severity = error
-dotnet_diagnostic.SA1402.severity = error
+
+# SA1402 = FileMayOnlyContainASingleType. Change to suggestion to allow records in same file as classes
+dotnet_diagnostic.SA1402.severity = suggestion
+
 dotnet_diagnostic.SA1403.severity = error
 dotnet_diagnostic.SA1404.severity = error
 dotnet_diagnostic.SA1405.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -447,7 +447,8 @@ dotnet_diagnostic.SA1313.severity = error
 dotnet_diagnostic.SA1400.severity = error
 dotnet_diagnostic.SA1401.severity = error
 
-# SA1402 = FileMayOnlyContainASingleType. Change to suggestion to allow records in same file as classes
+# Change SA1402 (FileMayOnlyContainASingleType) to suggestion to allow records in same file as classes
+# Rule link: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
 dotnet_diagnostic.SA1402.severity = suggestion
 
 dotnet_diagnostic.SA1403.severity = error

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
+      <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>11.0</LangVersion>
+        <LangVersion>12.0</LangVersion>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <Nullable>enable</Nullable>

--- a/source/AcceptanceTests/Drivers/EdiB2CDriver.cs
+++ b/source/AcceptanceTests/Drivers/EdiB2CDriver.cs
@@ -14,7 +14,7 @@
 
 using System.Net.Http.Headers;
 using System.Text;
-using Energinet.DataHub.EDI.AcceptanceTests.Responses.json;
+using Energinet.DataHub.EDI.AcceptanceTests.Responses.Json;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Nito.AsyncEx;

--- a/source/AcceptanceTests/Dsl/ArchivedMessageDsl.cs
+++ b/source/AcceptanceTests/Dsl/ArchivedMessageDsl.cs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Diagnostics.CodeAnalysis;
 using Energinet.DataHub.EDI.AcceptanceTests.Drivers;
-using Energinet.DataHub.EDI.AcceptanceTests.Responses.json;
 using Energinet.DataHub.EDI.AcceptanceTests.TestData;
 using FluentAssertions;
 

--- a/source/AcceptanceTests/Responses/json/ArchivedMessageSearchResponse.cs
+++ b/source/AcceptanceTests/Responses/json/ArchivedMessageSearchResponse.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Energinet.DataHub.EDI.AcceptanceTests.Responses.json;
+namespace Energinet.DataHub.EDI.AcceptanceTests.Responses.Json;
 
 public class ArchivedMessageSearchResponse
 {

--- a/source/AcceptanceTests/Responses/xml/SynchronousError.cs
+++ b/source/AcceptanceTests/Responses/xml/SynchronousError.cs
@@ -16,57 +16,57 @@ using System.Diagnostics.CodeAnalysis;
 using System.Xml.Serialization;
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
-namespace Energinet.DataHub.EDI.AcceptanceTests.Responses.xml;
+namespace Energinet.DataHub.EDI.AcceptanceTests.Responses.Xml;
 
-    [XmlRoot(ElementName = "Error")]
-    public class ErrorResponse
+[SuppressMessage("Security", "CA5369:Use XmlReader for \'XmlSerializer.Deserialize()\'", Justification = "Not available through API")]
+public static class SynchronousError
+{
+    public static ErrorResponse? BuildB2BErrorResponse(string responseData)
     {
-        [XmlElement(ElementName = "Code")]
-        public string Code { get; set; }
+        var serializer = new XmlSerializer(typeof(ErrorResponse));
+        ErrorResponse error;
 
-        [XmlElement(ElementName = "Message")]
-        public string Message { get; set; }
-
-        [XmlElement(ElementName = "Target")]
-        public string Target { get; set; }
-
-        [XmlElement(ElementName = "Details")]
-        public Details Details { get; set; }
-    }
-
-    [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Deserializer needs to write")]
-    [SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Deserializer needs to be able to set it")]
-    public class Details
-    {
-        [XmlElement(ElementName = "Error")]
-        public List<InnerError> InnerErrors { get; set; }
-    }
-
-    public class InnerError
-    {
-        [XmlElement(ElementName = "Code")]
-        public string Code { get; set; }
-
-        [XmlElement(ElementName = "Message")]
-        public string Message { get; set; }
-
-        [XmlElement(ElementName = "Target")]
-        public string Target { get; set; }
-    }
-
-    [SuppressMessage("Security", "CA5369:Use XmlReader for \'XmlSerializer.Deserialize()\'", Justification = "Not available through API")]
-    public static class SynchronousError
-    {
-        public static ErrorResponse? BuildB2BErrorResponse(string responseData)
+        using (var reader = new StringReader(responseData))
         {
-            var serializer = new XmlSerializer(typeof(ErrorResponse));
-            ErrorResponse error;
-
-            using (var reader = new StringReader(responseData))
-            {
-                error = (ErrorResponse)serializer.Deserialize(reader)!;
-            }
-
-            return error;
+            error = (ErrorResponse)serializer.Deserialize(reader)!;
         }
+
+        return error;
     }
+}
+
+[XmlRoot(ElementName = "Error")]
+public class ErrorResponse
+{
+    [XmlElement(ElementName = "Code")]
+    public string Code { get; set; }
+
+    [XmlElement(ElementName = "Message")]
+    public string Message { get; set; }
+
+    [XmlElement(ElementName = "Target")]
+    public string Target { get; set; }
+
+    [XmlElement(ElementName = "Details")]
+    public Details Details { get; set; }
+}
+
+[SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Deserializer needs to write")]
+[SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Deserializer needs to be able to set it")]
+public class Details
+{
+    [XmlElement(ElementName = "Error")]
+    public List<InnerError> InnerErrors { get; set; }
+}
+
+public class InnerError
+{
+    [XmlElement(ElementName = "Code")]
+    public string Code { get; set; }
+
+    [XmlElement(ElementName = "Message")]
+    public string Message { get; set; }
+
+    [XmlElement(ElementName = "Target")]
+    public string Target { get; set; }
+}

--- a/source/AcceptanceTests/Tests/B2BErrors/Asserters/ErrorAsserter.cs
+++ b/source/AcceptanceTests/Tests/B2BErrors/Asserters/ErrorAsserter.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
-using Energinet.DataHub.EDI.AcceptanceTests.Responses.xml;
+using Energinet.DataHub.EDI.AcceptanceTests.Responses.Xml;
 
 namespace Energinet.DataHub.EDI.AcceptanceTests.Tests.B2BErrors.Asserters;
 

--- a/source/AcceptanceTests/Tests/B2BErrors/WhenBusinessTypeAndProcessTypeIsNotCorrectTests.cs
+++ b/source/AcceptanceTests/Tests/B2BErrors/WhenBusinessTypeAndProcessTypeIsNotCorrectTests.cs
@@ -14,7 +14,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Energinet.DataHub.EDI.AcceptanceTests.Factories;
-using Energinet.DataHub.EDI.AcceptanceTests.Responses.xml;
+using Energinet.DataHub.EDI.AcceptanceTests.Responses.Xml;
 using Energinet.DataHub.EDI.AcceptanceTests.TestData;
 using Energinet.DataHub.EDI.AcceptanceTests.Tests.B2BErrors.Asserters;
 using Xunit.Abstractions;

--- a/source/ApplyDBMigrationsApp/ApplyDBMigrationsApp.csproj
+++ b/source/ApplyDBMigrationsApp/ApplyDBMigrationsApp.csproj
@@ -32,10 +32,6 @@ limitations under the License.
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.2" />
   </ItemGroup>

--- a/source/ArchitectureTests/ArchitectureTests.csproj
+++ b/source/ArchitectureTests/ArchitectureTests.csproj
@@ -47,10 +47,6 @@ limitations under the License.
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/source/B2BApi/B2BApi.csproj
+++ b/source/B2BApi/B2BApi.csproj
@@ -41,10 +41,6 @@ limitations under the License.
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
       <!--Microsoft.IdentityModel.XX has to be in sync, aka. same version-->
       <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.1"/>

--- a/source/B2BApi/B2BApi.csproj
+++ b/source/B2BApi/B2BApi.csproj
@@ -15,7 +15,6 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <LangVersion>preview</LangVersion>
         <AzureFunctionsVersion>v4</AzureFunctionsVersion>
         <OutputType>Exe</OutputType>
         <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>

--- a/source/B2CWebApi/Models/RequestAggregatedMeasureDataMarketDocument.cs
+++ b/source/B2CWebApi/Models/RequestAggregatedMeasureDataMarketDocument.cs
@@ -14,18 +14,6 @@
 
 namespace Energinet.DataHub.EDI.B2CWebApi.Models;
 
-/// <summary>
-/// Responsible for carrying the market message data from the incoming message before any data validation.
-/// </summary>
-public record RequestAggregatedMeasureDataMarketRequest(
-    CalculationType ProcessType, // TODO: Rename property to CalculationType when we implement RequestWholesaleSettlement in BFF
-    MeteringPointType? MeteringPointType,
-    string StartDate,
-    string EndDate,
-    string? GridArea,
-    string? EnergySupplierId,
-    string? BalanceResponsibleId);
-
 public enum MeteringPointType
 {
     Production,
@@ -44,3 +32,15 @@ public enum CalculationType
     SecondCorrection,
     ThirdCorrection,
 }
+
+/// <summary>
+/// Responsible for carrying the market message data from the incoming message before any data validation.
+/// </summary>
+public record RequestAggregatedMeasureDataMarketRequest(
+    CalculationType ProcessType, // TODO: Rename property to CalculationType when we implement RequestWholesaleSettlement in BFF
+    MeteringPointType? MeteringPointType,
+    string StartDate,
+    string EndDate,
+    string? GridArea,
+    string? EnergySupplierId,
+    string? BalanceResponsibleId);

--- a/source/BuildingBlocks.Domain/Models/Period.cs
+++ b/source/BuildingBlocks.Domain/Models/Period.cs
@@ -29,11 +29,6 @@ public record Period(Instant Start, Instant End)
         return ParsePeriodDateFrom(End);
     }
 
-    private static string ParsePeriodDateFrom(Instant instant)
-    {
-        return instant.ToString("yyyy-MM-ddTHH:mm'Z'", CultureInfo.InvariantCulture);
-    }
-
     public string StartToEbixString()
     {
         return ParsePeriodDateFromToEbix(Start);
@@ -47,5 +42,10 @@ public record Period(Instant Start, Instant End)
     private static string ParsePeriodDateFromToEbix(Instant instant)
     {
         return instant.ToString("yyyy-MM-ddTHH:mm:ss'Z'", CultureInfo.InvariantCulture);
+    }
+
+    private static string ParsePeriodDateFrom(Instant instant)
+    {
+        return instant.ToString("yyyy-MM-ddTHH:mm'Z'", CultureInfo.InvariantCulture);
     }
 }

--- a/source/IntegrationTests/IntegrationTests.csproj
+++ b/source/IntegrationTests/IntegrationTests.csproj
@@ -50,10 +50,6 @@ limitations under the License.
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/source/RequestResponse/source/RequestResponse/RequestResponse.csproj
+++ b/source/RequestResponse/source/RequestResponse/RequestResponse.csproj
@@ -63,10 +63,6 @@ limitations under the License.
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -49,10 +49,6 @@ limitations under the License.
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Description
- Update c# language version to 12 (enables collection initializers 🎉)
- Update stylecop version (required for language version 12.0)
- Remove stylecop reference from project files (it is already referenced in a shared `Directory.Build.props` file)

Updating stylecop version requires configuring the stylecop rule https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md, since it was updated to not allow records in the same file as classes. This would be a big refactor in our repository, so we've reconfigured the rule to be a suggestion instead.

## References
