### PR TITLE
test: Add behavior test for calculation orchestration activities

### DIFF
--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerBrpGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerBrpGridAreaDescription.cs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.EnergyResults.Queries;
+using NodaTime;
+using Period = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Period;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.TestData;
 
@@ -32,4 +35,27 @@ public class EnergyResultPerBrpGridAreaDescription
     public override string GridAreaCode => "543";
 
     public override int ExpectedOutgoingMessagesCount => 20;
+
+    public Period Period => new(
+        Instant.FromUtc(2022, 1, 11, 23, 0, 0),
+        Instant.FromUtc(2022, 1, 12, 23, 0, 0));
+
+    public ExampleDataForActor<ExampleMessageForBalanceResponsible> ExampleBalanceResponsible => new(
+        ActorNumber: ActorNumber.Create("7080000729821"),
+        ExpectedOutgoingMessagesCount: 3,
+        ExampleMessageData: new ExampleMessageForBalanceResponsible(
+            GridArea: "543",
+            MeteringPointType.Consumption,
+            SettlementMethod.Flex,
+            Resolution.Hourly,
+            111));
 }
+
+public record ExampleDataForActor<TMessageData>(ActorNumber ActorNumber, int ExpectedOutgoingMessagesCount, TMessageData ExampleMessageData);
+
+public record ExampleMessageForBalanceResponsible(
+    string GridArea,
+    MeteringPointType MeteringPointType,
+    SettlementMethod SettlementMethod,
+    Resolution Resolution,
+    int Version);

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerBrpGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerBrpGridAreaDescription.cs
@@ -14,8 +14,11 @@
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.EnergyResults.Queries;
+using Energinet.DataHub.Edi.Responses;
 using NodaTime;
+using NodaTime.Serialization.Protobuf;
 using Period = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Period;
+using Resolution = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Resolution;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.TestData;
 
@@ -48,7 +51,27 @@ public class EnergyResultPerBrpGridAreaDescription
             MeteringPointType.Consumption,
             SettlementMethod.Flex,
             Resolution.Hourly,
-            111));
+            111,
+            CreatePointsForDay(
+                Period.Start,
+                1211.912m,
+                QuantityQuality.Measured)));
+
+    private IReadOnlyCollection<TimeSeriesPoint> CreatePointsForDay(Instant start, decimal quantity, QuantityQuality quality)
+    {
+        var points = new List<TimeSeriesPoint>();
+        for (var i = 0; i < 24; i++)
+        {
+            points.Add(new TimeSeriesPoint
+            {
+                Time = start.Plus(Duration.FromHours(i)).ToTimestamp(),
+                Quantity = DecimalValue.FromDecimal(quantity),
+                QuantityQualities = { quality },
+            });
+        }
+
+        return points;
+    }
 }
 
 public record ExampleDataForActor<TMessageData>(ActorNumber ActorNumber, int ExpectedOutgoingMessagesCount, TMessageData ExampleMessageData);
@@ -58,4 +81,5 @@ public record ExampleMessageForBalanceResponsible(
     MeteringPointType MeteringPointType,
     SettlementMethod SettlementMethod,
     Resolution Resolution,
-    int Version);
+    int Version,
+    IReadOnlyCollection<TimeSeriesPoint> Points);

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerBrpGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerBrpGridAreaDescription.cs
@@ -65,7 +65,7 @@ public record ExampleDataForActor<TMessageData>(ActorNumber ActorNumber, int Exp
 public record ExampleMessageForActor(
     string GridArea,
     MeteringPointType MeteringPointType,
-    SettlementMethod SettlementMethod,
+    SettlementMethod? SettlementMethod,
     Resolution Resolution,
     int Version,
     IReadOnlyCollection<TimeSeriesPointAssertionInput> Points);

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerBrpGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerBrpGridAreaDescription.cs
@@ -53,6 +53,7 @@ public class EnergyResultPerBrpGridAreaDescription
             MeteringPointType.Consumption,
             SettlementMethod.Flex,
             Resolution.Hourly,
+            null,
             111,
             TimeSeriesPointsFactory.CreatePointsForDay(
                 Period.Start,
@@ -67,5 +68,6 @@ public record ExampleMessageForActor(
     MeteringPointType MeteringPointType,
     SettlementMethod? SettlementMethod,
     Resolution Resolution,
+    ActorNumber? EnergySupplier,
     int Version,
     IReadOnlyCollection<TimeSeriesPointAssertionInput> Points);

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerBrpGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerBrpGridAreaDescription.cs
@@ -42,10 +42,10 @@ public class EnergyResultPerBrpGridAreaDescription
         Instant.FromUtc(2022, 1, 11, 23, 0, 0),
         Instant.FromUtc(2022, 1, 12, 23, 0, 0));
 
-    public ExampleDataForActor<ExampleMessageForActor> ExampleBalanceResponsible => new(
+    public ExampleDataForActor<ExampleEnergyResultMessageForActor> ExampleBalanceResponsible => new(
         ActorNumber: ActorNumber.Create("7080000729821"),
         ExpectedOutgoingMessagesCount: 3,
-        ExampleMessageData: new ExampleMessageForActor(
+        ExampleMessageData: new ExampleEnergyResultMessageForActor(
             GridArea: "543",
             MeteringPointType.Consumption,
             SettlementMethod.Flex,

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerBrpGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerBrpGridAreaDescription.cs
@@ -15,10 +15,7 @@
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.IntegrationTests.Factories;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.EnergyResults.Queries;
-using Energinet.DataHub.Edi.Responses;
-using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
 using NodaTime;
-using NodaTime.Serialization.Protobuf;
 using Period = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Period;
 using Resolution = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Resolution;
 
@@ -60,14 +57,3 @@ public class EnergyResultPerBrpGridAreaDescription
                 1211.912m,
                 CalculatedQuantityQuality.Measured)));
 }
-
-public record ExampleDataForActor<TMessageData>(ActorNumber ActorNumber, int ExpectedOutgoingMessagesCount, TMessageData ExampleMessageData);
-
-public record ExampleMessageForActor(
-    string GridArea,
-    MeteringPointType MeteringPointType,
-    SettlementMethod? SettlementMethod,
-    Resolution Resolution,
-    ActorNumber? EnergySupplier,
-    int Version,
-    IReadOnlyCollection<TimeSeriesPointAssertionInput> Points);

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerEnergySupplierBrpGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerEnergySupplierBrpGridAreaDescription.cs
@@ -41,10 +41,10 @@ public class EnergyResultPerEnergySupplierBrpGridAreaDescription
         Instant.FromUtc(2022, 1, 11, 23, 0, 0),
         Instant.FromUtc(2022, 1, 12, 23, 0, 0));
 
