### PR TITLE
fix: Altered reading method of resolution for wholesale services

### DIFF
--- a/source/IncomingMessages.Application/MessageParser/WholesaleSettlementMessageParsers/XmlMessageParser.cs
+++ b/source/IncomingMessages.Application/MessageParser/WholesaleSettlementMessageParsers/XmlMessageParser.cs
@@ -146,7 +146,7 @@ public class XmlMessageParser : XmlBaseParser
             }
             else if (reader.Is("aggregationSeries_Period.resolution", ns))
             {
-                resolution = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
+                resolution = reader.ReadString();
             }
             else if (reader.Depth == 3 && reader.Is("type", ns))
             {

--- a/source/Tests/CimMessageAdapter/Messages/WholesaleSettlementMessageParsers/MessageParserTests.cs
+++ b/source/Tests/CimMessageAdapter/Messages/WholesaleSettlementMessageParsers/MessageParserTests.cs
@@ -12,13 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.IncomingMessages.Application.MessageParser;
@@ -35,7 +29,8 @@ namespace Energinet.DataHub.EDI.Tests.CimMessageAdapter.Messages.WholesaleSettle
 
 public class MessageParserTests
 {
-    private const string SeriesDummy = "{\"mRID\":\"25836143\",\"aggregationSeries_Period.resolution\":\"PT1M\",\"chargeTypeOwner_MarketParticipant.mRID\":{\"codingScheme\":\"A10\",\"value\":\"570001110111\"},\"end_DateAndOrTime.dateTime\": \"2022-08-31T22:00:00Z\",\"energySupplier_MarketParticipant.mRID\":{\"codingScheme\":\"A10\",\"value\":\"5799999933318\"},\"meteringGridArea_Domain.mRID\":{\"codingScheme\": \"NDK\",\"value\":\"244\"},\"settlement_Series.version\":{\"value\":\"D01\"},\"start_DateAndOrTime.dateTime\":\"2022-08-17T22:00:00Z\",\"ChargeType\":[{\"mRID\":\"EA-001\",\"type\":{\"value\":\"D03\"}}]},";
+    private const string SeriesDummy =
+        "{\"mRID\":\"25836143\",\"aggregationSeries_Period.resolution\":\"P1M\",\"chargeTypeOwner_MarketParticipant.mRID\":{\"codingScheme\":\"A10\",\"value\":\"570001110111\"},\"end_DateAndOrTime.dateTime\": \"2022-08-31T22:00:00Z\",\"energySupplier_MarketParticipant.mRID\":{\"codingScheme\":\"A10\",\"value\":\"5799999933318\"},\"meteringGridArea_Domain.mRID\":{\"codingScheme\": \"NDK\",\"value\":\"244\"},\"settlement_Series.version\":{\"value\":\"D01\"},\"start_DateAndOrTime.dateTime\":\"2022-08-17T22:00:00Z\",\"ChargeType\":[{\"mRID\":\"EA-001\",\"type\":{\"value\":\"D03\"}}]},";
 
     private static readonly string PathToMessages =
         $"cimmessageadapter{Path.DirectorySeparatorChar}messages{Path.DirectorySeparatorChar}";
@@ -115,7 +110,6 @@ public class MessageParserTests
         {
             Assert.NotNull(serie);
             Assert.Equal("25836143", serie.TransactionId);
-            Assert.Equal("PT1M", serie.Resolution);
             Assert.Equal("570001110111", serie.ChargeOwner);
             Assert.Equal("5799999933318", serie.EnergySupplierId);
             Assert.Equal("2022-08-31T22:00:00Z", serie.EndDateTime);
@@ -125,6 +119,7 @@ public class MessageParserTests
             Assert.Single(serie.ChargeTypes);
             Assert.Equal("EA-001", serie.ChargeTypes.First().Id);
             Assert.Equal("D03", serie.ChargeTypes.First().Type);
+            Assert.Equal("P1M", serie.Resolution);
         }
     }
 

--- a/source/Tests/CimMessageAdapter/Messages/json/WholesaleSettlement/RequestWholesaleSettlement.json
+++ b/source/Tests/CimMessageAdapter/Messages/json/WholesaleSettlement/RequestWholesaleSettlement.json
@@ -28,7 +28,7 @@
 		"Series": [
       {
         "mRID": "25836143",
-        "aggregationSeries_Period.resolution": "PT1M",
+        "aggregationSeries_Period.resolution": "P1M",
         "chargeTypeOwner_MarketParticipant.mRID": {
           "codingScheme": "A10",
           "value": "570001110111"

--- a/source/Tests/CimMessageAdapter/Messages/xml/WholesaleSettlement/RequestWholesaleSettlement.xml
+++ b/source/Tests/CimMessageAdapter/Messages/xml/WholesaleSettlement/RequestWholesaleSettlement.xml
@@ -18,7 +18,7 @@
         <cim:meteringGridArea_Domain.mRID codingScheme="NDK">244</cim:meteringGridArea_Domain.mRID>
         <cim:energySupplier_MarketParticipant.mRID codingScheme="A10">5799999933318</cim:energySupplier_MarketParticipant.mRID>
         <cim:chargeTypeOwner_MarketParticipant.mRID codingScheme="A10">570001110111</cim:chargeTypeOwner_MarketParticipant.mRID>
-        <cim:aggregationSeries_Period.resolution>PT1M</cim:aggregationSeries_Period.resolution> <!-- kun i forbindelse med BRS-030 -->
+        <cim:aggregationSeries_Period.resolution>P1M</cim:aggregationSeries_Period.resolution> <!-- kun i forbindelse med BRS-030 -->
         <cim:ChargeType>
             <cim:type>D03</cim:type>
             <cim:mRID>EA-001</cim:mRID>

--- a/source/Tests/CimMessageAdapter/Messages/xml/WholesaleSettlement/RequestWholesaleSettlementTwoSeries.xml
+++ b/source/Tests/CimMessageAdapter/Messages/xml/WholesaleSettlement/RequestWholesaleSettlementTwoSeries.xml
@@ -18,7 +18,7 @@
         <cim:meteringGridArea_Domain.mRID codingScheme="NDK">244</cim:meteringGridArea_Domain.mRID>
         <cim:energySupplier_MarketParticipant.mRID codingScheme="A10">5799999933318</cim:energySupplier_MarketParticipant.mRID>
         <cim:chargeTypeOwner_MarketParticipant.mRID codingScheme="A10">570001110111</cim:chargeTypeOwner_MarketParticipant.mRID>
-        <cim:aggregationSeries_Period.resolution>PT1M</cim:aggregationSeries_Period.resolution> <!-- kun i forbindelse med BRS-030 -->
+        <cim:aggregationSeries_Period.resolution>P1M</cim:aggregationSeries_Period.resolution> <!-- kun i forbindelse med BRS-030 -->
         <cim:ChargeType>
             <cim:type>D03</cim:type>
             <cim:mRID>EA-001</cim:mRID>
@@ -32,7 +32,7 @@
         <cim:meteringGridArea_Domain.mRID codingScheme="NDK">244</cim:meteringGridArea_Domain.mRID>
         <cim:energySupplier_MarketParticipant.mRID codingScheme="A10">5799999933318</cim:energySupplier_MarketParticipant.mRID>
         <cim:chargeTypeOwner_MarketParticipant.mRID codingScheme="A10">570001110111</cim:chargeTypeOwner_MarketParticipant.mRID>
-        <cim:aggregationSeries_Period.resolution>PT1M</cim:aggregationSeries_Period.resolution> <!-- kun i forbindelse med BRS-030 -->
+        <cim:aggregationSeries_Period.resolution>P1M</cim:aggregationSeries_Period.resolution> <!-- kun i forbindelse med BRS-030 -->
         <cim:ChargeType>
             <cim:type>D03</cim:type>
             <cim:mRID>EA-001</cim:mRID>

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -62,6 +62,12 @@ limitations under the License.
       <None Remove="json\Reject request Change of Supplier.json" />
       <None Remove="json\Request Change of Supplier.json" />
       <None Remove="json\Invalid Request Change of Supplier.json" />
+      <None Update="CimMessageAdapter\Messages\json\WholesaleSettlement\RequestWholesaleSettlement.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="CimMessageAdapter\Messages\xml\WholesaleSettlement\RequestWholesaleSettlement.xml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
     <ItemGroup>
@@ -86,9 +92,9 @@ limitations under the License.
       <EmbeddedResource Include="CimMessageAdapter\Messages\xml\WholesaleSettlement\RequestWholesaleSettlementOneSmallOneBigSeries.xml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </EmbeddedResource>
-      <EmbeddedResource Include="CimMessageAdapter\Messages\xml\WholesaleSettlement\RequestWholesaleSettlementTwoSeries.xml">
+      <None Include="CimMessageAdapter\Messages\xml\WholesaleSettlement\RequestWholesaleSettlementTwoSeries.xml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </EmbeddedResource>
+      </None>
       <None Include="CimMessageAdapter\Messages\json\AggregatedMeasure\InvalidJsonAggregatedMeasureData.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
@@ -104,20 +110,12 @@ limitations under the License.
       <None Remove="CimMessageAdapter\Messages\xml\RequestChangeAccountingPointCharacteristics.xml" />
       <None Remove="CimMessageAdapter\Messages\xml\RequestChangeCustomerCharacteristics.xml" />
       <None Remove="CimMessageAdapter\Messages\json\AggregatedMeasure\Request Aggregated Measure Data.json" />
-      <None Remove="CimMessageAdapter\Messages\json\WholesaleSettlement\RequestWholesaleSettlement.json" />
-      <EmbeddedResource Include="CimMessageAdapter\Messages\json\WholesaleSettlement\RequestWholesaleSettlement.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </EmbeddedResource>
       <None Remove="CimMessageAdapter\Messages\json\WholesaleSettlement\InvalidRequestWholesaleSettlement.json" />
       <EmbeddedResource Include="CimMessageAdapter\Messages\json\WholesaleSettlement\InvalidJsonRequestWholesaleSettlement.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </EmbeddedResource>
       <None Remove="CimMessageAdapter\Messages\json\WholesaleSettlement\FailRequestWholesaleSettlement.json" />
       <EmbeddedResource Include="CimMessageAdapter\Messages\json\WholesaleSettlement\FailSchemeValidationRequestWholesaleSettlement.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </EmbeddedResource>
-      <None Remove="CimMessageAdapter\Messages\xml\WholesaleSettlement\RequestWholesaleSettlement.xml" />
-      <EmbeddedResource Include="CimMessageAdapter\Messages\xml\WholesaleSettlement\RequestWholesaleSettlement.xml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </EmbeddedResource>
     </ItemGroup>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
For some ungodly reason a xml request with resolution = "P1M" was translated to "P30D"
This is fixed now such that we do not alter the input, which we should not.

## References
