### PR TITLE
fix: avoid resolving actor roles for b2b DataHubAdministrator

### DIFF
--- a/source/B2CWebApi/Factories/RequestWholesaleSettlementDtoFactory.cs
+++ b/source/B2CWebApi/Factories/RequestWholesaleSettlementDtoFactory.cs
@@ -15,7 +15,6 @@
 using Energinet.DataHub.EDI.B2CWebApi.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
-using Energinet.DataHub.EDI.IncomingMessages.Interfaces;
 using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
 using NodaTime;
 using RequestWholesaleSettlementChargeType = Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models.RequestWholesaleSettlementChargeType;
@@ -62,7 +61,7 @@ public static class RequestWholesaleSettlementDtoFactory
             senderNumber,
             senderRoleCode,
             DataHubDetails.DataHubActorNumber.Value,
-            MarketRole.CalculationResponsibleRole.Code,
+            ActorRole.MeteredDataAdministrator.Code,
             MapToBusinessReasonCode(request.CalculationType),
             WholesaleSettlementMessageType,
             Guid.NewGuid().ToString(),
@@ -126,22 +125,16 @@ public static class RequestWholesaleSettlementDtoFactory
     private static string MapRoleNameToCode(string roleName)
     {
         ArgumentException.ThrowIfNullOrEmpty(roleName);
+        var marketRole = MarketRole.FromName(roleName);
 
-        if (roleName.Equals(MarketRole.SystemOperator.Name, StringComparison.OrdinalIgnoreCase))
+        if ((marketRole == MarketRole.SystemOperator
+             || marketRole == MarketRole.EnergySupplier
+             || marketRole == MarketRole.GridAccessProvider)
+            && marketRole.Code != null)
         {
-            return MarketRole.SystemOperator.Code;
+            return marketRole.Code;
         }
 
-        if (roleName.Equals(MarketRole.EnergySupplier.Name, StringComparison.OrdinalIgnoreCase))
-        {
-            return MarketRole.EnergySupplier.Code;
-        }
-
-        if (roleName.Equals(MarketRole.GridAccessProvider.Name, StringComparison.OrdinalIgnoreCase))
-        {
-            return MarketRole.GridAccessProvider.Code;
-        }
-
-        throw new ArgumentException($"roleName: {roleName}. is unsupported to map to a role name");
+        throw new ArgumentException($"Market Role: {marketRole}, is not allowed to request wholesale settlement.");
     }
 }

--- a/source/B2CWebApi/Models/MarketRole.cs
+++ b/source/B2CWebApi/Models/MarketRole.cs
@@ -18,7 +18,7 @@ using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 namespace Energinet.DataHub.EDI.B2CWebApi.Models;
 
 [SuppressMessage("Usage", "CA1034", Justification = "Nested types should not be visible")]
-public class MarketRole : DataHubType<MarketRole>
+public class MarketRole : EnumerationType
 {
     public static readonly MarketRole CalculationResponsibleRole = new("DGL", "CalculationResponsible");
     public static readonly MarketRole EnergySupplier = new("DDQ", "EnergySupplier");
@@ -26,9 +26,20 @@ public class MarketRole : DataHubType<MarketRole>
     public static readonly MarketRole BalanceResponsibleParty = new("DDK", "BalanceResponsibleParty");
     public static readonly MarketRole GridAccessProvider = new("DDM", "GridAccessProvider");
     public static readonly MarketRole SystemOperator = new("EZ", "SystemOperator");
+    public static readonly MarketRole DataHubAdministrator = new(null, "DataHubAdministrator");
 
-    private MarketRole(string code, string name)
-        : base(name, code)
+    private MarketRole(string? code, string name)
+        : base(name)
     {
+        Code = code;
+    }
+
+    public string? Code { get; }
+
+    public static MarketRole FromName(string name)
+    {
+        return GetAll<MarketRole>().FirstOrDefault(t => t.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+               ?? throw new InvalidOperationException(
+                   $"{name} is not a valid {nameof(MarketRole)} {nameof(name)}");
     }
 }

--- a/source/B2CWebApi/Security/FrontendUserProvider.cs
+++ b/source/B2CWebApi/Security/FrontendUserProvider.cs
@@ -97,10 +97,16 @@ public sealed class FrontendUserProvider : IUserProvider<FrontendUser>
     {
         try
         {
-            var marketRole = MarketRole.FromName(role);
+            var marketRole = EnumerationType.FromName<MarketRole>(role);
+
+            // DataHubAdministrator does not have a corresponding actor role
+            if (marketRole == MarketRole.DataHubAdministrator)
+                return null;
+
+            if (marketRole.Code == null)
+                throw new InvalidOperationException("Market role code is null");
 
             var actorRole = ActorRole.FromCode(marketRole.Code);
-
             return actorRole;
         }
         catch (Exception e)

--- a/source/Tests/B2CWebApi/RequestWholesaleSettlement/RequestWholesaleSettlementFactoryTests.cs
+++ b/source/Tests/B2CWebApi/RequestWholesaleSettlement/RequestWholesaleSettlementFactoryTests.cs
@@ -202,7 +202,7 @@ public class RequestWholesaleSettlementFactoryTests
             _dateTimeZone,
             SystemClock.Instance.GetCurrentInstant());
 
-        act.Should().ThrowExactly<ArgumentException>().WithMessage("roleName: *. is unsupported to map to a role name");
+        act.Should().ThrowExactly<ArgumentException>().WithMessage($"Market Role: *, is not allowed to request wholesale settlement.");
     }
 
     private RequestWholesaleSettlementMarketRequest GetRequestWithCalculationType(CalculationType calculationType)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
MarketRole (b2c) didn't have a representation of a DataHubAdministrator, which made it log a warring with an exception each time a DataHubAdministrator User was making a request. 

This PR contains the following: 
- Change MarketRole to EnumerationType, since not all roles have a code.
- Added DataHubAdministrator to MarketRole
- Avoid resolving an ActorRole for DataHubAdministrator, since they don't have any. 


## References
- https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/257