-    public ExampleDataForActor<ExampleMessageForActor> ExampleEnergySupplier => new(
+    public ExampleDataForActor<ExampleEnergyResultMessageForActor> ExampleEnergySupplier => new(
         ActorNumber: ActorNumber.Create("5790002105289"),
         ExpectedOutgoingMessagesCount: 2,
-        ExampleMessageData: new ExampleMessageForActor(
+        ExampleMessageData: new ExampleEnergyResultMessageForActor(
             GridArea: "543",
             MeteringPointType.Consumption,
             SettlementMethod.NonProfiled,
@@ -56,10 +56,10 @@ public class EnergyResultPerEnergySupplierBrpGridAreaDescription
                 3011.368m,
                 CalculatedQuantityQuality.Incomplete)));
 
-    public ExampleDataForActor<ExampleMessageForActor> ExampleBalanceResponsible => new(
+    public ExampleDataForActor<ExampleEnergyResultMessageForActor> ExampleBalanceResponsible => new(
         ActorNumber: ActorNumber.Create("7080000729821"),
         ExpectedOutgoingMessagesCount: 5,
-        ExampleMessageData: new ExampleMessageForActor(
+        ExampleMessageData: new ExampleEnergyResultMessageForActor(
             GridArea: "543",
             MeteringPointType.Production,
             null,

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerEnergySupplierBrpGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerEnergySupplierBrpGridAreaDescription.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.EnergyResults.Queries;
+using NodaTime;
+using Period = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Period;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.TestData;
 
@@ -32,4 +34,8 @@ public class EnergyResultPerEnergySupplierBrpGridAreaDescription
     public override string GridAreaCode => "543";
 
     public override int ExpectedOutgoingMessagesCount => 35 * 2; // 35 results, which we must prepare for BRP and ES
+
+    public override Period Period => new(
+        Instant.FromUtc(2022, 1, 11, 23, 0, 0),
+        Instant.FromUtc(2022, 1, 12, 23, 0, 0));
 }

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerEnergySupplierBrpGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerEnergySupplierBrpGridAreaDescription.cs
@@ -49,6 +49,7 @@ public class EnergyResultPerEnergySupplierBrpGridAreaDescription
             MeteringPointType.Consumption,
             SettlementMethod.NonProfiled,
             Resolution.Hourly,
+            ActorNumber.Create("5790002105289"),
             111,
             TimeSeriesPointsFactory.CreatePointsForDay(
                 Period.Start,
@@ -57,12 +58,13 @@ public class EnergyResultPerEnergySupplierBrpGridAreaDescription
 
     public ExampleDataForActor<ExampleMessageForActor> ExampleBalanceResponsible => new(
         ActorNumber: ActorNumber.Create("7080000729821"),
-        ExpectedOutgoingMessagesCount: 2,
+        ExpectedOutgoingMessagesCount: 5,
         ExampleMessageData: new ExampleMessageForActor(
             GridArea: "543",
             MeteringPointType.Production,
             null,
             Resolution.Hourly,
+            ActorNumber.Create("7080000729821"),
             111,
             TimeSeriesPointsFactory.CreatePointsForDay(
                 Period.Start,

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerEnergySupplierBrpGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerEnergySupplierBrpGridAreaDescription.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.IntegrationTests.Factories;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.EnergyResults.Queries;
 using NodaTime;
 using Period = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Period;
@@ -38,4 +40,32 @@ public class EnergyResultPerEnergySupplierBrpGridAreaDescription
     public override Period Period => new(
         Instant.FromUtc(2022, 1, 11, 23, 0, 0),
         Instant.FromUtc(2022, 1, 12, 23, 0, 0));
+
+    public ExampleDataForActor<ExampleMessageForActor> ExampleEnergySupplier => new(
+        ActorNumber: ActorNumber.Create("5790002105289"),
+        ExpectedOutgoingMessagesCount: 2,
+        ExampleMessageData: new ExampleMessageForActor(
+            GridArea: "543",
+            MeteringPointType.Consumption,
+            SettlementMethod.NonProfiled,
+            Resolution.Hourly,
+            111,
+            TimeSeriesPointsFactory.CreatePointsForDay(
+                Period.Start,
+                3011.368m,
+                CalculatedQuantityQuality.Incomplete)));
+
+    public ExampleDataForActor<ExampleMessageForActor> ExampleBalanceResponsible => new(
+        ActorNumber: ActorNumber.Create("7080000729821"),
+        ExpectedOutgoingMessagesCount: 2,
+        ExampleMessageData: new ExampleMessageForActor(
+            GridArea: "543",
+            MeteringPointType.Production,
+            null,
+            Resolution.Hourly,
+            111,
+            TimeSeriesPointsFactory.CreatePointsForDay(
+                Period.Start,
+                39471.336m,
+                CalculatedQuantityQuality.Measured)));
 }

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerGridAreaDescription.cs
@@ -15,7 +15,6 @@
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.IntegrationTests.Factories;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.EnergyResults.Queries;
-using Energinet.DataHub.Edi.Responses;
 using NodaTime;
 using Period = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Period;
 using Resolution = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Resolution;

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerGridAreaDescription.cs
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.IntegrationTests.Factories;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.EnergyResults.Queries;
+using Energinet.DataHub.Edi.Responses;
+using NodaTime;
+using Period = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Period;
+using Resolution = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Resolution;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.TestData;
 
@@ -33,4 +38,19 @@ public class EnergyResultPerGridAreaDescription
     public override string GridAreaCode => "543";
 
     public override int ExpectedOutgoingMessagesCount => 5;
+
+    public override Period Period => new(
+        Instant.FromUtc(2022, 1, 11, 23, 0, 0),
+        Instant.FromUtc(2022, 1, 12, 23, 0, 0));
+
+    public ExampleMessageForActor ExampleMessageData => new(
+        GridArea: GridAreaCode,
+        MeteringPointType.Consumption,
+        SettlementMethod.Flex,
+        Resolution.Hourly,
+        111,
+        TimeSeriesPointsFactory.CreatePointsForDay(
+            Period.Start,
+            1928898.153m,
+            CalculatedQuantityQuality.Incomplete));
 }

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerGridAreaDescription.cs
@@ -42,7 +42,7 @@ public class EnergyResultPerGridAreaDescription
         Instant.FromUtc(2022, 1, 11, 23, 0, 0),
         Instant.FromUtc(2022, 1, 12, 23, 0, 0));
 
-    public ExampleMessageForActor ExampleMessageData => new(
+    public ExampleEnergyResultMessageForActor ExampleEnergyResultMessageData => new(
         GridArea: GridAreaCode,
         MeteringPointType.Consumption,
         SettlementMethod.Flex,

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerGridAreaDescription.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.EnergyResults.Queries;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.TestData;

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerGridAreaDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultPerGridAreaDescription.cs
@@ -48,6 +48,7 @@ public class EnergyResultPerGridAreaDescription
         MeteringPointType.Consumption,
         SettlementMethod.Flex,
         Resolution.Hourly,
+        null,
         111,
         TimeSeriesPointsFactory.CreatePointsForDay(
             Period.Start,

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultTestDataDescription.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/EnergyResultTestDataDescription.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.TestData;
 
 /// <summary>
@@ -46,4 +48,9 @@ public abstract class EnergyResultTestDataDescription
     /// Expected outgoing messages based on test file content.
     /// </summary>
     public abstract int ExpectedOutgoingMessagesCount { get; }
+
+    /// <summary>
+    /// Period start/end matching the file content.
+    /// </summary>
+    public abstract Period Period { get;  }
 }

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/ExampleDataForActor.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/ExampleDataForActor.cs
@@ -1,0 +1,19 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+
+namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.TestData;
+
+public record ExampleDataForActor<TMessageData>(ActorNumber ActorNumber, int ExpectedOutgoingMessagesCount, TMessageData ExampleMessageData);

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/ExampleEnergyResultMessageForActor.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/ExampleEnergyResultMessageForActor.cs
@@ -17,7 +17,7 @@ using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.TestData;
 
-public record ExampleMessageForActor(
+public record ExampleEnergyResultMessageForActor(
     string GridArea,
     MeteringPointType MeteringPointType,
     SettlementMethod? SettlementMethod,

--- a/source/IntegrationTests/Application/OutgoingMessages/TestData/ExampleMessageForActor.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/TestData/ExampleMessageForActor.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
+
+namespace Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.TestData;
+
+public record ExampleMessageForActor(
+    string GridArea,
+    MeteringPointType MeteringPointType,
+    SettlementMethod? SettlementMethod,
+    Resolution Resolution,
+    ActorNumber? EnergySupplier,
+    int Version,
+    IReadOnlyCollection<TimeSeriesPointAssertionInput> Points);

--- a/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
+++ b/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
-using AutoFixture;
 using Azure.Messaging.ServiceBus;
 using BuildingBlocks.Application.Extensions.DependencyInjection;
 using BuildingBlocks.Application.Extensions.Options;

--- a/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
+++ b/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using AutoFixture;
 using Azure.Messaging.ServiceBus;
 using BuildingBlocks.Application.Extensions.DependencyInjection;
 using BuildingBlocks.Application.Extensions.Options;
@@ -44,6 +45,7 @@ using Energinet.DataHub.EDI.MasterData.Application.Extensions.DependencyInjectio
 using Energinet.DataHub.EDI.MasterData.Interfaces;
 using Energinet.DataHub.EDI.MasterData.Interfaces.Models;
 using Energinet.DataHub.EDI.OutgoingMessages.Application.Extensions.DependencyInjection;
+using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Extensions.Options;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models;
 using Energinet.DataHub.EDI.Process.Application.Extensions.DependencyInjection;
@@ -126,12 +128,16 @@ public class BehavioursTestBase : IDisposable
     private readonly AuthenticatedActor _authenticatedActor;
     private readonly DateTimeZone _dateTimeZone;
     private readonly ServiceProvider _serviceProvider;
+    private readonly IntegrationTestFixture _integrationTestFixture;
     private ServiceCollection? _services;
     private bool _disposed;
 
     protected BehavioursTestBase(IntegrationTestFixture integrationTestFixture, ITestOutputHelper testOutputHelper)
     {
         ArgumentNullException.ThrowIfNull(integrationTestFixture);
+
+        _integrationTestFixture = integrationTestFixture;
+
         IntegrationTestFixture.CleanupDatabase();
         integrationTestFixture.CleanupFileStorage();
         _serviceBusSenderFactoryStub = new ServiceBusSenderFactoryStub();
@@ -139,7 +145,7 @@ public class BehavioursTestBase : IDisposable
         InboxEventNotificationHandler = new TestNotificationHandlerSpy();
         _systemDateTimeProviderStub = new SystemDateTimeProviderStub();
         _dateTimeZone = DateTimeZoneProviders.Tzdb["Europe/Copenhagen"];
-        _serviceProvider = BuildServices(integrationTestFixture.AzuriteManager.BlobStorageConnectionString, testOutputHelper);
+        _serviceProvider = BuildServices(testOutputHelper);
         _processContext = GetService<ProcessContext>();
         _incomingMessagesContext = GetService<IncomingMessagesContext>();
         _authenticatedActor = GetService<AuthenticatedActor>();
@@ -418,11 +424,11 @@ public class BehavioursTestBase : IDisposable
             .Publish(new TenSecondsHasHasPassed(datetimeProvider.Now()));
     }
 
-    private ServiceProvider BuildServices(string fileStorageConnectionString, ITestOutputHelper testOutputHelper)
+    private ServiceProvider BuildServices(ITestOutputHelper testOutputHelper)
     {
         Environment.SetEnvironmentVariable("FEATUREFLAG_ACTORMESSAGEQUEUE", "true");
         Environment.SetEnvironmentVariable("DB_CONNECTION_STRING", IntegrationTestFixture.DatabaseConnectionString);
-        Environment.SetEnvironmentVariable("AZURE_STORAGE_ACCOUNT_CONNECTION_STRING", fileStorageConnectionString);
+        Environment.SetEnvironmentVariable("AZURE_STORAGE_ACCOUNT_CONNECTION_STRING", _integrationTestFixture.AzuriteManager.BlobStorageConnectionString);
 
         var config = new ConfigurationBuilder()
             .AddEnvironmentVariables()
@@ -439,9 +445,12 @@ public class BehavioursTestBase : IDisposable
                     ["IntegrationEvents:SubscriptionName"] = "NotEmpty",
 
                     // Databricks
-                    [nameof(DatabricksSqlStatementOptions.WorkspaceUrl)] = "https://adb-1000.azuredatabricks.net/",
-                    [nameof(DatabricksSqlStatementOptions.WorkspaceToken)] = "FakeToken",
-                    [nameof(DatabricksSqlStatementOptions.WarehouseId)] = Guid.NewGuid().ToString(),
+                    [nameof(DatabricksSqlStatementOptions.WorkspaceUrl)] = _integrationTestFixture.IntegrationTestConfiguration.DatabricksSettings.WorkspaceUrl,
+                    [nameof(DatabricksSqlStatementOptions.WorkspaceToken)] = _integrationTestFixture.IntegrationTestConfiguration.DatabricksSettings.WorkspaceAccessToken,
+                    [nameof(DatabricksSqlStatementOptions.WarehouseId)] = _integrationTestFixture.IntegrationTestConfiguration.DatabricksSettings.WarehouseId,
+
+                    // => EDI views
+                    [$"{EdiDatabricksOptions.SectionName}:{nameof(EdiDatabricksOptions.DatabaseName)}"] = _integrationTestFixture.DatabricksSchemaManager.SchemaName,
                 })
             .Build();
 

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenAggregatedMeasureDataRequestTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenAggregatedMeasureDataRequestTests.cs
@@ -21,6 +21,7 @@ using Energinet.DataHub.EDI.IntegrationTests.DocumentAsserters;
 using Energinet.DataHub.EDI.IntegrationTests.EventBuilders;
 using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models;
+using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using NodaTime;
@@ -193,7 +194,7 @@ public class GivenAggregatedMeasureDataRequestTests : AggregatedMeasureDataBehav
                 Period: new Period(
                     CreateDateInstant(2024, 1, 1),
                     CreateDateInstant(2024, 1, 31)),
-                Points: acceptedResponse.Series.Single().TimeSeriesPoints));
+                Points: TimeSeriesPointAssertionInput.From(acceptedResponse.Series.Single().TimeSeriesPoints)));
     }
 
     [Theory]
@@ -316,7 +317,7 @@ public class GivenAggregatedMeasureDataRequestTests : AggregatedMeasureDataBehav
                     Period: new Period(
                         CreateDateInstant(2024, 1, 1),
                         CreateDateInstant(2024, 1, 31)),
-                    Points: seriesRequest.TimeSeriesPoints));
+                    Points: TimeSeriesPointAssertionInput.From(seriesRequest.TimeSeriesPoints)));
         }
 
         resultGridAreas.Should().BeEquivalentTo("106", "509");
