### PR TITLE
feat: Avoid enqueueing messages to BRP from wholesaleFixing and correction

### DIFF
--- a/source/IntegrationTests/Factories/EnergyResultPerEnergySupplierPerBalanceResponsibleMessageDtoBuilder.cs
+++ b/source/IntegrationTests/Factories/EnergyResultPerEnergySupplierPerBalanceResponsibleMessageDtoBuilder.cs
@@ -22,9 +22,9 @@ namespace Energinet.DataHub.EDI.IntegrationTests.Factories;
 public class EnergyResultPerEnergySupplierPerBalanceResponsibleMessageDtoBuilder
 {
     private readonly EventId _eventId = EventId.From(Guid.NewGuid());
-    private readonly BusinessReason _businessReason = BusinessReason.WholesaleFixing;
     private readonly Guid _calculationId = Guid.NewGuid();
 
+    private BusinessReason _businessReason = BusinessReason.BalanceFixing;
     private ActorNumber _receiverNumber = ActorNumber.Create("1234567891912");
     private ActorNumber _balanceResponsibleNumber = ActorNumber.Create("1234567891911");
     private Guid _calculationResultId;
@@ -67,6 +67,12 @@ public class EnergyResultPerEnergySupplierPerBalanceResponsibleMessageDtoBuilder
     public EnergyResultPerEnergySupplierPerBalanceResponsibleMessageDtoBuilder WithBalanceResponsiblePartyReceiverNumber(string receiverIdValue)
     {
         _balanceResponsibleNumber = ActorNumber.Create(receiverIdValue);
+        return this;
+    }
+
+    public EnergyResultPerEnergySupplierPerBalanceResponsibleMessageDtoBuilder WithBusinessReason(BusinessReason businessReason)
+    {
+        _businessReason = businessReason;
         return this;
     }
 }

--- a/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
+++ b/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
@@ -340,8 +340,7 @@ public class OutgoingMessage
         ArgumentNullException.ThrowIfNull(serializer);
         ArgumentNullException.ThrowIfNull(messageDto);
 
-        return
-        [
+        List<OutgoingMessage> outgoingMessages = [
             new OutgoingMessage(
                 eventId: messageDto.EventId,
                 documentType: messageDto.DocumentType,
@@ -358,8 +357,13 @@ public class OutgoingMessage
                 gridAreaCode: messageDto.GridArea,
                 externalId: messageDto.ExternalId,
                 calculationId: messageDto.CalculationId),
+        ];
 
-            new OutgoingMessage(
+        // Only create a message for the balance responsible if the business reason is BalanceFixing or PreliminaryAggregation
+        if (messageDto.BusinessReason is not DataHubNames.BusinessReason.WholesaleFixing &&
+            messageDto.BusinessReason is not DataHubNames.BusinessReason.Correction)
+        {
+            var outgoingMessageToBalanceResponsible = new OutgoingMessage(
                 eventId: messageDto.EventId,
                 documentType: messageDto.DocumentType,
                 processId: messageDto.ProcessId,
@@ -374,8 +378,12 @@ public class OutgoingMessage
                 relatedToMessageId: messageDto.RelatedToMessageId,
                 gridAreaCode: messageDto.GridArea,
                 externalId: messageDto.ExternalId,
-                calculationId: messageDto.CalculationId),
-        ];
+                calculationId: messageDto.CalculationId);
+
+            outgoingMessages.Add(outgoingMessageToBalanceResponsible);
+        }
+
+        return outgoingMessages;
     }
 
     /// <summary>


### PR DESCRIPTION

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Wholesale begynder at lave Energy Resultater til Balance Ansvarlig Per Energy Supplier Per Gridarea, når de lave Wholesale beregninger. Det betyder at der vil være flere resultater, som vi ikke må danne beskeder på. Så vi må ikke lave Energy beskeder (RSM-014) til balance ansvarlig per energy supplier per gridarea, når beregningen er en wholesale og korrektion

## References
