### PR TITLE
refac: OutgoingMessageFactory

### DIFF
--- a/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageTests.cs
@@ -22,6 +22,7 @@ using Energinet.DataHub.EDI.BuildingBlocks.Interfaces;
 using Energinet.DataHub.EDI.IntegrationTests.Factories;
 using Energinet.DataHub.EDI.IntegrationTests.Fixtures;
 using Energinet.DataHub.EDI.IntegrationTests.TestDoubles;
+using Energinet.DataHub.EDI.OutgoingMessages.Application;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.OutgoingMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Configuration.DataAccess;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
@@ -275,7 +276,7 @@ public class WhenEnqueueingOutgoingMessageTests : TestBase
         var message = _acceptedEnergyResultMessageDtoBuilder
             .WithReceiverNumber(SampleData.NewEnergySupplierNumber)
             .Build();
-        var outgoingMessage = OutgoingMessage.CreateMessage(
+        var outgoingMessage = OutgoingMessageFactory.CreateMessage(
             message,
             serializer,
             Instant.FromUtc(2024, 1, 1, 0, 0));

--- a/source/OutgoingMessages.Application/OutgoingMessageFactory.cs
+++ b/source/OutgoingMessages.Application/OutgoingMessageFactory.cs
@@ -1,0 +1,398 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.BuildingBlocks.Interfaces;
+using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.ActorMessagesQueues;
+using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.OutgoingMessages;
+using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.EnergyResultMessages;
+using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.EnergyResultMessages.Request;
+using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.WholesaleResultMessages;
+using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.WholesaleResultMessages.Request;
+using NodaTime;
+
+namespace Energinet.DataHub.EDI.OutgoingMessages.Application;
+
+public static class OutgoingMessageFactory
+{
+       /// <summary>
+    /// This method create a single outgoing message, for the receiver, based on the accepted energyResultMessage.
+    /// </summary>
+    public static OutgoingMessage CreateMessage(
+        AcceptedEnergyResultMessageDto acceptedMessage,
+        ISerializer serializer,
+        Instant timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(acceptedMessage);
+
+        return new OutgoingMessage(
+            eventId: acceptedMessage.EventId,
+            documentType: acceptedMessage.DocumentType,
+            receiver: Receiver.Create(acceptedMessage.ReceiverNumber, acceptedMessage.ReceiverRole),
+            processId: acceptedMessage.ProcessId,
+            businessReason: acceptedMessage.BusinessReason,
+            senderId: acceptedMessage.SenderId,
+            senderRole: acceptedMessage.SenderRole,
+            serializedContent: serializer.Serialize(acceptedMessage.Series),
+            createdAt: timestamp,
+            messageCreatedFromProcess: ProcessType.RequestEnergyResults,
+            relatedToMessageId: acceptedMessage.RelatedToMessageId,
+            gridAreaCode: acceptedMessage.Series.GridAreaCode,
+            externalId: acceptedMessage.ExternalId,
+            calculationId: null,
+            documentReceiver: Receiver.Create(acceptedMessage.DocumentReceiverNumber, acceptedMessage.DocumentReceiverRole));
+    }
+
+    /// <summary>
+    /// This method create a single outgoing message, for the receiver, based on the rejected energyResultMessage.
+    /// </summary>
+    public static OutgoingMessage CreateMessage(
+        RejectedEnergyResultMessageDto rejectedMessage,
+        ISerializer serializer,
+        Instant timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(rejectedMessage);
+
+        return new OutgoingMessage(
+            eventId: rejectedMessage.EventId,
+            documentType: rejectedMessage.DocumentType,
+            receiver: Receiver.Create(rejectedMessage.ReceiverNumber, rejectedMessage.ReceiverRole),
+            processId: rejectedMessage.ProcessId,
+            businessReason: rejectedMessage.BusinessReason,
+            senderId: rejectedMessage.SenderId,
+            senderRole: rejectedMessage.SenderRole,
+            serializedContent: serializer.Serialize(rejectedMessage.Series),
+            createdAt: timestamp,
+            messageCreatedFromProcess: ProcessType.RequestEnergyResults,
+            relatedToMessageId: rejectedMessage.RelatedToMessageId,
+            gridAreaCode: null,
+            externalId: rejectedMessage.ExternalId,
+            calculationId: null,
+            documentReceiver: Receiver.Create(rejectedMessage.DocumentReceiverNumber, rejectedMessage.DocumentReceiverRole));
+    }
+
+    /// <summary>
+    /// Create one outgoing message for the metered data responsible, based on the <paramref name="messageDto"/>.
+    /// </summary>
+    public static OutgoingMessage CreateMessage(
+        EnergyResultPerGridAreaMessageDto messageDto,
+        ISerializer serializer,
+        Instant timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(messageDto);
+
+        return new OutgoingMessage(
+            messageDto.EventId,
+            messageDto.DocumentType,
+            Receiver.Create(messageDto.ReceiverNumber, messageDto.ReceiverRole),
+            Receiver.Create(messageDto.ReceiverNumber, messageDto.ReceiverRole),
+            messageDto.ProcessId,
+            messageDto.BusinessReason,
+            messageDto.SenderId,
+            messageDto.SenderRole,
+            serializer.Serialize(messageDto.Series),
+            timestamp,
+            ProcessType.ReceiveEnergyResults,
+            messageDto.RelatedToMessageId,
+            messageDto.Series.GridAreaCode,
+            messageDto.ExternalId,
+            messageDto.CalculationId);
+    }
+
+    /// <summary>
+    /// Create one outgoing message for the balance responsible, based on the <paramref name="messageDto"/>.
+    /// </summary>
+    public static OutgoingMessage CreateMessage(
+        EnergyResultPerBalanceResponsibleMessageDto messageDto,
+        ISerializer serializer,
+        Instant timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(messageDto);
+
+        return new OutgoingMessage(
+            messageDto.EventId,
+            messageDto.DocumentType,
+            Receiver.Create(messageDto.ReceiverNumber, messageDto.ReceiverRole),
+            Receiver.Create(messageDto.ReceiverNumber, messageDto.ReceiverRole),
+            messageDto.ProcessId,
+            messageDto.BusinessReason,
+            messageDto.SenderId,
+            messageDto.ReceiverRole,
+            serializer.Serialize(messageDto.Series),
+            timestamp,
+            ProcessType.ReceiveEnergyResults,
+            messageDto.RelatedToMessageId,
+            messageDto.Series.GridAreaCode,
+            messageDto.ExternalId,
+            messageDto.CalculationId);
+    }
+
+    /// <summary>
+    /// Create two outgoing messages, one for the balance responsible and one for the energy supplier,
+    /// based on the <paramref name="messageDto"/>.
+    /// </summary>
+    public static List<OutgoingMessage> CreateMessages(
+        EnergyResultPerEnergySupplierPerBalanceResponsibleMessageDto messageDto,
+        ISerializer serializer,
+        Instant timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(messageDto);
+
+        List<OutgoingMessage> outgoingMessages = [
+            new OutgoingMessage(
+                eventId: messageDto.EventId,
+                documentType: messageDto.DocumentType,
+                processId: messageDto.ProcessId,
+                businessReason: messageDto.BusinessReason,
+                receiver: Receiver.Create(messageDto.EnergySupplierNumber, ActorRole.EnergySupplier),
+                documentReceiver: Receiver.Create(messageDto.BalanceResponsibleNumber, ActorRole.EnergySupplier),
+                senderId: messageDto.SenderId,
+                senderRole: messageDto.SenderRole,
+                serializedContent: serializer.Serialize(messageDto.SeriesForEnergySupplier),
+                createdAt: timestamp,
+                messageCreatedFromProcess: ProcessType.ReceiveEnergyResults,
+                relatedToMessageId: messageDto.RelatedToMessageId,
+                gridAreaCode: messageDto.GridArea,
+                externalId: messageDto.ExternalId,
+                calculationId: messageDto.CalculationId),
+        ];
+
+        // Only create a message for the balance responsible if the business reason is BalanceFixing or PreliminaryAggregation
+        if (messageDto.BusinessReason is not DataHubNames.BusinessReason.WholesaleFixing &&
+            messageDto.BusinessReason is not DataHubNames.BusinessReason.Correction)
+        {
+            var outgoingMessageToBalanceResponsible = new OutgoingMessage(
+                eventId: messageDto.EventId,
+                documentType: messageDto.DocumentType,
+                processId: messageDto.ProcessId,
+                businessReason: messageDto.BusinessReason,
+                receiver: Receiver.Create(messageDto.BalanceResponsibleNumber, ActorRole.BalanceResponsibleParty),
+                documentReceiver: Receiver.Create(messageDto.BalanceResponsibleNumber, ActorRole.BalanceResponsibleParty),
+                senderId: messageDto.SenderId,
+                senderRole: messageDto.SenderRole,
+                serializedContent: serializer.Serialize(messageDto.SeriesForBalanceResponsible),
+                createdAt: timestamp,
+                messageCreatedFromProcess: ProcessType.ReceiveEnergyResults,
+                relatedToMessageId: messageDto.RelatedToMessageId,
+                gridAreaCode: messageDto.GridArea,
+                externalId: messageDto.ExternalId,
+                calculationId: messageDto.CalculationId);
+
+            outgoingMessages.Add(outgoingMessageToBalanceResponsible);
+        }
+
+        return outgoingMessages;
+    }
+
+    /// <summary>
+    /// This method creates two outgoing messages, one for the receiver and one for the charge owner, based on the wholesaleResultMessage.
+    /// </summary>
+    public static IReadOnlyCollection<OutgoingMessage> CreateMessages(
+        WholesaleAmountPerChargeMessageDto wholesaleAmountPerChargeMessageDto,
+        ISerializer serializer,
+        Instant timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(wholesaleAmountPerChargeMessageDto);
+
+        return new List<OutgoingMessage>()
+        {
+            new(
+                wholesaleAmountPerChargeMessageDto.EventId,
+                wholesaleAmountPerChargeMessageDto.DocumentType,
+                Receiver.Create(wholesaleAmountPerChargeMessageDto.EnergySupplierReceiverId, ActorRole.EnergySupplier),
+                Receiver.Create(wholesaleAmountPerChargeMessageDto.EnergySupplierReceiverId, ActorRole.EnergySupplier),
+                wholesaleAmountPerChargeMessageDto.ProcessId,
+                wholesaleAmountPerChargeMessageDto.BusinessReason,
+                senderId: wholesaleAmountPerChargeMessageDto.SenderId,
+                senderRole: wholesaleAmountPerChargeMessageDto.SenderRole,
+                serializer.Serialize(wholesaleAmountPerChargeMessageDto.Series),
+                timestamp,
+                ProcessType.ReceiveWholesaleResults,
+                wholesaleAmountPerChargeMessageDto.RelatedToMessageId,
+                wholesaleAmountPerChargeMessageDto.Series.GridAreaCode,
+                wholesaleAmountPerChargeMessageDto.ExternalId,
+                wholesaleAmountPerChargeMessageDto.CalculationId),
+            new(
+                wholesaleAmountPerChargeMessageDto.EventId,
+                wholesaleAmountPerChargeMessageDto.DocumentType,
+                Receiver.Create(
+                    wholesaleAmountPerChargeMessageDto.ChargeOwnerReceiverId,
+                    GetChargeOwnerRole(wholesaleAmountPerChargeMessageDto.ChargeOwnerReceiverId)),
+                Receiver.Create(
+                    wholesaleAmountPerChargeMessageDto.ChargeOwnerReceiverId,
+                    GetChargeOwnerRole(wholesaleAmountPerChargeMessageDto.ChargeOwnerReceiverId)),
+                wholesaleAmountPerChargeMessageDto.ProcessId,
+                wholesaleAmountPerChargeMessageDto.BusinessReason,
+                senderId: wholesaleAmountPerChargeMessageDto.SenderId,
+                senderRole: wholesaleAmountPerChargeMessageDto.SenderRole,
+                serializer.Serialize(wholesaleAmountPerChargeMessageDto.Series),
+                timestamp,
+                ProcessType.ReceiveWholesaleResults,
+                wholesaleAmountPerChargeMessageDto.RelatedToMessageId,
+                wholesaleAmountPerChargeMessageDto.Series.GridAreaCode,
+                wholesaleAmountPerChargeMessageDto.ExternalId,
+                wholesaleAmountPerChargeMessageDto.CalculationId),
+        };
+    }
+
+    /// <summary>
+    /// This method creates two outgoing messages, one for the receiver and one for the charge owner, based on the wholesaleResultMessage.
+    /// </summary>
+    public static IReadOnlyCollection<OutgoingMessage> CreateMessages(
+        WholesaleMonthlyAmountPerChargeMessageDto wholesaleMonthlyAmountPerChargeMessageDto,
+        ISerializer serializer,
+        Instant timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(wholesaleMonthlyAmountPerChargeMessageDto);
+
+        return new List<OutgoingMessage>
+        {
+            new(
+                wholesaleMonthlyAmountPerChargeMessageDto.EventId,
+                wholesaleMonthlyAmountPerChargeMessageDto.DocumentType,
+                Receiver.Create(wholesaleMonthlyAmountPerChargeMessageDto.EnergySupplierReceiverId, ActorRole.EnergySupplier),
+                Receiver.Create(wholesaleMonthlyAmountPerChargeMessageDto.EnergySupplierReceiverId, ActorRole.EnergySupplier),
+                wholesaleMonthlyAmountPerChargeMessageDto.ProcessId,
+                wholesaleMonthlyAmountPerChargeMessageDto.BusinessReason,
+                senderId: wholesaleMonthlyAmountPerChargeMessageDto.SenderId,
+                senderRole: wholesaleMonthlyAmountPerChargeMessageDto.SenderRole,
+                serializer.Serialize(wholesaleMonthlyAmountPerChargeMessageDto.Series),
+                timestamp,
+                ProcessType.ReceiveWholesaleResults,
+                wholesaleMonthlyAmountPerChargeMessageDto.RelatedToMessageId,
+                wholesaleMonthlyAmountPerChargeMessageDto.Series.GridAreaCode,
+                wholesaleMonthlyAmountPerChargeMessageDto.ExternalId,
+                wholesaleMonthlyAmountPerChargeMessageDto.CalculationId),
+            new(
+                wholesaleMonthlyAmountPerChargeMessageDto.EventId,
+                wholesaleMonthlyAmountPerChargeMessageDto.DocumentType,
+                Receiver.Create(
+                    wholesaleMonthlyAmountPerChargeMessageDto.ChargeOwnerReceiverId,
+                    GetChargeOwnerRole(wholesaleMonthlyAmountPerChargeMessageDto.ChargeOwnerReceiverId)),
+                Receiver.Create(
+                    wholesaleMonthlyAmountPerChargeMessageDto.ChargeOwnerReceiverId,
+                    GetChargeOwnerRole(wholesaleMonthlyAmountPerChargeMessageDto.ChargeOwnerReceiverId)),
+                wholesaleMonthlyAmountPerChargeMessageDto.ProcessId,
+                wholesaleMonthlyAmountPerChargeMessageDto.BusinessReason,
+                senderId: wholesaleMonthlyAmountPerChargeMessageDto.SenderId,
+                senderRole: wholesaleMonthlyAmountPerChargeMessageDto.SenderRole,
+                serializer.Serialize(wholesaleMonthlyAmountPerChargeMessageDto.Series),
+                timestamp,
+                ProcessType.ReceiveWholesaleResults,
+                wholesaleMonthlyAmountPerChargeMessageDto.RelatedToMessageId,
+                wholesaleMonthlyAmountPerChargeMessageDto.Series.GridAreaCode,
+                wholesaleMonthlyAmountPerChargeMessageDto.ExternalId,
+                wholesaleMonthlyAmountPerChargeMessageDto.CalculationId),
+        };
+    }
+
+    /// <summary>
+    /// This method creates an outgoing message, one for the receiver based on the WholesaleTotalAmountMessageDto.
+    /// </summary>
+    public static OutgoingMessage CreateMessage(WholesaleTotalAmountMessageDto wholesaleTotalAmountMessageDto, ISerializer serializer, Instant timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(wholesaleTotalAmountMessageDto);
+
+        return new(
+            wholesaleTotalAmountMessageDto.EventId,
+            wholesaleTotalAmountMessageDto.DocumentType,
+            Receiver.Create(wholesaleTotalAmountMessageDto.ReceiverNumber, wholesaleTotalAmountMessageDto.ReceiverRole),
+            Receiver.Create(wholesaleTotalAmountMessageDto.ReceiverNumber, wholesaleTotalAmountMessageDto.ReceiverRole),
+            wholesaleTotalAmountMessageDto.ProcessId,
+            wholesaleTotalAmountMessageDto.BusinessReason,
+            senderId: wholesaleTotalAmountMessageDto.SenderId,
+            senderRole: wholesaleTotalAmountMessageDto.SenderRole,
+            serializer.Serialize(wholesaleTotalAmountMessageDto.Series),
+            timestamp,
+            ProcessType.ReceiveWholesaleResults,
+            wholesaleTotalAmountMessageDto.RelatedToMessageId,
+            wholesaleTotalAmountMessageDto.Series.GridAreaCode,
+            wholesaleTotalAmountMessageDto.ExternalId,
+            wholesaleTotalAmountMessageDto.CalculationId);
+    }
+
+    /// <summary>
+    ///     This method create a single outgoing message, for the receiver, based on the rejected WholesaleServicesMessage.
+    /// </summary>
+    public static OutgoingMessage CreateMessage(
+        RejectedWholesaleServicesMessageDto message,
+        ISerializer serializer,
+        Instant timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(message);
+
+        return new OutgoingMessage(
+            eventId: message.EventId,
+            documentType: message.DocumentType,
+            receiver: Receiver.Create(message.ReceiverNumber, message.ReceiverRole),
+            processId: message.ProcessId,
+            businessReason: message.BusinessReason,
+            senderId: message.SenderId,
+            senderRole: message.SenderRole,
+            serializedContent: serializer.Serialize(message.Series),
+            createdAt: timestamp,
+            messageCreatedFromProcess: ProcessType.RequestWholesaleResults,
+            relatedToMessageId: message.RelatedToMessageId,
+            gridAreaCode: null,
+            externalId: message.ExternalId,
+            calculationId: null,
+            documentReceiver: Receiver.Create(message.DocumentReceiverNumber, message.DocumentReceiverRole));
+    }
+
+    /// <summary>
+    ///     This method create a single outgoing message, for the receiver, based on the accepted WholesaleServicesMessage.
+    /// </summary>
+    public static OutgoingMessage CreateMessage(
+        AcceptedWholesaleServicesMessageDto message,
+        ISerializer serializer,
+        Instant timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(message);
+
+        return new OutgoingMessage(
+            eventId: message.EventId,
+            documentType: message.DocumentType,
+            receiver: Receiver.Create(message.ReceiverNumber, message.ReceiverRole),
+            processId: message.ProcessId,
+            businessReason: message.BusinessReason,
+            senderId: message.SenderId,
+            senderRole: message.SenderRole,
+            serializedContent: serializer.Serialize(message.Series),
+            createdAt: timestamp,
+            messageCreatedFromProcess: ProcessType.RequestWholesaleResults,
+            relatedToMessageId: message.RelatedToMessageId,
+            gridAreaCode: message.Series.GridAreaCode,
+            externalId: message.ExternalId,
+            calculationId: null,
+            documentReceiver: Receiver.Create(message.DocumentReceiverNumber, message.DocumentReceiverRole));
+    }
+
+    private static ActorRole GetChargeOwnerRole(ActorNumber chargeOwnerId)
+    {
+        return chargeOwnerId == DataHubDetails.SystemOperatorActorNumber
+            ? ActorRole.SystemOperator
+            : ActorRole.GridOperator;
+    }
+}

--- a/source/OutgoingMessages.Application/OutgoingMessagesClient.cs
+++ b/source/OutgoingMessages.Application/OutgoingMessagesClient.cs
@@ -70,7 +70,7 @@ public class OutgoingMessagesClient : IOutgoingMessagesClient
         AcceptedEnergyResultMessageDto acceptedEnergyResultMessage,
         CancellationToken cancellationToken)
     {
-        var message = OutgoingMessage.CreateMessage(
+        var message = OutgoingMessageFactory.CreateMessage(
             acceptedEnergyResultMessage,
             _serializer,
             _systemDateTimeProvider.Now());
@@ -82,7 +82,7 @@ public class OutgoingMessagesClient : IOutgoingMessagesClient
         RejectedEnergyResultMessageDto rejectedEnergyResultMessage,
         CancellationToken cancellationToken)
     {
-        var message = OutgoingMessage.CreateMessage(
+        var message = OutgoingMessageFactory.CreateMessage(
             rejectedEnergyResultMessage,
             _serializer,
             _systemDateTimeProvider.Now());
@@ -94,7 +94,7 @@ public class OutgoingMessagesClient : IOutgoingMessagesClient
         RejectedWholesaleServicesMessageDto rejectedWholesaleServicesMessage,
         CancellationToken cancellationToken)
     {
-        var message = OutgoingMessage.CreateMessage(
+        var message = OutgoingMessageFactory.CreateMessage(
             rejectedWholesaleServicesMessage,
             _serializer,
             _systemDateTimeProvider.Now());
@@ -107,7 +107,7 @@ public class OutgoingMessagesClient : IOutgoingMessagesClient
         EnergyResultPerGridAreaMessageDto messageDto,
         CancellationToken cancellationToken)
     {
-        var message = OutgoingMessage.CreateMessage(
+        var message = OutgoingMessageFactory.CreateMessage(
             messageDto,
             _serializer,
             _systemDateTimeProvider.Now());
@@ -122,7 +122,7 @@ public class OutgoingMessagesClient : IOutgoingMessagesClient
         EnergyResultPerBalanceResponsibleMessageDto messageDto,
         CancellationToken cancellationToken)
     {
-        var message = OutgoingMessage.CreateMessage(
+        var message = OutgoingMessageFactory.CreateMessage(
             messageDto,
             _serializer,
             _systemDateTimeProvider.Now());
@@ -137,7 +137,7 @@ public class OutgoingMessagesClient : IOutgoingMessagesClient
         EnergyResultPerEnergySupplierPerBalanceResponsibleMessageDto messageDto,
         CancellationToken cancellationToken)
     {
-        var messages = OutgoingMessage.CreateMessages(
+        var messages = OutgoingMessageFactory.CreateMessages(
             messageDto,
             _serializer,
             _systemDateTimeProvider.Now());
@@ -158,7 +158,7 @@ public class OutgoingMessagesClient : IOutgoingMessagesClient
         WholesaleTotalAmountMessageDto wholesaleTotalAmountMessageDto,
         CancellationToken cancellationToken)
     {
-        var message = OutgoingMessage.CreateMessage(
+        var message = OutgoingMessageFactory.CreateMessage(
             wholesaleTotalAmountMessageDto,
             _serializer,
             _systemDateTimeProvider.Now());
@@ -170,7 +170,7 @@ public class OutgoingMessagesClient : IOutgoingMessagesClient
         WholesaleAmountPerChargeMessageDto wholesaleAmountPerChargeMessageDto,
         CancellationToken cancellationToken)
     {
-        var messages = OutgoingMessage.CreateMessages(
+        var messages = OutgoingMessageFactory.CreateMessages(
             wholesaleAmountPerChargeMessageDto,
             _serializer,
             _systemDateTimeProvider.Now());
@@ -186,7 +186,7 @@ public class OutgoingMessagesClient : IOutgoingMessagesClient
         WholesaleMonthlyAmountPerChargeMessageDto wholesaleMonthlyAmountPerChargeMessageDto,
         CancellationToken cancellationToken)
     {
-        var messages = OutgoingMessage.CreateMessages(
+        var messages = OutgoingMessageFactory.CreateMessages(
             wholesaleMonthlyAmountPerChargeMessageDto,
             _serializer,
             _systemDateTimeProvider.Now());
@@ -202,7 +202,7 @@ public class OutgoingMessagesClient : IOutgoingMessagesClient
         AcceptedWholesaleServicesMessageDto acceptedWholesaleServicesMessage,
         CancellationToken cancellationToken)
     {
-        var message = OutgoingMessage.CreateMessage(
+        var message = OutgoingMessageFactory.CreateMessage(
             acceptedWholesaleServicesMessage,
             _serializer,
             _systemDateTimeProvider.Now());

--- a/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
+++ b/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
@@ -120,10 +120,15 @@ public class OutgoingMessage
     public string? GridAreaCode { get; }
 
     /// <summary>
-    /// Reference the actor queue that should receive the message.
+    /// Is the Receiver of the message.
     /// </summary>
     public Receiver Receiver { get; private set; }
 
+    /// <summary>
+    /// Is the Receiver written within the document.
+    /// This will differ from the 'Receiver' if the message is delegated to another actor.
+    /// Or when requesting energy or wholesale data, where the receiver is always the party who requested the data.
+    /// </summary>
     public Receiver DocumentReceiver { get; }
 
     public BundleId? AssignedBundleId { get; private set; }

--- a/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
+++ b/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
@@ -57,7 +57,6 @@ public class OutgoingMessage
         _serializedContent = serializedContent;
         RelatedToMessageId = relatedToMessageId;
         Receiver = receiver;
-        // We only cases when requesting making sure the receiver written in the document is not the same as the receiver of the message.
         DocumentReceiver = documentReceiver;
         CreatedAt = createdAt;
         FileStorageReference = CreateFileStorageReference(Receiver.Number, createdAt, Id);
@@ -121,6 +120,7 @@ public class OutgoingMessage
 
     /// <summary>
     /// Is the Receiver of the message.
+    /// The message will be place into the ActorMessageQueue of the Receiver.
     /// </summary>
     public Receiver Receiver { get; private set; }
 

--- a/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
+++ b/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
@@ -58,7 +58,7 @@ public class OutgoingMessage
         RelatedToMessageId = relatedToMessageId;
         Receiver = receiver;
         // We only cases when requesting making sure the receiver written in the document is not the same as the receiver of the message.
-        DocumentReceiver = documentReceiver == null ? receiver : documentReceiver;
+        DocumentReceiver = documentReceiver;
         CreatedAt = createdAt;
         FileStorageReference = CreateFileStorageReference(Receiver.Number, createdAt, Id);
         ExternalId = externalId;

--- a/source/Tests/Domain/OutgoingMessages/Queueing/ActorMessageQueueTests.cs
+++ b/source/Tests/Domain/OutgoingMessages/Queueing/ActorMessageQueueTests.cs
@@ -228,10 +228,10 @@ public class ActorMessageQueueTests
         var outgoingMessage = new OutgoingMessage(
             eventId: EventId.From(Guid.NewGuid()),
             documentType: messageType ?? DocumentType.NotifyAggregatedMeasureData,
-            receiverId: receiver.Number,
+            receiver: Receiver.Create(receiver.Number, receiver.ActorRole),
+            documentReceiver: Receiver.Create(receiver.Number, receiver.ActorRole),
             processId: ProcessId.New().Id,
             businessReason: businessReason?.Name ?? BusinessReason.BalanceFixing.Name,
-            receiverRole: receiver.ActorRole,
             senderId: ActorNumber.Create("1234567890987"),
             senderRole: ActorRole.MeteringPointAdministrator,
             serializedContent: string.Empty,

--- a/source/Tests/Domain/OutgoingMessages/Queueing/OutgoingMessageTests.cs
+++ b/source/Tests/Domain/OutgoingMessages/Queueing/OutgoingMessageTests.cs
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Serialization;
 using Energinet.DataHub.EDI.OutgoingMessages.Application;
-using Energinet.DataHub.EDI.OutgoingMessages.Domain;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.DocumentWriters;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.DocumentWriters.NotifyAggregatedMeasureData;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.DocumentWriters.NotifyWholesaleServices;
@@ -112,7 +107,7 @@ public class OutgoingMessageTests
             .Build();
 
         // Act
-        var outgoingMessage = OutgoingMessage.CreateMessage(
+        var outgoingMessage = OutgoingMessageFactory.CreateMessage(
             energyResultMessageDto,
             serializer,
             SystemClock.Instance.GetCurrentInstant());
@@ -136,7 +131,7 @@ public class OutgoingMessageTests
         var acceptedEnergyResultMessageDto = acceptedEnergyResultMessageDtoBuilder.Build();
 
         // Act
-        var outgoingMessage = OutgoingMessage.CreateMessage(
+        var outgoingMessage = OutgoingMessageFactory.CreateMessage(
             acceptedEnergyResultMessageDto,
             serializer,
             SystemClock.Instance.GetCurrentInstant());
@@ -159,7 +154,7 @@ public class OutgoingMessageTests
         var rejectedEnergyResultMessageDto = RejectedEnergyResultMessageDtoBuilder.Build();
 
         // Act
-        var outgoingMessage = OutgoingMessage.CreateMessage(
+        var outgoingMessage = OutgoingMessageFactory.CreateMessage(
             rejectedEnergyResultMessageDto,
             serializer,
             SystemClock.Instance.GetCurrentInstant());
@@ -183,7 +178,7 @@ public class OutgoingMessageTests
             .Build();
 
         // Act
-        var outgoingMessages = OutgoingMessage.CreateMessages(
+        var outgoingMessages = OutgoingMessageFactory.CreateMessages(
             wholesaleServicesMessageDto,
             serializer,
             SystemClock.Instance.GetCurrentInstant());
@@ -213,7 +208,7 @@ public class OutgoingMessageTests
         var acceptedWholesaleServicesMessageDto = AcceptedWholesaleServicesMessageDtoBuilder.Build();
 
         // Act
-        var outgoingMessage = OutgoingMessage.CreateMessage(
+        var outgoingMessage = OutgoingMessageFactory.CreateMessage(
             acceptedWholesaleServicesMessageDto,
             serializer,
             SystemClock.Instance.GetCurrentInstant());
@@ -236,7 +231,7 @@ public class OutgoingMessageTests
         var rejectedWholesaleServicesMessageDto = RejectedWholesaleServicesMessageDtoBuilder.Build();
 
         // Act
-        var outgoingMessage = OutgoingMessage.CreateMessage(
+        var outgoingMessage = OutgoingMessageFactory.CreateMessage(
             rejectedWholesaleServicesMessageDto,
             serializer,
             SystemClock.Instance.GetCurrentInstant());
@@ -260,7 +255,7 @@ public class OutgoingMessageTests
             .Build();
 
         // Act
-        var outgoingMessages = OutgoingMessage.CreateMessages(
+        var outgoingMessages = OutgoingMessageFactory.CreateMessages(
             wholesaleServicesMessageDto,
             serializer,
             SystemClock.Instance.GetCurrentInstant());
@@ -284,7 +279,7 @@ public class OutgoingMessageTests
             .Build();
 
         // Act
-        var outgoingMessage = OutgoingMessage.CreateMessage(
+        var outgoingMessage = OutgoingMessageFactory.CreateMessage(
             energyResultMessageDto,
             new Serializer(),
             SystemClock.Instance.GetCurrentInstant());


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
This will lighten the `OutgoingMessage` domain model and seek to move its coupling to DTO's and factory patterns into a `OutgoingMessageFactory` located in `OutgoingMessage.Application`.

My next PR will remove the reference to `OutgoingMessage.Interfaces` from the `OutgoingMessage.Domain` project.
## References
