### PR TITLE
feat: Add orchestration control admin endpoints

### DIFF
--- a/source/B2CWebApi/B2CWebApi.csproj
+++ b/source/B2CWebApi/B2CWebApi.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="12.2.1" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+        <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.4" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48">
           <PrivateAssets>all</PrivateAssets>

--- a/source/B2CWebApi/Controllers/OrchestrationsController.cs
+++ b/source/B2CWebApi/Controllers/OrchestrationsController.cs
@@ -1,0 +1,136 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.Core.App.Common.Abstractions.Users;
+using Energinet.DataHub.EDI.B2CWebApi.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
+using Newtonsoft.Json;
+
+namespace Energinet.DataHub.EDI.B2CWebApi.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class OrchestrationsController(
+    ILogger<OrchestrationsController> logger,
+    IDurableClientFactory durableClientFactory,
+    IUserContext<FrontendUser> userContext) : ControllerBase
+{
+    private readonly ILogger<OrchestrationsController> _logger = logger;
+    private readonly IDurableClientFactory _durableClientFactory = durableClientFactory;
+    private readonly IUserContext<FrontendUser> _userContext = userContext;
+
+    /// <summary>
+    /// Get orchestrations
+    /// </summary>
+    /// <param name="from">Optional parameter to only get orchestrations after this value</param>
+    /// <returns>
+    /// Returns a <see cref="OrchestrationStatusQueryResult"/>. If <paramref name="from"/> is included
+    /// it will return all orchestrations after this value. If <paramref name="from"/> is not included then
+    /// it will return all pending and running orchestrations.
+    /// </returns>
+    [HttpGet]
+    [ProducesResponseType<OrchestrationStatusQueryResult>(200, "application/json")]
+    [Authorize(Roles = "calculations:manage")]
+    public async Task<IActionResult> IndexAsync(DateTime? from)
+    {
+        AdminUserGuard();
+
+        var durableClient = _durableClientFactory.CreateClient();
+
+        var query = new OrchestrationStatusQueryCondition { ShowInput = true, };
+
+        if (from is not null)
+        {
+            query.CreatedTimeFrom = from.Value;
+        }
+        else
+        {
+            query.RuntimeStatus =
+            [
+                OrchestrationRuntimeStatus.Pending,
+                OrchestrationRuntimeStatus.Running,
+            ];
+        }
+
+        var runningOrchestrations = await durableClient
+            .ListInstancesAsync(query, CancellationToken.None)
+            .ConfigureAwait(false);
+
+        return Content(JsonConvert.SerializeObject(runningOrchestrations), "application/json");
+    }
+
+    /// <summary>
+    /// Get status of orchestration with a given instance id
+    /// </summary>
+    /// <param name="id">The instance id of the orchestration to get status for</param>
+    [HttpGet("{id}")]
+    [ProducesResponseType<DurableOrchestrationStatus>(200, "application/json")]
+    [Authorize(Roles = "calculations:manage")]
+    public async Task<IActionResult> IndexAsync(string id)
+    {
+        AdminUserGuard();
+
+        var durableClient = _durableClientFactory.CreateClient();
+        var orchestrationStatus = await durableClient
+            .GetStatusAsync(id, true, true, true)
+            .ConfigureAwait(false);
+
+        return Content(JsonConvert.SerializeObject(orchestrationStatus), "application/json");
+    }
+
+    /// <summary>
+    /// Terminate a running orchestration
+    /// </summary>
+    /// <param name="id">The instance id of the orchestration to terminate</param>
+    /// <param name="reason">The reasons for the termination</param>
+    [HttpPost("{id}/terminate")]
+    [Authorize(Roles = "calculations:manage")]
+    public async Task<IActionResult> TerminateAsync(string id, string reason)
+    {
+        AdminUserGuard();
+
+        var currentUser = _userContext.CurrentUser;
+        _logger.LogWarning(
+            "Terminating orchestration \"{OrchestrationId}\" with reason \"{Reason}\". Terminated by user id: {UserId}, actor number: {ActorNumber}, azp: {Azp}",
+            id,
+            reason,
+            currentUser.UserId,
+            currentUser.ActorNumber,
+            currentUser.Azp);
+
+        var durableClient = _durableClientFactory.CreateClient();
+        await durableClient
+            .TerminateAsync(id, reason)
+            .ConfigureAwait(false);
+
+        return Accepted();
+    }
+
+    private void AdminUserGuard()
+    {
+        var user = _userContext.CurrentUser;
+
+        if (user.Azp != "00000000-0000-0000-0000-000000000001")
+            throw new UnauthorizedAccessException($"User azp ({user.Azp}) is invalid for this action");
+
+        if (user.ActorNumber != "5790001330583")
+            throw new UnauthorizedAccessException($"User actor number ({user.ActorNumber}) is invalid for this action");
+
+        if (user.Role != "DataHubAdministrator")
+            throw new UnauthorizedAccessException($"User role ({user.Role}) is invalid for this action");
+    }
+}

