### PR TITLE
fix: Fix mapping B2C market roles to correct actor roles

### DIFF
--- a/source/B2CWebApi/Models/MarketRole.cs
+++ b/source/B2CWebApi/Models/MarketRole.cs
@@ -13,45 +13,22 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 
 namespace Energinet.DataHub.EDI.B2CWebApi.Models;
 
 [SuppressMessage("Usage", "CA1034", Justification = "Nested types should not be visible")]
-public static class MarketRole
+public class MarketRole : DataHubType<MarketRole>
 {
-    public static class CalculationResponsibleRole
-    {
-        public const string Code = "DGL";
-        public const string Name = "CalculationResponsible";
-    }
+    public static readonly MarketRole CalculationResponsibleRole = new("DGL", "CalculationResponsible");
+    public static readonly MarketRole EnergySupplier = new("DDQ", "EnergySupplier");
+    public static readonly MarketRole MeteredDataResponsible = new("MDR", "MeteredDataResponsible");
+    public static readonly MarketRole BalanceResponsibleParty = new("DDK", "BalanceResponsibleParty");
+    public static readonly MarketRole GridAccessProvider = new("DDM", "GridAccessProvider");
+    public static readonly MarketRole SystemOperator = new("EZ", "SystemOperator");
 
-    public static class EnergySupplier
+    private MarketRole(string code, string name)
+        : base(name, code)
     {
-        public const string Code = "DDQ";
-        public const string Name = "EnergySupplier";
-    }
-
-    public static class MeteredDataResponsible
-    {
-        public const string Code = "MDR";
-        public const string Name = "MeteredDataResponsible";
-    }
-
-    public static class BalanceResponsibleParty
-    {
-        public const string Code = "DDK";
-        public const string Name = "BalanceResponsibleParty";
-    }
-
-    public static class GridAccessProvider
-    {
-        public const string Code = "DDM";
-        public const string Name = "GridAccessProvider";
-    }
-
-    public static class SystemOperator
-    {
-        public const string Code = "EZ";
-        public const string Name = "SystemOperator";
     }
 }

--- a/source/Tests/B2CWebApi/FrontendUserProviderTests.cs
+++ b/source/Tests/B2CWebApi/FrontendUserProviderTests.cs
@@ -1,0 +1,124 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Security.Claims;
+using Energinet.DataHub.EDI.B2CWebApi.Security;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Authentication;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Energinet.DataHub.EDI.Tests.B2CWebApi;
+
+public class FrontendUserProviderTests
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public FrontendUserProviderTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Theory]
+    [InlineData("CalculationResponsible", "DGL")]
+    [InlineData("EnergySupplier", "DDQ")]
+    [InlineData("MeteredDataResponsible", "MDR")]
+    [InlineData("BalanceResponsibleParty", "DDK")]
+    [InlineData("GridAccessProvider", "DDM")]
+    [InlineData("SystemOperator", "EZ")]
+    public async Task Given_ValidFrontendUserRole_When_ProvideUserAsync_Then_CorrectAuthenticatedUserIsSet(string marketrole, string expectedCode)
+    {
+        // Arrange
+        const string expectedActorNumber = "1234567890123";
+
+        var authenticatedActor = new AuthenticatedActor();
+        var logger = new NullLogger<FrontendUserProvider>();
+
+        var sut = new FrontendUserProvider(logger, authenticatedActor);
+
+        // Act
+        await sut.ProvideUserAsync(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            true,
+            [
+                new("actornumber", expectedActorNumber),
+                new("marketroles", marketrole),
+                new Claim("azp", "random-string"),
+            ]);
+
+        // Assert
+        authenticatedActor
+            .TryGetCurrentActorIdentity(out var authenticatedActorIdentity)
+            .Should()
+            .BeTrue("because the actor identity should be set");
+
+        authenticatedActorIdentity
+            .Should()
+            .NotBeNull("because the actor identity should be set");
+
+        authenticatedActorIdentity!.MarketRole
+            .Should()
+            .NotBeNull();
+
+        authenticatedActorIdentity!.MarketRole!.Code
+            .Should()
+            .Be(expectedCode);
+
+        authenticatedActorIdentity.ActorNumber.Value
+            .Should()
+            .Be(expectedActorNumber);
+
+        authenticatedActorIdentity.Restriction
+            .Should()
+            .Be(Restriction.None);
+    }
+
+    [Fact]
+    public async Task Given_InvalidFrontendUserRole_When_ProvideUserAsync_Then_AuthenticatedUserIsSetWithoutRole()
+    {
+        // Arrange
+        var authenticatedActor = new AuthenticatedActor();
+        var logger = new TestLogger<FrontendUserProvider>(_testOutputHelper);
+
+        var sut = new FrontendUserProvider(logger, authenticatedActor);
+
+        // Act
+        await sut.ProvideUserAsync(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            true,
+            [
+                new("actornumber", "1234567890123"),
+                new("marketroles", "invalid-role-name"),
+                new Claim("azp", "random-string"),
+            ]);
+
+        // Assert
+        authenticatedActor
+            .TryGetCurrentActorIdentity(out var authenticatedActorIdentity)
+            .Should()
+            .BeTrue("because the actor identity should be set");
+
+        authenticatedActorIdentity
+            .Should()
+            .NotBeNull("because the actor identity should be set");
+
+        authenticatedActorIdentity!.MarketRole
+            .Should()
+            .BeNull("because the given market role was invalid");
+    }
+}