@@ -439,7 +440,7 @@ public class GivenAggregatedMeasureDataRequestTests : AggregatedMeasureDataBehav
                 Period: new Period(
                     CreateDateInstant(2024, 1, 1),
                     CreateDateInstant(2024, 1, 31)),
-                Points: acceptedResponse.Series.Single().TimeSeriesPoints));
+                Points: TimeSeriesPointAssertionInput.From(acceptedResponse.Series.Single().TimeSeriesPoints)));
     }
 
     [Theory]
@@ -605,7 +606,7 @@ public class GivenAggregatedMeasureDataRequestTests : AggregatedMeasureDataBehav
                     Period: new Period(
                         CreateDateInstant(2024, 1, 1),
                         CreateDateInstant(2024, 1, 31)),
-                    Points: acceptedResponse.AcceptedResponse.Series.Single().TimeSeriesPoints));
+                    Points: TimeSeriesPointAssertionInput.From(acceptedResponse.AcceptedResponse.Series.Single().TimeSeriesPoints)));
         }
 
         gridAreas.Should().BeEquivalentTo("143", "512", "877");

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenAggregatedMeasureDataRequestWithDelegationTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenAggregatedMeasureDataRequestWithDelegationTests.cs
@@ -24,6 +24,7 @@ using Energinet.DataHub.EDI.IntegrationTests.EventBuilders;
 using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models;
 using Energinet.DataHub.Edi.Responses;
+using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using NodaTime;
@@ -226,7 +227,7 @@ public class GivenAggregatedMeasureDataRequestWithDelegationTests : AggregatedMe
                 Period: new Period(
                     CreateDateInstant(2024, 1, 1),
                     CreateDateInstant(2024, 1, 31)),
-                Points: aggregatedMeasureDataRequestAcceptedMessage.Series.Single().TimeSeriesPoints));
+                Points: TimeSeriesPointAssertionInput.From(aggregatedMeasureDataRequestAcceptedMessage.Series.Single().TimeSeriesPoints)));
     }
 
     /// <summary>
@@ -493,7 +494,7 @@ public class GivenAggregatedMeasureDataRequestWithDelegationTests : AggregatedMe
                 Period: new Period(
                     CreateDateInstant(2024, 1, 1),
                     CreateDateInstant(2024, 1, 31)),
