### PR TITLE
chore: Number of inbox events being proccessed at once

### DIFF
--- a/source/Process.Infrastructure/InboxEvents/InboxEventsProcessor.cs
+++ b/source/Process.Infrastructure/InboxEvents/InboxEventsProcessor.cs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Dapper;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.DataAccess;
 using Energinet.DataHub.EDI.BuildingBlocks.Interfaces;
@@ -52,6 +47,7 @@ public class InboxEventsProcessor
     {
         var inboxEvents = await FindPendingMessagesAsync(cancellationToken).ConfigureAwait(false);
 
+        _logger.LogInformation("Processing {Count} inbox events", inboxEvents.Count);
         foreach (var inboxEvent in inboxEvents)
         {
             try


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

We have experienced a timeout exception when processing inbox events. This log statement should help determine if the number of events could be the cause of the problem. 

## References