--- a/source/Tests/B2CWebApi/RequestWholesaleSettlement/RequestWholesaleSettlementFactoryTests.cs
+++ b/source/Tests/B2CWebApi/RequestWholesaleSettlement/RequestWholesaleSettlementFactoryTests.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Reflection;
 using Energinet.DataHub.EDI.B2CWebApi.Factories;
 using Energinet.DataHub.EDI.B2CWebApi.Models;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using NodaTime;
@@ -50,14 +51,13 @@ public class RequestWholesaleSettlementFactoryTests
     {
         var validActorRoles = GetValidActorRoles().SelectMany(a => a);
 
-        return typeof(MarketRole).GetNestedTypes(BindingFlags.Public | BindingFlags.Static)
-            .SelectMany(t => t.GetFields(BindingFlags.Public | BindingFlags.Static))
-            .Where(f => f.FieldType == typeof(string) && f.Name == "Name")
-            .Select(f => f.GetValue(null))
-            .Where(v => v is string)
+        var invalidActorRoles = EnumerationType.GetAll<MarketRole>()
+            .Select(r => r.Name)
             .Where(v => !validActorRoles.Contains(v!))
             .Select(v => new[] { v! })
             .ToList();
+
+        return invalidActorRoles;
     }
 
     [Fact]

--- a/source/Tests/TestLogger.cs
+++ b/source/Tests/TestLogger.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Energinet.DataHub.EDI.Tests;
+
+public class TestLogger<T> : ILogger<T>
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public TestLogger(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
+    {
+        return null;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return true;
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        var logOutput = formatter(state, exception);
+
+        _testOutputHelper.WriteLine("[{0}] {1}", logLevel.ToString().ToUpperInvariant(), logOutput);
+
+        if (exception != null)
+        {
+            _testOutputHelper.WriteLine("Test logger found an exception: {0}", exception);
+        }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

EDI tried to map B2C front-end user roles using the `ActorRole` names, however these names are not equal to the names written in the B2C front-end user claims. The correct role claim values are written in the `MarketRole` class.

- Use `MarketRole` names to map B2C front-end user claim values to `ActorRole`
- Refactor `MarketRole` to use `DataHubType`
- Add tests to ensure `FrontendUserProvider` maps to correct authenticated actor
- Add logging to enable tracing the B2C user roles in application insights

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/150