-                Points: aggregatedMeasureDataRequestAcceptedMessage.Series.Single().TimeSeriesPoints));
+                Points: TimeSeriesPointAssertionInput.From(aggregatedMeasureDataRequestAcceptedMessage.Series.Single().TimeSeriesPoints)));
     }
 
     [Theory]
@@ -641,7 +642,7 @@ public class GivenAggregatedMeasureDataRequestWithDelegationTests : AggregatedMe
                     Period: new Period(
                         CreateDateInstant(2024, 1, 1),
                         CreateDateInstant(2024, 1, 31)),
-                    Points: seriesRequest.TimeSeriesPoints));
+                    Points: TimeSeriesPointAssertionInput.From(seriesRequest.TimeSeriesPoints)));
         }
 
         resultGridAreas.Should().BeEquivalentTo("512", "609");
@@ -924,7 +925,7 @@ public class GivenAggregatedMeasureDataRequestWithDelegationTests : AggregatedMe
                     Period: new Period(
                         CreateDateInstant(2024, 1, 1),
                         CreateDateInstant(2024, 1, 31)),
-                    Points: seriesRequest.TimeSeriesPoints));
+                    Points: TimeSeriesPointAssertionInput.From(seriesRequest.TimeSeriesPoints)));
         }
 
         resultGridAreas.Should().BeEquivalentTo("106", "512", "804");