--- a/source/B2CWebApi/Controllers/OrchestrationsController.cs
+++ b/source/B2CWebApi/Controllers/OrchestrationsController.cs
@@ -106,7 +106,7 @@ public class OrchestrationsController(
         var currentUser = _userContext.CurrentUser;
         _logger.LogWarning(
             "Terminating orchestration \"{OrchestrationId}\" with reason \"{Reason}\". Terminated by user id: {UserId}, actor number: {ActorNumber}, azp: {Azp}",
-            id,
+            id.Replace(Environment.NewLine, string.Empty), // Replace new lines to avoid log injection
             reason,
             currentUser.UserId,
             currentUser.ActorNumber,

--- a/source/B2CWebApi/Controllers/OrchestrationsController.cs
+++ b/source/B2CWebApi/Controllers/OrchestrationsController.cs
@@ -107,7 +107,7 @@ public class OrchestrationsController(
         _logger.LogWarning(
             "Terminating orchestration \"{OrchestrationId}\" with reason \"{Reason}\". Terminated by user id: {UserId}, actor number: {ActorNumber}, azp: {Azp}",
             id.Replace(Environment.NewLine, string.Empty), // Replace new lines to avoid log injection
-            reason,
+            reason.Replace(Environment.NewLine, string.Empty), // Replace new lines to avoid log injection,
             currentUser.UserId,
             currentUser.ActorNumber,
             currentUser.Azp);

--- a/source/B2CWebApi/Extensions/DependencyInjection/DurableClientExtensions.cs
+++ b/source/B2CWebApi/Extensions/DependencyInjection/DurableClientExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+
+namespace Energinet.DataHub.EDI.B2CWebApi.Extensions.DependencyInjection;
+
+public static class DurableClientExtensions
+{
+    public static IServiceCollection AddDurableClient(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // Durable Task
+        services.AddDurableClientFactory(options =>
+        {
+            options.ConnectionName = "OrchestrationsStorageAccountConnectionString";
+            options.TaskHub = configuration["OrchestrationsTaskHubName"]!;
+            options.IsExternalClient = true;
+        });
+
+        return services;
+    }
+}

--- a/source/B2CWebApi/Program.cs
+++ b/source/B2CWebApi/Program.cs
@@ -49,6 +49,9 @@ builder.Services
     .AddNodaTimeForApplication()
     .AddSystemTimer()
 
+    // Durable client (orchestration)
+    .AddDurableClient(builder.Configuration)
+
     // Modules
     .AddIncomingMessagesModule(builder.Configuration)
     .AddArchivedMessagesModule(builder.Configuration)

--- a/source/B2CWebApi/appsettings.sample.json
+++ b/source/B2CWebApi/appsettings.sample.json
@@ -3,6 +3,7 @@
   "AZURE_STORAGE_ACCOUNT_CONNECTION_STRING":  "UseDevelopmentStorage=true",
   "AZURE_STORAGE_ACCOUNT_URL":                "<Azure storage account url>",
 
+
   "UserAuthentication": {
     "MitIdExternalMetadataAddress": "<Url to external Mit id provider>",
     "ExternalMetadataAddress":      "<Url to external OpenID provider>",
@@ -16,5 +17,8 @@
     "SendConnectionString":   "<Connection string for shared service bus with sender permissions>"
   },
 
-  "IncomingMessages__QueueName":  "<Name of queue where incoming messages to EDI from EDI are placed>"
+  "IncomingMessages__QueueName":  "<Name of queue where incoming messages to EDI from EDI are placed>",
+
+  "OrchestrationsStorageAccountConnectionString":  "<Orchestration (durable functions) storage account connection string>",
+  "OrchestrationsTaskHubName":   "<Name of the task hub for orchestrations (Edi01)>"
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Expose endpoints (to datahub admins) to get status and terminate running orchestrations, since Durable Function Monitor cannot be used in production. The endpoints can only be accessed if the user:

- Belongs to actor `5790001330583`, which is `Energinet DataHub A/S (DataHub systemadministrator)`
- Has Azp `00000000-0000-0000-0000-000000000001`
- Has role `DataHubAdministrator`
- Has role claim `calculations:manage`

## References
- Infrastructure PR: https://github.com/Energinet-DataHub/dh3-infrastructure/pull/1738
- Issue: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/217
- D-002 deploy run: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/9875157629