### PR TITLE
refac: Bundles are removed outside of the ActorMessageQueue

### DIFF
--- a/source/IntegrationTests/Infrastructure/Retention/RemoveOldDequeuedBundlesWhenADayHasPassedTests.cs
+++ b/source/IntegrationTests/Infrastructure/Retention/RemoveOldDequeuedBundlesWhenADayHasPassedTests.cs
@@ -17,10 +17,12 @@ using Energinet.DataHub.EDI.IntegrationTests.Factories;
 using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.EDI.IntegrationTests.TestDoubles;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.ActorMessagesQueues;
+using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.Bundles;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.MarketDocuments;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.OutgoingMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Configuration.DataAccess;
+using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Repositories.ActorMessageQueues;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models;
 using FluentAssertions;
@@ -51,19 +53,20 @@ public class RemoveOldDequeuedBundlesWhenADayHasPassedTests : TestBase
         // Arrange
         var receiverId = ActorNumber.Create("1234567891912");
         var chargeOwnerId = ActorNumber.Create("1234567891911");
-        var actorMessageQueueRepository = GetService<IActorMessageQueueRepository>();
+        var bundleRepository = GetService<IBundleRepository>();
         var actorMessageQueueContext = GetService<ActorMessageQueueContext>();
         var systemDateTimeProviderStub = new SystemDateTimeProviderStub();
+        var actorMessageQueueRepository = GetService<IActorMessageQueueRepository>();
 
         // When we set the current date to 31 days in the future, any bundles dequeued now should then be removed.
         systemDateTimeProviderStub.SetNow(systemDateTimeProviderStub.Now().PlusDays(31));
 
         var sut = new DequeuedBundlesRetention(
             systemDateTimeProviderStub,
-            actorMessageQueueRepository,
             GetService<IMarketDocumentRepository>(),
             GetService<IOutgoingMessageRepository>(),
             actorMessageQueueContext,
+            bundleRepository,
             GetService<ILogger<DequeuedBundlesRetention>>());
 
         var message = _wholesaleAmountPerChargeDtoBuilder

--- a/source/OutgoingMessages.Domain/Models/ActorMessagesQueues/IActorMessageQueueRepository.cs
+++ b/source/OutgoingMessages.Domain/Models/ActorMessagesQueues/IActorMessageQueueRepository.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.ObjectModel;
-using System.Threading.Tasks;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 
 namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.ActorMessagesQueues;
@@ -37,9 +35,4 @@ public interface IActorMessageQueueRepository
     /// Add a new actor queue.
     /// </summary>
     void Add(ActorMessageQueue actorMessageQueue);
-
-    /// <summary>
-    /// Get all actor message queues.
-    /// </summary>
-    Task<IReadOnlyCollection<ActorMessageQueue>> GetActorMessageQueuesAsync(int skip, int take);
 }

--- a/source/OutgoingMessages.Domain/Models/Bundles/IBundleRepository.cs
+++ b/source/OutgoingMessages.Domain/Models/Bundles/IBundleRepository.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using NodaTime;
+
 namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.Bundles;
 
 /// <summary>
@@ -23,4 +25,17 @@ public interface IBundleRepository
     /// Add a new Bundle
     /// </summary>
     void Add(Bundle bundle);
+
+    /// <summary>
+    ///  Get dequeued bundles older than a specific time.
+    /// </summary>
+    /// <param name="olderThan"></param>
+    /// <param name="take"></param>
+    Task<IReadOnlyCollection<Bundle?>> GetDequeuedBundlesOlderThanAsync(Instant olderThan, int take);
+
+    /// <summary>
+    ///  Delete a bundle.
+    /// </summary>
+    /// <param name="bundle"></param>
+    void Delete(Bundle bundle);
 }

--- a/source/OutgoingMessages.Infrastructure/Repositories/ActorMessageQueues/ActorMessageQueueRepository.cs
+++ b/source/OutgoingMessages.Infrastructure/Repositories/ActorMessageQueues/ActorMessageQueueRepository.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.ObjectModel;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.ActorMessagesQueues;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Configuration.DataAccess;
@@ -75,15 +74,6 @@ public class ActorMessageQueueRepository : IActorMessageQueueRepository
         }
 
         return actorMessageQueueId;
-    }
-
-    public async Task<IReadOnlyCollection<ActorMessageQueue>> GetActorMessageQueuesAsync(int skip, int take)
-    {
-        return await ActorMessageQueuesIncludingBundlesQuery()
-            .Skip(skip)
-            .Take(take)
-            .ToListAsync()
-            .ConfigureAwait(false);
     }
 
     public void Add(ActorMessageQueue actorMessageQueue)

--- a/source/OutgoingMessages.Infrastructure/Repositories/Bundles/BundleRepository.cs
+++ b/source/OutgoingMessages.Infrastructure/Repositories/Bundles/BundleRepository.cs
@@ -14,6 +14,8 @@
 
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.Bundles;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Configuration.DataAccess;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
 
 namespace Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Repositories.Bundles;
 
@@ -24,5 +26,15 @@ public class BundleRepository(ActorMessageQueueContext dbContext) : IBundleRepos
     public void Add(Bundle bundle)
     {
         _dbContext.Bundles.Add(bundle);
+    }
+
+    public void Delete(Bundle bundle)
+    {
+        _dbContext.Bundles.Remove(bundle);
+    }
+
+    public async Task<IReadOnlyCollection<Bundle?>> GetDequeuedBundlesOlderThanAsync(Instant olderThan, int take)
+    {
+        return await _dbContext.Bundles.Where(x => x.DequeuedAt < olderThan).Take(take).ToListAsync().ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
This PR will change the way that bundles are removed because of the sheer amount of potential undequeued bundles (as of now there is around 4 million bundles on production).

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/258