### PR TITLE
chore: Revert Grps.Tools to v 2.62.0

### DIFF
--- a/source/Contracts/Contracts.csproj
+++ b/source/Contracts/Contracts.csproj
@@ -25,7 +25,7 @@ limitations under the License.
 
     <ItemGroup>
       <PackageReference Include="Google.Protobuf" Version="3.27.1" />
-      <PackageReference Include="Grpc.Tools" Version="2.64.0">
+      <PackageReference Include="Grpc.Tools" Version="2.62.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>


### PR DESCRIPTION
## Description

Because of issue https://github.com/grpc/grpc/issues/36518 we have to revert to v. 2.62.0 for all developers to be able to build locally.

## References