--- a/source/IntegrationTests/Behaviours/IntegrationEvents/GivenCalculationCompletedV1ReceivedForBalanceFixingTests.cs
+++ b/source/IntegrationTests/Behaviours/IntegrationEvents/GivenCalculationCompletedV1ReceivedForBalanceFixingTests.cs
@@ -219,8 +219,6 @@ public class GivenCalculationCompletedV1ReceivedTests : AggregatedMeasureDataBeh
         DocumentFormat documentFormat,
         NotifyAggregatedMeasureDataDocumentAssertionInput assertionInput)
     {
-        using var assertionScope = new AssertionScope();
-
         // We need to assert that one of the messages is correct and don't care about the rest. However we have no
         // way of knowing which message is the correct one, so we will assert all of them and count the number of
         // failed/successful assertions.
@@ -230,10 +228,13 @@ public class GivenCalculationCompletedV1ReceivedTests : AggregatedMeasureDataBeh
         {
             try
             {
-                await ThenNotifyAggregatedMeasureDataDocumentIsCorrect(
-                    peekResultDto.Bundle,
-                    documentFormat,
-                    assertionInput);
+                using (new AssertionScope())
+                {
+                    await ThenNotifyAggregatedMeasureDataDocumentIsCorrect(
+                        peekResultDto.Bundle,
+                        documentFormat,
+                        assertionInput);
+                }
 
                 successfulAssertions++;
             }

--- a/source/IntegrationTests/Behaviours/IntegrationEvents/GivenCalculationCompletedV1ReceivedForBalanceFixingTests.cs
+++ b/source/IntegrationTests/Behaviours/IntegrationEvents/GivenCalculationCompletedV1ReceivedForBalanceFixingTests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.B2BApi.Functions.EnqueueMessages.Activities;
+using Energinet.DataHub.EDI.B2BApi.Functions.EnqueueMessages.Model;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.IntegrationTests.Application.OutgoingMessages.TestData;
+using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
+using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.EnergyResults.Queries;
+using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.SqlStatements;
+using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Extensions.Options;
+using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NodaTime;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Energinet.DataHub.EDI.IntegrationTests.Behaviours.IntegrationEvents;
+
+public class GivenCalculationCompletedV1ReceivedTests : AggregatedMeasureDataBehaviourTestBase, IAsyncLifetime
+{
+    private readonly IntegrationTestFixture _fixture;
+    private readonly EnergyResultPerGridAreaDescription _energyResultPerGridAreaTestDataDescription;
+
+    public GivenCalculationCompletedV1ReceivedTests(
+        IntegrationTestFixture integrationTestFixture,
+        ITestOutputHelper testOutputHelper)
+            : base(integrationTestFixture, testOutputHelper)
+    {
+        _fixture = integrationTestFixture;
+        _energyResultPerGridAreaTestDataDescription = new EnergyResultPerGridAreaDescription();
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.DatabricksSchemaManager.CreateSchemaAsync();
+        var ediDatabricksOptions = GetService<IOptions<EdiDatabricksOptions>>();
+
+        var energyResultPerGridAreaQuery = new EnergyResultPerGridAreaQuery(ediDatabricksOptions.Value, _energyResultPerGridAreaTestDataDescription.CalculationId);
+
+        await SeedDatabricksWithDataAsync(_energyResultPerGridAreaTestDataDescription, energyResultPerGridAreaQuery);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DatabricksSchemaManager.DropSchemaAsync();
+    }
+
+    [Theory]
+    [MemberData(nameof(DocumentFormats.AllDocumentFormats), MemberType = typeof(DocumentFormats))]
+    public async Task AndGiven_CalculationIsBalanceFixing_WhenGridOperatorPeeksMessages_ThenReceivesCorrectNotifyAggregatedMeasureDataDocuments(DocumentFormat documentFormat)
+    {
+        // Given (arrange)
+        GivenNowIs(Instant.FromUtc(2022, 09, 07, 13, 37, 05));
+        var gridOperator = new Actor(ActorNumber.Create("1111111111111"), ActorRole.GridOperator);
+        var gridArea = _energyResultPerGridAreaTestDataDescription.GridAreaCode;
+        var calculationId = _energyResultPerGridAreaTestDataDescription.CalculationId;
+
+        await GivenGridAreaOwnershipAsync(gridArea, gridOperator.ActorNumber);
+        await GivenEnqueueEnergyResultsForGridAreaOwnersAsync(calculationId);
+
+        // When (act)
+        var peekResultsForGridOperator = await WhenActorPeeksAllMessages(
+            gridOperator.ActorNumber,
+            gridOperator.ActorRole,
+            documentFormat);
+
+        // Then (assert)
+        peekResultsForGridOperator.Should().HaveCount(_energyResultPerGridAreaTestDataDescription.ExpectedOutgoingMessagesCount);
+
+        // TODO: Assert correct document content
+    }
+
+    private Task GivenEnqueueEnergyResultsForGridAreaOwnersAsync(Guid calculationId)
+    {
+        var activity = new EnqueueEnergyResultsForGridAreaOwnersActivity(
+            GetService<IOutgoingMessagesClient>());
+
+        return activity.Run(new EnqueueMessagesInput(calculationId, Guid.NewGuid()));
+    }
+
+    private async Task SeedDatabricksWithDataAsync(EnergyResultTestDataDescription testDataDescription, IDeltaTableSchemaDescription schemaInfomation)
+    {
+        await _fixture.DatabricksSchemaManager.CreateTableAsync(schemaInfomation);
+        await _fixture.DatabricksSchemaManager.InsertFromCsvFileAsync(schemaInfomation, testDataDescription.TestFilePath);
+    }
+}

--- a/source/IntegrationTests/Behaviours/IntegrationEvents/GivenCalculationCompletedV1ReceivedForBalanceFixingTests.cs
+++ b/source/IntegrationTests/Behaviours/IntegrationEvents/GivenCalculationCompletedV1ReceivedForBalanceFixingTests.cs
@@ -63,17 +63,13 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
     {
         // Given (arrange)
         var testDataDescription = await GivenDatabricksResultDataForEnergyResultPerGridArea();
-        var expectedMessagesCount = testDataDescription.ExpectedOutgoingMessagesCount;
-        var expectedPeriod = testDataDescription.Period;
-        var exampleMessageData = testDataDescription.ExampleEnergyResultMessageData;
+        var testMessageData = testDataDescription.ExampleEnergyResultMessageData;
 
         GivenNowIs(Instant.FromUtc(2022, 09, 07, 13, 37, 05));
         var gridOperator = new Actor(ActorNumber.Create("1111111111111"), ActorRole.GridOperator);
-        var gridArea = testDataDescription.GridAreaCode;
-        var calculationId = testDataDescription.CalculationId;
 
-        await GivenGridAreaOwnershipAsync(gridArea, gridOperator.ActorNumber);
-        await GivenEnqueueEnergyResultsForGridOperatorsAsync(calculationId);
+        await GivenGridAreaOwnershipAsync(testDataDescription.GridAreaCode, gridOperator.ActorNumber);
+        await GivenEnqueueEnergyResultsForGridOperatorsAsync(testDataDescription.CalculationId);
 
         // When (act)
         var peekResultsForGridOperator = await WhenActorPeeksAllMessages(
@@ -82,7 +78,7 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
             documentFormat);
 
         // Then (assert)
-        peekResultsForGridOperator.Should().HaveCount(expectedMessagesCount);
+        peekResultsForGridOperator.Should().HaveCount(testDataDescription.ExpectedOutgoingMessagesCount);
 
         var assertionInput = new NotifyAggregatedMeasureDataDocumentAssertionInput(
             Timestamp: "2022-09-07T13:37:05Z",
@@ -95,16 +91,16 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
             // SenderRole: ActorRole.MeteredDataAdministrator,
             EnergySupplierNumber: null,
             BalanceResponsibleNumber: null,
-            SettlementMethod: exampleMessageData.SettlementMethod,
-            MeteringPointType: exampleMessageData.MeteringPointType,
-            GridAreaCode: exampleMessageData.GridArea,
+            SettlementMethod: testMessageData.SettlementMethod,
+            MeteringPointType: testMessageData.MeteringPointType,
+            GridAreaCode: testMessageData.GridArea,
             OriginalTransactionIdReference: null,
             ProductCode: ProductType.EnergyActive.Code,
             QuantityMeasurementUnit: MeasurementUnit.Kwh,
-            CalculationVersion: exampleMessageData.Version,
-            Resolution: exampleMessageData.Resolution,
-            Period: expectedPeriod,
-            Points: exampleMessageData.Points);
+            CalculationVersion: testMessageData.Version,
+            Resolution: testMessageData.Resolution,
+            Period: testDataDescription.Period,
+            Points: testMessageData.Points);
 
         await ThenOneOfNotifyAggregatedMeasureDataDocumentsAreCorrect(
             peekResultsForGridOperator,
@@ -119,17 +115,14 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
     {
         // Given (arrange)
         var testDataDescription = await GivenDatabricksResultDataForEnergyResultPerBalanceResponsible();
-        var (
-            balanceResponsibleActorNumber,
-            expectedMessagesCount,
-            exampleMessageData) = testDataDescription.ExampleBalanceResponsible;
+        var testMessageData = testDataDescription.ExampleBalanceResponsible.ExampleMessageData;
 
         GivenNowIs(Instant.FromUtc(2022, 09, 07, 13, 37, 05));
-        var balanceResponsible = new Actor(balanceResponsibleActorNumber, ActorRole.BalanceResponsibleParty);
-        var calculationId = testDataDescription.CalculationId;
-        var expectedPeriod = testDataDescription.Period;
+        var balanceResponsible = new Actor(
+            testDataDescription.ExampleBalanceResponsible.ActorNumber,
+            ActorRole.BalanceResponsibleParty);
 
-        await GivenEnqueueEnergyResultsForBalanceResponsibles(calculationId);
+        await GivenEnqueueEnergyResultsForBalanceResponsibles(testDataDescription.CalculationId);
 
         // When (act)
         var peekResultsForBalanceResponsible = await WhenActorPeeksAllMessages(
@@ -138,7 +131,7 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
             documentFormat);
 
         // Then (assert)
-        peekResultsForBalanceResponsible.Should().HaveCount(expectedMessagesCount);
+        peekResultsForBalanceResponsible.Should().HaveCount(testDataDescription.ExampleBalanceResponsible.ExpectedOutgoingMessagesCount);
 
         var assertionInput = new NotifyAggregatedMeasureDataDocumentAssertionInput(
             Timestamp: "2022-09-07T13:37:05Z",
@@ -151,16 +144,16 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
             // SenderRole: ActorRole.MeteredDataAdministrator,
             EnergySupplierNumber: null,
             BalanceResponsibleNumber: balanceResponsible.ActorNumber,
-            SettlementMethod: exampleMessageData.SettlementMethod,
-            MeteringPointType: exampleMessageData.MeteringPointType,
-            GridAreaCode: exampleMessageData.GridArea,
+            SettlementMethod: testMessageData.SettlementMethod,
+            MeteringPointType: testMessageData.MeteringPointType,
+            GridAreaCode: testMessageData.GridArea,
             OriginalTransactionIdReference: null,
             ProductCode: ProductType.EnergyActive.Code,
             QuantityMeasurementUnit: MeasurementUnit.Kwh,
-            CalculationVersion: exampleMessageData.Version,
-            Resolution: exampleMessageData.Resolution,
-            Period: expectedPeriod,
-            Points: exampleMessageData.Points);
+            CalculationVersion: testMessageData.Version,
+            Resolution: testMessageData.Resolution,
+            Period: testDataDescription.Period,
+            Points: testMessageData.Points);
 
         await ThenOneOfNotifyAggregatedMeasureDataDocumentsAreCorrect(
             peekResultsForBalanceResponsible,
@@ -175,23 +168,14 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
     {
         // Given (arrange)
         var testDataDescription = await GivenDatabricksResultDataForEnergyResultPerEnergySupplier();
-        var (
-            energySupplierActorNumber,
-            energySupplierExpectedMessagesCount,
-            energySupplierExampleMessageData) = testDataDescription.ExampleEnergySupplier;
-
-        var (
-            balanceResponsibleActorNumber,
-            balanceResponsibleExpectedMessagesCount,
-            balanceResponsibleExampleMessageData) = testDataDescription.ExampleBalanceResponsible;
+        var energySupplierTestMessageData = testDataDescription.ExampleEnergySupplier.ExampleMessageData;
+        var balanceResponsibleTestMessageData = testDataDescription.ExampleBalanceResponsible.ExampleMessageData;
 
         GivenNowIs(Instant.FromUtc(2022, 09, 07, 13, 37, 05));
-        var energySupplier = new Actor(energySupplierActorNumber, ActorRole.EnergySupplier);
-        var balanceResponsible = new Actor(balanceResponsibleActorNumber, ActorRole.BalanceResponsibleParty);
-        var calculationId = testDataDescription.CalculationId;
-        var expectedPeriod = testDataDescription.Period;
+        var energySupplier = new Actor(testDataDescription.ExampleEnergySupplier.ActorNumber, ActorRole.EnergySupplier);
+        var balanceResponsible = new Actor(testDataDescription.ExampleBalanceResponsible.ActorNumber, ActorRole.BalanceResponsibleParty);
 
-        await GivenEnqueueEnergyResultsForEnergySuppliers(calculationId);
+        await GivenEnqueueEnergyResultsForEnergySuppliers(testDataDescription.CalculationId);
 
         // When (act)
         var peekResultsForEnergySupplier = await WhenActorPeeksAllMessages(
@@ -207,7 +191,9 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
         // Then (assert)
 
         // Assert energy supplier peek result
-        peekResultsForEnergySupplier.Should().HaveCount(energySupplierExpectedMessagesCount);
+        peekResultsForEnergySupplier
+            .Should()
+            .HaveCount(testDataDescription.ExampleEnergySupplier.ExpectedOutgoingMessagesCount);
 
         var energySupplierAssertionInput = new NotifyAggregatedMeasureDataDocumentAssertionInput(
             Timestamp: "2022-09-07T13:37:05Z",
@@ -220,16 +206,16 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
             // SenderRole: ActorRole.MeteredDataAdministrator,
             EnergySupplierNumber: energySupplier.ActorNumber,
             BalanceResponsibleNumber: null,
-            SettlementMethod: energySupplierExampleMessageData.SettlementMethod,
-            MeteringPointType: energySupplierExampleMessageData.MeteringPointType,
-            GridAreaCode: energySupplierExampleMessageData.GridArea,
+            SettlementMethod: energySupplierTestMessageData.SettlementMethod,
+            MeteringPointType: energySupplierTestMessageData.MeteringPointType,
+            GridAreaCode: energySupplierTestMessageData.GridArea,
             OriginalTransactionIdReference: null,
             ProductCode: ProductType.EnergyActive.Code,
             QuantityMeasurementUnit: MeasurementUnit.Kwh,
-            CalculationVersion: energySupplierExampleMessageData.Version,
-            Resolution: energySupplierExampleMessageData.Resolution,
-            Period: expectedPeriod,
-            Points: energySupplierExampleMessageData.Points);
+            CalculationVersion: energySupplierTestMessageData.Version,
+            Resolution: energySupplierTestMessageData.Resolution,
+            Period: testDataDescription.Period,
+            Points: energySupplierTestMessageData.Points);
 
         await ThenOneOfNotifyAggregatedMeasureDataDocumentsAreCorrect(
             peekResultsForEnergySupplier,
@@ -237,7 +223,9 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
             energySupplierAssertionInput);
 
         // Assert balance responsible peek result
-        peekResultsForBalanceResponsible.Should().HaveCount(balanceResponsibleExpectedMessagesCount);
+        peekResultsForBalanceResponsible
+            .Should()
+            .HaveCount(testDataDescription.ExampleBalanceResponsible.ExpectedOutgoingMessagesCount);
 
         var balanceResponsibleAssertionInput = new NotifyAggregatedMeasureDataDocumentAssertionInput(
             Timestamp: "2022-09-07T13:37:05Z",
@@ -248,18 +236,18 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
             // ReceiverRole: originalActor.ActorRole,
             SenderId: ActorNumber.Create("5790001330552"), // Sender is always DataHub
             // SenderRole: ActorRole.MeteredDataAdministrator,
-            EnergySupplierNumber: balanceResponsibleExampleMessageData.EnergySupplier,
+            EnergySupplierNumber: balanceResponsibleTestMessageData.EnergySupplier,
             BalanceResponsibleNumber: balanceResponsible.ActorNumber,
-            SettlementMethod: balanceResponsibleExampleMessageData.SettlementMethod,
-            MeteringPointType: balanceResponsibleExampleMessageData.MeteringPointType,
-            GridAreaCode: balanceResponsibleExampleMessageData.GridArea,
+            SettlementMethod: balanceResponsibleTestMessageData.SettlementMethod,
+            MeteringPointType: balanceResponsibleTestMessageData.MeteringPointType,
+            GridAreaCode: balanceResponsibleTestMessageData.GridArea,
             OriginalTransactionIdReference: null,
             ProductCode: ProductType.EnergyActive.Code,
             QuantityMeasurementUnit: MeasurementUnit.Kwh,
-            CalculationVersion: balanceResponsibleExampleMessageData.Version,
-            Resolution: balanceResponsibleExampleMessageData.Resolution,
-            Period: expectedPeriod,
-            Points: balanceResponsibleExampleMessageData.Points);
+            CalculationVersion: balanceResponsibleTestMessageData.Version,
+            Resolution: balanceResponsibleTestMessageData.Resolution,
+            Period: testDataDescription.Period,
+            Points: balanceResponsibleTestMessageData.Points);
 
         await ThenOneOfNotifyAggregatedMeasureDataDocumentsAreCorrect(
             peekResultsForBalanceResponsible,
@@ -333,14 +321,15 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
         return energyResultPerEnergySupplierDescription;
     }
 
+    /// <summary>
+    /// Assert that one of the messages is correct and don't care about the rest. We have no way of knowing which
+    /// message is the correct one, so we will assert all of them and count the number of failed/successful assertions.
+    /// </summary>
     private async Task ThenOneOfNotifyAggregatedMeasureDataDocumentsAreCorrect(
         List<PeekResultDto> peekResults,
         DocumentFormat documentFormat,
         NotifyAggregatedMeasureDataDocumentAssertionInput assertionInput)
     {
-        // We need to assert that one of the messages is correct and don't care about the rest. However we have no
-        // way of knowing which message is the correct one, so we will assert all of them and count the number of
-        // failed/successful assertions.
         var failedAssertions = new List<Exception>();
         var successfulAssertions = 0;
         foreach (var peekResultDto in peekResults)

--- a/source/IntegrationTests/Behaviours/IntegrationEvents/GivenCalculationCompletedV1ReceivedForBalanceFixingTests.cs
+++ b/source/IntegrationTests/Behaviours/IntegrationEvents/GivenCalculationCompletedV1ReceivedForBalanceFixingTests.cs
@@ -65,7 +65,7 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
         var testDataDescription = await GivenDatabricksResultDataForEnergyResultPerGridArea();
         var expectedMessagesCount = testDataDescription.ExpectedOutgoingMessagesCount;
         var expectedPeriod = testDataDescription.Period;
-        var exampleMessageData = testDataDescription.ExampleMessageData;
+        var exampleMessageData = testDataDescription.ExampleEnergyResultMessageData;
 
         GivenNowIs(Instant.FromUtc(2022, 09, 07, 13, 37, 05));
         var gridOperator = new Actor(ActorNumber.Create("1111111111111"), ActorRole.GridOperator);

--- a/source/IntegrationTests/Behaviours/IntegrationEvents/GivenCalculationCompletedV1ReceivedForBalanceFixingTests.cs
+++ b/source/IntegrationTests/Behaviours/IntegrationEvents/GivenCalculationCompletedV1ReceivedForBalanceFixingTests.cs
@@ -248,7 +248,7 @@ public class GivenCalculationCompletedV1ReceivedForBalanceFixingTests : Aggregat
             // ReceiverRole: originalActor.ActorRole,
             SenderId: ActorNumber.Create("5790001330552"), // Sender is always DataHub
             // SenderRole: ActorRole.MeteredDataAdministrator,
-            EnergySupplierNumber: null,
+            EnergySupplierNumber: balanceResponsibleExampleMessageData.EnergySupplier,
             BalanceResponsibleNumber: balanceResponsible.ActorNumber,
             SettlementMethod: balanceResponsibleExampleMessageData.SettlementMethod,
             MeteringPointType: balanceResponsibleExampleMessageData.MeteringPointType,

--- a/source/IntegrationTests/DocumentAsserters/NotifyAggregatedMeasureDataDocumentAsserter.cs
+++ b/source/IntegrationTests/DocumentAsserters/NotifyAggregatedMeasureDataDocumentAsserter.cs
@@ -81,7 +81,6 @@ public static class NotifyAggregatedMeasureDataDocumentAsserter
             .HasGridAreaCode(assertionInput.GridAreaCode)
             .HasProductCode(assertionInput.ProductCode)
             .HasQuantityMeasurementUnit(assertionInput.QuantityMeasurementUnit)
-            .HasSettlementMethod(assertionInput.SettlementMethod)
             .HasResolution(assertionInput.Resolution)
             .HasPeriod(assertionInput.Period)
             .HasPoints(assertionInput.Points);
@@ -101,6 +100,11 @@ public static class NotifyAggregatedMeasureDataDocumentAsserter
         {
             asserter.SettlementVersionIsNotPresent();
         }
+
+        if (assertionInput.SettlementMethod is not null)
+            asserter.HasSettlementMethod(assertionInput.SettlementMethod);
+        else
+            asserter.SettlementMethodIsNotPresent();
 
         if (assertionInput.EnergySupplierNumber != null)
             asserter.HasEnergySupplierNumber(assertionInput.EnergySupplierNumber.Value);

--- a/source/IntegrationTests/DocumentAsserters/NotifyAggregatedMeasureDataDocumentAssertionInput.cs
+++ b/source/IntegrationTests/DocumentAsserters/NotifyAggregatedMeasureDataDocumentAssertionInput.cs
@@ -36,5 +36,5 @@ public record NotifyAggregatedMeasureDataDocumentAssertionInput(
     Period Period,
     Resolution Resolution,
     IReadOnlyCollection<TimeSeriesPointAssertionInput> Points,
-    SettlementMethod SettlementMethod,
+    SettlementMethod? SettlementMethod,
     TransactionId? OriginalTransactionIdReference);

--- a/source/IntegrationTests/DocumentAsserters/NotifyAggregatedMeasureDataDocumentAssertionInput.cs
+++ b/source/IntegrationTests/DocumentAsserters/NotifyAggregatedMeasureDataDocumentAssertionInput.cs
@@ -15,6 +15,7 @@
 using System.Collections.Generic;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Edi.Responses;
+using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
 using Period = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Period;
 using Resolution = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Resolution;
 
@@ -34,9 +35,6 @@ public record NotifyAggregatedMeasureDataDocumentAssertionInput(
     MeasurementUnit QuantityMeasurementUnit,
     Period Period,
     Resolution Resolution,
-    IReadOnlyCollection<TimeSeriesPoint> Points,
+    IReadOnlyCollection<TimeSeriesPointAssertionInput> Points,
     SettlementMethod SettlementMethod,
-    TransactionId? OriginalTransactionIdReference)
-{
-    public TransactionId? OriginalTransactionIdReference { get; set; } = OriginalTransactionIdReference;
-}
+    TransactionId? OriginalTransactionIdReference);

--- a/source/IntegrationTests/Factories/TimeSeriesPointsFactory.cs
+++ b/source/IntegrationTests/Factories/TimeSeriesPointsFactory.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
+using NodaTime;
+
+namespace Energinet.DataHub.EDI.IntegrationTests.Factories;
+
+internal static class TimeSeriesPointsFactory
+{
+    public static IReadOnlyCollection<TimeSeriesPointAssertionInput> CreatePointsForDay(
+        Instant start,
+        decimal quantity,
+        CalculatedQuantityQuality calculatedQuality)
+    {
+        var points = new List<TimeSeriesPointAssertionInput>();
+        for (var i = 0; i < 24; i++)
+        {
+            points.Add(new TimeSeriesPointAssertionInput(
+                start.Plus(Duration.FromHours(i)),
+                quantity,
+                calculatedQuality));
+        }
+
+        return points;
+    }
+}

--- a/source/Tests/Infrastructure/OutgoingMessages/Asserts/TimeSeriesPointAssertionInput.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/Asserts/TimeSeriesPointAssertionInput.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.Edi.Responses;
+using Google.Protobuf.Collections;
+using NodaTime;
+using NodaTime.Extensions;
+
+namespace Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
+
+public record TimeSeriesPointAssertionInput(
+    Instant Time,
+    decimal Quantity,
+    CalculatedQuantityQuality Quality)
+{
+    public static implicit operator TimeSeriesPointAssertionInput(TimeSeriesPoint tsp) => From(tsp);
+
+    public static List<TimeSeriesPointAssertionInput> From(RepeatedField<TimeSeriesPoint> timeSeriesPoints) => timeSeriesPoints
+        .Select(From)
+        .ToList();
+
+    public static TimeSeriesPointAssertionInput From(TimeSeriesPoint timeSeriesPoint) => new(
+        timeSeriesPoint.Time.ToDateTimeOffset().ToInstant(),
+        timeSeriesPoint.Quantity.ToDecimal(),
+        ConvertQuality(timeSeriesPoint.QuantityQualities));
+
+    private static CalculatedQuantityQuality ConvertQuality(RepeatedField<QuantityQuality> qualities)
+    {
+        var expectedQuantityQuality = qualities.Single() switch
+        {
+            QuantityQuality.Calculated => CalculatedQuantityQuality.Calculated,
+            QuantityQuality.Measured => CalculatedQuantityQuality.Measured,
+            QuantityQuality.Estimated => CalculatedQuantityQuality.Estimated,
+            QuantityQuality.Missing => CalculatedQuantityQuality.Missing,
+            _ => throw new NotImplementedException(
+                $"Quantity quality {qualities.Single()} not implemented"),
+        };
+
+        return expectedQuantityQuality;
+    }
+}

--- a/source/Tests/Infrastructure/OutgoingMessages/NotifyAggregatedMeasureData/AssertNotifyAggregatedMeasureDataEbixDocument.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/NotifyAggregatedMeasureData/AssertNotifyAggregatedMeasureDataEbixDocument.cs
@@ -16,7 +16,6 @@ using System.Globalization;
 using System.Xml.XPath;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.DocumentWriters.Formats.Ebix;
-using Energinet.DataHub.Edi.Responses;
 using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
 using FluentAssertions;
 using Period = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Period;
@@ -210,7 +209,7 @@ public class AssertNotifyAggregatedMeasureDataEbixDocument : IAssertNotifyAggreg
         return this;
     }
 
-    public IAssertNotifyAggregatedMeasureDataDocument HasPoints(IReadOnlyCollection<TimeSeriesPoint> points)
+    public IAssertNotifyAggregatedMeasureDataDocument HasPoints(IReadOnlyCollection<TimeSeriesPointAssertionInput> points)
     {
         var pointsInDocument = _documentAsserter
             .GetElements($"PayloadEnergyTimeSeries[1]/IntervalEnergyObservation")!;
@@ -233,22 +232,31 @@ public class AssertNotifyAggregatedMeasureDataEbixDocument : IAssertNotifyAggreg
                 .Value
                 .ToDecimal()
                 .Should()
-                .Be(expectedPoints[i].Quantity.ToDecimal());
+                .Be(expectedPoints[i].Quantity);
 
-            var expectedQuantityQuality = expectedPoints[i].QuantityQualities.Single() switch
+            var expectedQuantityQuality = EbixCode.ForEnergyResultOf(expectedPoints[i].Quality);
+
+            if (expectedQuantityQuality == null)
             {
-                QuantityQuality.Calculated => EbixCode.QuantityQualityCodeCalculated,
-                QuantityQuality.Estimated => EbixCode.QuantityQualityCodeEstimated,
-                QuantityQuality.Measured => EbixCode.QuantityQualityCodeMeasured,
-                _ => throw new NotImplementedException(
-                    $"Quantity quality {expectedPoints[i].QuantityQualities.Single()} not implemented"),
-            };
+                pointsInDocument[i]
+                    .XPathSelectElement(_documentAsserter.EnsureXPathHasPrefix("QuantityQuality"), _documentAsserter.XmlNamespaceManager)
+                    .Should()
+                    .BeNull();
 
-            pointsInDocument[i]
-                .XPathSelectElement(_documentAsserter.EnsureXPathHasPrefix("QuantityQuality"), _documentAsserter.XmlNamespaceManager)!
-                .Value
-                .Should()
-                .Be(expectedQuantityQuality);
+                pointsInDocument[i]
+                    .XPathSelectElement(_documentAsserter.EnsureXPathHasPrefix("QuantityMissing"), _documentAsserter.XmlNamespaceManager)!
+                    .Value
+                    .Should()
+                    .Be("true");
+            }
+            else
+            {
+                pointsInDocument[i]
+                    .XPathSelectElement(_documentAsserter.EnsureXPathHasPrefix("QuantityQuality"), _documentAsserter.XmlNamespaceManager)!
+                    .Value
+                    .Should()
+                    .Be(expectedQuantityQuality);
+            }
         }
 
         return this;

--- a/source/Tests/Infrastructure/OutgoingMessages/NotifyAggregatedMeasureData/AssertNotifyAggregatedMeasureDataEbixDocument.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/NotifyAggregatedMeasureData/AssertNotifyAggregatedMeasureDataEbixDocument.cs
@@ -236,6 +236,8 @@ public class AssertNotifyAggregatedMeasureDataEbixDocument : IAssertNotifyAggreg
 
             var expectedQuantityQuality = EbixCode.ForEnergyResultOf(expectedPoints[i].Quality);
 
+            // If the quality is Missing or NotAvailable, QuantityQuality should be replaced by
+            // a QuantityMissing element in ebIX
             if (expectedQuantityQuality == null)
             {
                 pointsInDocument[i]

--- a/source/Tests/Infrastructure/OutgoingMessages/NotifyAggregatedMeasureData/AssertNotifyAggregatedMeasureDataJsonDocument.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/NotifyAggregatedMeasureData/AssertNotifyAggregatedMeasureDataJsonDocument.cs
@@ -265,29 +265,34 @@ public sealed class AssertNotifyAggregatedMeasureDataJsonDocument : IAssertNotif
 
         var expectedPoints = points.OrderBy(p => p.Time).ToList();
 
-        for (var i = 0; i < pointsInDocument.Count; i++)
+        for (var index = 0; index < pointsInDocument.Count; index++)
         {
-            pointsInDocument[i]
+            var expectedPoint = expectedPoints[index];
+            var expectedPosition = index + 1;
+
+            pointsInDocument[index]
                 .GetProperty("position")
                 .GetProperty("value")
                 .GetInt32()
                 .Should()
-                .Be(i + 1);
+                .Be(expectedPosition);
 
-            pointsInDocument[i]
+            pointsInDocument[index]
                 .GetProperty("quantity")
                 .GetDecimal()
                 .Should()
-                .Be(expectedPoints[i].Quantity);
+                .Be(expectedPoint.Quantity);
 
-            var expectedQuantityQuality = CimCode.ForEnergyResultOf(expectedPoints[i].Quality);
-
-            pointsInDocument[i]
-                .GetProperty("quality")
-                .GetProperty("value")
-                .GetString()
-                .Should()
-                .Be(expectedQuantityQuality);
+            // If the quality is measured, the quality element should not be present in CIM
+            if (expectedPoint.Quality == CalculatedQuantityQuality.Measured)
+            {
+                QualityIsNotPresentForPosition(expectedPosition);
+            }
+            else
+            {
+                var expectedQuality = CimCode.ForEnergyResultOf(expectedPoint.Quality);
+                QualityIsPresentForPosition(expectedPosition, expectedQuality);
+            }
         }
 
         return this;

--- a/source/Tests/Infrastructure/OutgoingMessages/NotifyAggregatedMeasureData/AssertNotifyAggregatedMeasureDataXmlDocument.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/NotifyAggregatedMeasureData/AssertNotifyAggregatedMeasureDataXmlDocument.cs
@@ -191,7 +191,7 @@ public class AssertNotifyAggregatedMeasureDataXmlDocument : IAssertNotifyAggrega
         return this;
     }
 
-    public IAssertNotifyAggregatedMeasureDataDocument HasPoints(IReadOnlyCollection<TimeSeriesPoint> points)
+    public IAssertNotifyAggregatedMeasureDataDocument HasPoints(IReadOnlyCollection<TimeSeriesPointAssertionInput> points)
     {
         var pointsInDocument = _documentAsserter
             .GetElements("Series[1]/Period/Point")!;
@@ -214,16 +214,9 @@ public class AssertNotifyAggregatedMeasureDataXmlDocument : IAssertNotifyAggrega
                 .Value
                 .ToDecimal()
                 .Should()
-                .Be(expectedPoints[i].Quantity.ToDecimal());
+                .Be(expectedPoints[i].Quantity);
 
-            var expectedQuantityQuality = expectedPoints[i].QuantityQualities.Single() switch
-            {
-                QuantityQuality.Calculated => CimCode.QuantityQualityCodeCalculated,
-                QuantityQuality.Measured => CimCode.QuantityQualityCodeMeasured,
-                QuantityQuality.Estimated => CimCode.QuantityQualityCodeEstimated,
-                _ => throw new NotImplementedException(
-                    $"Quantity quality {expectedPoints[i].QuantityQualities.Single()} not implemented"),
-            };
+            var expectedQuantityQuality = CimCode.ForEnergyResultOf(expectedPoints[i].Quality);
 
             pointsInDocument[i]
                 .XPathSelectElement(_documentAsserter.EnsureXPathHasPrefix("quality"), _documentAsserter.XmlNamespaceManager)!

--- a/source/Tests/Infrastructure/OutgoingMessages/NotifyAggregatedMeasureData/AssertNotifyAggregatedMeasureDataXmlDocument.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/NotifyAggregatedMeasureData/AssertNotifyAggregatedMeasureDataXmlDocument.cs
@@ -200,29 +200,35 @@ public class AssertNotifyAggregatedMeasureDataXmlDocument : IAssertNotifyAggrega
 
         var expectedPoints = points.OrderBy(p => p.Time).ToList();
 
-        for (var i = 0; i < pointsInDocument.Count; i++)
+        for (var index = 0; index < pointsInDocument.Count; index++)
         {
-            pointsInDocument[i]
+            var expectedPoint = expectedPoints[index];
+            var expectedPosition = index + 1;
+
+            pointsInDocument[index]
                 .XPathSelectElement(_documentAsserter.EnsureXPathHasPrefix("position"), _documentAsserter.XmlNamespaceManager)!
                 .Value
                 .ToInt()
                 .Should()
-                .Be(i + 1);
+                .Be(expectedPosition);
 
-            pointsInDocument[i]
+            pointsInDocument[index]
                 .XPathSelectElement(_documentAsserter.EnsureXPathHasPrefix("quantity"), _documentAsserter.XmlNamespaceManager)!
                 .Value
                 .ToDecimal()
                 .Should()
-                .Be(expectedPoints[i].Quantity);
+                .Be(expectedPoint.Quantity);
 
-            var expectedQuantityQuality = CimCode.ForEnergyResultOf(expectedPoints[i].Quality);
-
-            pointsInDocument[i]
-                .XPathSelectElement(_documentAsserter.EnsureXPathHasPrefix("quality"), _documentAsserter.XmlNamespaceManager)!
-                .Value
-                .Should()
-                .Be(expectedQuantityQuality);
+            // If the quality is measured, the quality element should not be present in CIM
+            if (expectedPoint.Quality == CalculatedQuantityQuality.Measured)
+            {
+                QualityIsNotPresentForPosition(expectedPosition);
+            }
+            else
+            {
+                var expectedQuality = CimCode.ForEnergyResultOf(expectedPoint.Quality);
+                QualityIsPresentForPosition(expectedPosition, expectedQuality);
+            }
         }
 
         return this;

--- a/source/Tests/Infrastructure/OutgoingMessages/NotifyAggregatedMeasureData/IAssertNotifyAggregatedMeasureDataDocument.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/NotifyAggregatedMeasureData/IAssertNotifyAggregatedMeasureDataDocument.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Edi.Responses;
+using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
 using Period = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Period;
 using Resolution = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Resolution;
 
@@ -194,8 +195,13 @@ public interface IAssertNotifyAggregatedMeasureDataDocument
     /// </summary>
     IAssertNotifyAggregatedMeasureDataDocument HasResolution(Resolution resolution);
 
+    // /// <summary>
+    // /// Asserts the points based on the Wholesale response
+    // /// </summary>
+    // IAssertNotifyAggregatedMeasureDataDocument HasPoints(IReadOnlyCollection<TimeSeriesPoint> points);
+
     /// <summary>
-    /// Asserts the points based on the Wholesale response
+    /// Asserts the points
     /// </summary>
-    IAssertNotifyAggregatedMeasureDataDocument HasPoints(IReadOnlyCollection<TimeSeriesPoint> points);
+    IAssertNotifyAggregatedMeasureDataDocument HasPoints(IReadOnlyCollection<TimeSeriesPointAssertionInput> points);
 }


### PR DESCRIPTION
## Description

- Add behaviour test that tests the calculaton orchestration activities aggregation levels and asserts an actor can peek a correct document
- Change time series point assertion for `IAssertNotifyAggregatedMeasureDataDocument` to use a `TimeSeriesPointAssertionInput` instead of the `TimeSeriesPoint` from protobuf contracts
- Change quality assertion for `IAssertNotifyAggregatedMeasureDataDocument` to use the calculated quality as input instead of the `QuantityQuality` from protobuf contracts

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/199