### PR TITLE
fix: wholesale request quality mappers

### DIFF
--- a/source/OutgoingMessages.Infrastructure/Databricks/WholesaleResults/Factories/QuantityQualitiesFactor.cs
+++ b/source/OutgoingMessages.Infrastructure/Databricks/WholesaleResults/Factories/QuantityQualitiesFactor.cs
@@ -27,7 +27,7 @@ public class QuantityQualitiesFactor
     {
         if (price == null)
         {
-            return CalculatedQuantityQuality.Incomplete;
+            return CalculatedQuantityQuality.Missing;
         }
 
         if (chargeType == ChargeType.Subscription || chargeType == ChargeType.Fee)

--- a/source/OutgoingMessages.Infrastructure/Databricks/WholesaleResults/Factories/QuantityQualitiesFactor.cs
+++ b/source/OutgoingMessages.Infrastructure/Databricks/WholesaleResults/Factories/QuantityQualitiesFactor.cs
@@ -27,7 +27,7 @@ public class QuantityQualitiesFactor
     {
         if (price == null)
         {
-            return CalculatedQuantityQuality.Missing;
+            return CalculatedQuantityQuality.Incomplete;
         }
 
         if (chargeType == ChargeType.Subscription || chargeType == ChargeType.Fee)

--- a/source/Process.Application/Transactions/Mappers/CalculatedQuantityQualityMapper.cs
+++ b/source/Process.Application/Transactions/Mappers/CalculatedQuantityQualityMapper.cs
@@ -99,7 +99,7 @@ public static class CalculatedQuantityQualityMapper
     ///         <item>
     ///             <description>
     ///                 If the price is missing, it
-    ///                 returns CalculatedQuantityQuality.Incomplete.
+    ///                 returns CalculatedQuantityQuality.Missing.
     ///             </description>
     ///         </item>
     ///         <item>
@@ -163,7 +163,7 @@ public static class CalculatedQuantityQualityMapper
 
         if (!hasPrice)
         {
-            return CalculatedQuantityQuality.Incomplete;
+            return CalculatedQuantityQuality.Missing;
         }
 
         if (chargeType is WholesaleServicesRequestSeries.Types.ChargeType.Subscription or WholesaleServicesRequestSeries.Types.ChargeType.Fee)

--- a/source/Process.Application/Transactions/Mappers/CalculatedQuantityQualityMapper.cs
+++ b/source/Process.Application/Transactions/Mappers/CalculatedQuantityQualityMapper.cs
@@ -143,10 +143,6 @@ public static class CalculatedQuantityQualityMapper
     ///         </item>
     ///     </list>
     /// </summary>
-    /// <param name="quantityQualities">The collection of quantity qualities to convert.</param>
-    /// <param name="resolution">The resolution for the calculation.</param>
-    /// <param name="hasPrice">Does the calculation result have a price.</param>
-    /// <param name="chargeType">calculation result charge type</param>
     /// <returns>The calculated quantity quality based on the input collection.</returns>
     public static CalculatedQuantityQuality? MapForWholesaleServices(
         ICollection<QuantityQuality> quantityQualities,

--- a/source/Process.Application/Transactions/Mappers/CalculatedQuantityQualityMapper.cs
+++ b/source/Process.Application/Transactions/Mappers/CalculatedQuantityQualityMapper.cs
@@ -98,6 +98,18 @@ public static class CalculatedQuantityQualityMapper
     ///         </item>
     ///         <item>
     ///             <description>
+    ///                 If the price is missing, it
+    ///                 returns CalculatedQuantityQuality.Incomplete.
+    ///             </description>
+    ///         </item>
+    ///         <item>
+    ///             <description>
+    ///                 If the chargeType is Subscription or Fee, it
+    ///                 returns CalculatedQuantityQuality.Calculated.
+    ///             </description>
+    ///         </item>
+    ///         <item>
+    ///             <description>
     ///                 If the collection contains Missing and doesn't contain Estimated, Measured, or Calculated, it
     ///                 returns CalculatedQuantityQuality.Missing.
     ///             </description>
@@ -132,17 +144,31 @@ public static class CalculatedQuantityQualityMapper
     ///     </list>
     /// </summary>
     /// <param name="quantityQualities">The collection of quantity qualities to convert.</param>
-    /// <param name="resolution"></param>
+    /// <param name="resolution">The resolution for the calculation.</param>
+    /// <param name="hasPrice">Does the calculation result have a price.</param>
+    /// <param name="chargeType">calculation result charge type</param>
     /// <returns>The calculated quantity quality based on the input collection.</returns>
     public static CalculatedQuantityQuality? MapForWholesaleServices(
         ICollection<QuantityQuality> quantityQualities,
-        WholesaleServicesRequestSeries.Types.Resolution resolution)
+        WholesaleServicesRequestSeries.Types.Resolution resolution,
+        bool hasPrice,
+        WholesaleServicesRequestSeries.Types.ChargeType? chargeType)
     {
         ArgumentNullException.ThrowIfNull(quantityQualities);
 
         if (resolution == WholesaleServicesRequestSeries.Types.Resolution.Monthly)
         {
             return null;
+        }
+
+        if (!hasPrice)
+        {
+            return CalculatedQuantityQuality.Incomplete;
+        }
+
+        if (chargeType is WholesaleServicesRequestSeries.Types.ChargeType.Subscription or WholesaleServicesRequestSeries.Types.ChargeType.Fee)
+        {
+            return CalculatedQuantityQuality.Calculated;
         }
 
         return (missing: quantityQualities.Contains(QuantityQuality.Missing),

--- a/source/Tests/Domain/Transactions/Mappers/CalculatedQuantityQualityMapperTests.cs
+++ b/source/Tests/Domain/Transactions/Mappers/CalculatedQuantityQualityMapperTests.cs
@@ -141,7 +141,7 @@ public sealed class CalculatedQuantityQualityMapperTests
             // Only available to Energinet employees.
             // Note that this is used for RSM-019
             // QuantityQuality for monthly amount is always “null”
-            // QuantityQuality when price is missing is always “Incomplete”
+            // QuantityQuality when price is missing is always “Missing”
             // If Price is present, the QuantityQuality is “Calculated” if the CalculationType is “Subscription” and “Fee”.
             // The following rules applies when calculation type is “Tariff”, has a price and is not monthly:
             /*
@@ -178,7 +178,7 @@ public sealed class CalculatedQuantityQualityMapperTests
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
                 false,
                 WholesaleServicesRequestSeries.Types.ChargeType.Subscription,
-                CalculatedQuantityQuality.Incomplete,
+                CalculatedQuantityQuality.Missing,
             };
 
             // If Price is present, the QuantityQuality is “Calculated” if the CalculationType is “Subscription”.
@@ -345,7 +345,7 @@ public sealed class CalculatedQuantityQualityMapperTests
             // Example mappings from the documentation at https://energinet.atlassian.net/wiki/spaces/D3/pages/529989633/QuantityQuality.
             // Only available to Energinet employees.
             // Note that this is used for RSM-019
-            // QuantityQuality when price is missing is always “Incomplete”
+            // QuantityQuality when price is missing is always “Missing”
             // If Price is present, the QuantityQuality is “Calculated” if the CalculationType is “Subscription” and “Fee”.
             // The following rules applies when calculation type is “Tariff”, has a price:
             /*
@@ -371,7 +371,7 @@ public sealed class CalculatedQuantityQualityMapperTests
                 null,
                 new[] { Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Missing },
                 ChargeType.Subscription,
-                CalculatedQuantityQuality.Incomplete,
+                CalculatedQuantityQuality.Missing,
             };
 
             // If Price is present, the QuantityQuality is “Calculated” if the CalculationType is “Subscription”.

--- a/source/Tests/Domain/Transactions/Mappers/CalculatedQuantityQualityMapperTests.cs
+++ b/source/Tests/Domain/Transactions/Mappers/CalculatedQuantityQualityMapperTests.cs
@@ -33,9 +33,9 @@ public sealed class CalculatedQuantityQualityMapperTests
         {
             // Example mappings from the documentation at https://energinet.atlassian.net/wiki/spaces/D3/pages/529989633/QuantityQuality.
             // Only available to Energinet employees.
-            // Note that this is used for RSM-014
+            // Note that this is used for RSM-014 in the CIM format
             /*
-             * | Combination QQ from RSM-012       | Calculated quantity quality |
+             * | Combination QQ from RSM-014       | Calculated quantity quality |
              * |-----------------------------------+-----------------------------|
              * | Missing + Missing                 | Missing                     |
              * | Missing + Estimated               | Incomplete                  |
@@ -139,13 +139,13 @@ public sealed class CalculatedQuantityQualityMapperTests
         {
             // Example mappings from the documentation at https://energinet.atlassian.net/wiki/spaces/D3/pages/529989633/QuantityQuality.
             // Only available to Energinet employees.
-            // Note that this is used for RSM-019
+            // Note that this is used for RSM-019 in the CIM format
             // QuantityQuality for monthly amount is always “null”
             // QuantityQuality when price is missing is always “Missing”
             // If Price is present, the QuantityQuality is “Calculated” if the CalculationType is “Subscription” and “Fee”.
             // The following rules applies when calculation type is “Tariff”, has a price and is not monthly:
             /*
-             * | Combination QQ from RSM-012       | Calculated quantity quality |
+             * | Combination QQ from RSM-014       | Calculated quantity quality |
              * |-----------------------------------+-----------------------------|
              * | Missing + Missing                 | Missing                     |
              * | Missing + Missing                 | Missing                     |
@@ -344,12 +344,12 @@ public sealed class CalculatedQuantityQualityMapperTests
         {
             // Example mappings from the documentation at https://energinet.atlassian.net/wiki/spaces/D3/pages/529989633/QuantityQuality.
             // Only available to Energinet employees.
-            // Note that this is used for RSM-019
+            // Note that this is used for RSM-019 in the CIM format
             // QuantityQuality when price is missing is always “Missing”
             // If Price is present, the QuantityQuality is “Calculated” if the CalculationType is “Subscription” and “Fee”.
             // The following rules applies when calculation type is “Tariff”, has a price:
             /*
-             * | Combination QQ from RSM-012       | Calculated quantity quality |
+             * | Combination QQ from RSM-014       | Calculated quantity quality |
              * |-----------------------------------+-----------------------------|
              * | Missing + Missing                 | Missing                     |
              * | Missing + Missing                 | Missing                     |

--- a/source/Tests/Domain/Transactions/Mappers/CalculatedQuantityQualityMapperTests.cs
+++ b/source/Tests/Domain/Transactions/Mappers/CalculatedQuantityQualityMapperTests.cs
@@ -14,6 +14,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.WholesaleResults.Factories;
 using Energinet.DataHub.EDI.Process.Application.Transactions.Mappers;
 using Energinet.DataHub.Edi.Responses;
 using FluentAssertions;
@@ -134,13 +135,15 @@ public sealed class CalculatedQuantityQualityMapperTests
             };
         }
 
-        public static IEnumerable<object?[]> QuantityQualityWholesaleServiceMappingData()
+        public static IEnumerable<object?[]> QuantityQualityWholesaleServiceRequestMappingData()
         {
             // Example mappings from the documentation at https://energinet.atlassian.net/wiki/spaces/D3/pages/529989633/QuantityQuality.
             // Only available to Energinet employees.
             // Note that this is used for RSM-019
             // QuantityQuality for monthly amount is always “null”
-            // If QuantityQuality is not monthly amount, the following rules apply:
+            // QuantityQuality when price is missing is always “Incomplete”
+            // If Price is present, the QuantityQuality is “Calculated” if the CalculationType is “Subscription” and “Fee”.
+            // The following rules applies when calculation type is “Tariff”, has a price and is not monthly:
             /*
              * | Combination QQ from RSM-012       | Calculated quantity quality |
              * |-----------------------------------+-----------------------------|
@@ -163,7 +166,39 @@ public sealed class CalculatedQuantityQualityMapperTests
             {
                 new[] { QuantityQuality.Missing },
                 WholesaleServicesRequestSeries.Types.Resolution.Monthly,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Subscription,
                 null,
+            };
+
+            //QuantityQuality when price is missing is always “Incomplete”
+            yield return new object?[]
+            {
+                new[] { QuantityQuality.Missing },
+                WholesaleServicesRequestSeries.Types.Resolution.Day,
+                false,
+                WholesaleServicesRequestSeries.Types.ChargeType.Subscription,
+                CalculatedQuantityQuality.Incomplete,
+            };
+
+            // If Price is present, the QuantityQuality is “Calculated” if the CalculationType is “Subscription”.
+            yield return new object?[]
+            {
+                new[] { QuantityQuality.Missing },
+                WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Subscription,
+                CalculatedQuantityQuality.Calculated,
+            };
+
+            // If Price is present, the QuantityQuality is “Calculated” if the CalculationType is “Fee”.
+            yield return new object?[]
+            {
+                new[] { QuantityQuality.Missing },
+                WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Fee,
+                CalculatedQuantityQuality.Calculated,
             };
 
             // The following test cases are defined as an input array of quantity qualities and a singular expected output.
@@ -171,6 +206,8 @@ public sealed class CalculatedQuantityQualityMapperTests
             {
                 new[] { QuantityQuality.Missing },
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
                 CalculatedQuantityQuality.Missing,
             };
 
@@ -178,6 +215,8 @@ public sealed class CalculatedQuantityQualityMapperTests
             {
                 new[] { QuantityQuality.Missing, QuantityQuality.Estimated },
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
                 CalculatedQuantityQuality.Incomplete,
             };
 
@@ -185,6 +224,8 @@ public sealed class CalculatedQuantityQualityMapperTests
             {
                 new[] { QuantityQuality.Missing, QuantityQuality.Measured },
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
                 CalculatedQuantityQuality.Incomplete,
             };
 
@@ -192,6 +233,8 @@ public sealed class CalculatedQuantityQualityMapperTests
             {
                 new[] { QuantityQuality.Missing, QuantityQuality.Estimated, QuantityQuality.Measured },
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
                 CalculatedQuantityQuality.Incomplete,
             };
 
@@ -199,6 +242,8 @@ public sealed class CalculatedQuantityQualityMapperTests
             {
                 new[] { QuantityQuality.Estimated, QuantityQuality.Measured },
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
                 CalculatedQuantityQuality.Calculated,
             };
 
@@ -206,6 +251,8 @@ public sealed class CalculatedQuantityQualityMapperTests
             {
                 new[] { QuantityQuality.Estimated },
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
                 CalculatedQuantityQuality.Calculated,
             };
 
@@ -213,6 +260,8 @@ public sealed class CalculatedQuantityQualityMapperTests
             {
                 new[] { QuantityQuality.Measured },
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
                 CalculatedQuantityQuality.Calculated,
             };
 
@@ -220,6 +269,8 @@ public sealed class CalculatedQuantityQualityMapperTests
             {
                 new[] { QuantityQuality.Calculated },
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
                 CalculatedQuantityQuality.Calculated,
             };
 
@@ -231,6 +282,8 @@ public sealed class CalculatedQuantityQualityMapperTests
                     QuantityQuality.Calculated,
                 },
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
                 CalculatedQuantityQuality.Incomplete,
             };
 
@@ -242,6 +295,8 @@ public sealed class CalculatedQuantityQualityMapperTests
                     QuantityQuality.Calculated,
                 },
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
                 CalculatedQuantityQuality.Calculated,
             };
 
@@ -254,6 +309,8 @@ public sealed class CalculatedQuantityQualityMapperTests
                     QuantityQuality.Measured,
                 },
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
                 CalculatedQuantityQuality.Calculated,
             };
 
@@ -262,6 +319,8 @@ public sealed class CalculatedQuantityQualityMapperTests
             {
                 new List<QuantityQuality>(),
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
                 CalculatedQuantityQuality.NotAvailable,
             };
 
@@ -275,6 +334,203 @@ public sealed class CalculatedQuantityQualityMapperTests
                     QuantityQuality.Calculated,
                 },
                 WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff,
+                CalculatedQuantityQuality.Calculated,
+            };
+        }
+
+        public static IEnumerable<object?[]> QuantityQualityWholesaleServiceMappingData()
+        {
+            // Example mappings from the documentation at https://energinet.atlassian.net/wiki/spaces/D3/pages/529989633/QuantityQuality.
+            // Only available to Energinet employees.
+            // Note that this is used for RSM-019
+            // QuantityQuality when price is missing is always “Incomplete”
+            // If Price is present, the QuantityQuality is “Calculated” if the CalculationType is “Subscription” and “Fee”.
+            // The following rules applies when calculation type is “Tariff”, has a price:
+            /*
+             * | Combination QQ from RSM-012       | Calculated quantity quality |
+             * |-----------------------------------+-----------------------------|
+             * | Missing + Missing                 | Missing                     |
+             * | Missing + Missing                 | Missing                     |
+             * | Missing + Estimated               | Incomplete                  |
+             * | Missing + Measured                | Incomplete                  |
+             * | Missing + Estimated + Measured    | Incomplete                  |
+             * | Missing + Calculated              | Incomplete                  |
+             * | Estimated + Measured              | Calculated                  |
+             * | Estimated + Estimated             | Calculated                  |
+             * | Estimated + Calculated            | Calculated                  |
+             * | Measured + Measured               | Calculated                  |
+             * | Calculated + Calculated           | Calculated                  |
+             * | Measured + Estimated + Calculated | Calculated                  |
+             */
+
+            //QuantityQuality when price is missing is always “Incomplete”
+            yield return new object?[]
+            {
+                null,
+                new[] { Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Missing },
+                ChargeType.Subscription,
+                CalculatedQuantityQuality.Incomplete,
+            };
+
+            // If Price is present, the QuantityQuality is “Calculated” if the CalculationType is “Subscription”.
+            yield return new object?[]
+            {
+                99m,
+                new[] { Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Missing },
+                ChargeType.Subscription,
+                CalculatedQuantityQuality.Calculated,
+            };
+
+            // If Price is present, the QuantityQuality is “Calculated” if the CalculationType is “Fee”.
+            yield return new object?[]
+            {
+                99m,
+                new[] { Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Missing },
+                ChargeType.Fee,
+                CalculatedQuantityQuality.Calculated,
+            };
+
+            // The following test cases are defined as an input array of quantity qualities and a singular expected output.
+            yield return new object?[]
+            {
+                99m,
+                new[] { Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Missing },
+                ChargeType.Tariff,
+                CalculatedQuantityQuality.Missing,
+            };
+
+            yield return new object?[]
+            {
+                99m,
+                new[]
+                {
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Missing,
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Estimated,
+                },
+                ChargeType.Tariff,
+                CalculatedQuantityQuality.Incomplete,
+            };
+
+            yield return new object?[]
+            {
+                99m,
+                new[]
+                {
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Missing,
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Measured,
+                },
+                ChargeType.Tariff,
+                CalculatedQuantityQuality.Incomplete,
+            };
+
+            yield return new object?[]
+            {
+                99m,
+                new[]
+                {
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Missing,
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Estimated,
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Measured,
+                },
+                ChargeType.Tariff,
+                CalculatedQuantityQuality.Incomplete,
+            };
+
+            yield return new object?[]
+            {
+                99m,
+                new[]
+                {
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Estimated,
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Measured,
+                },
+                ChargeType.Tariff,
+                CalculatedQuantityQuality.Calculated,
+            };
+
+            yield return new object?[]
+            {
+                99m,
+                new[] { Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Estimated },
+                ChargeType.Tariff,
+                CalculatedQuantityQuality.Calculated,
+            };
+
+            yield return new object?[]
+            {
+                99m,
+                new[] { Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Measured },
+                ChargeType.Tariff,
+                CalculatedQuantityQuality.Calculated,
+            };
+
+            yield return new object?[]
+            {
+                99m,
+                new[] { Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Calculated },
+                ChargeType.Tariff,
+                CalculatedQuantityQuality.Calculated,
+            };
+
+            yield return new object?[]
+            {
+                99m,
+                new[]
+                {
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Missing,
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Calculated,
+                },
+                ChargeType.Tariff,
+                CalculatedQuantityQuality.Incomplete,
+            };
+
+            yield return new object?[]
+            {
+                99m,
+                new[]
+                {
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Estimated,
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Calculated,
+                },
+                ChargeType.Tariff,
+                CalculatedQuantityQuality.Calculated,
+            };
+
+            yield return new object?[]
+            {
+                99m,
+                new[]
+                {
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Estimated,
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Calculated,
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Measured,
+                },
+                ChargeType.Tariff,
+                CalculatedQuantityQuality.Calculated,
+            };
+
+            // The empty set is undefined.
+            yield return new object?[]
+            {
+                99m,
+                new List<Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality>(),
+                ChargeType.Tariff,
+                CalculatedQuantityQuality.NotAvailable,
+            };
+
+            // Additional test cases not based on examples from the documentation.
+            yield return new object?[]
+            {
+                99m,
+                new[]
+                {
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Measured,
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Measured,
+                    Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality.Calculated,
+                },
+                ChargeType.Tariff,
                 CalculatedQuantityQuality.Calculated,
             };
         }
@@ -302,7 +558,7 @@ public sealed class CalculatedQuantityQualityMapperTests
             ICollection<QuantityQuality>? quality = null;
 
             // Act & Assert
-            var act = () => CalculatedQuantityQualityMapper.MapForWholesaleServices(quality, WholesaleServicesRequestSeries.Types.Resolution.Day);
+            var act = () => CalculatedQuantityQualityMapper.MapForWholesaleServices(quality, WholesaleServicesRequestSeries.Types.Resolution.Day, true, WholesaleServicesRequestSeries.Types.ChargeType.Tariff);
             act.Should().ThrowExactly<ArgumentNullException>();
         }
 
@@ -320,16 +576,20 @@ public sealed class CalculatedQuantityQualityMapperTests
         }
 
         [Theory]
-        [MemberData(nameof(QuantityQualityWholesaleServiceMappingData))]
-        public void Maps_wholesale_services_quantity_quality_to_edi_quality_in_accordance_with_the_rules(
+        [MemberData(nameof(QuantityQualityWholesaleServiceRequestMappingData))]
+        public void Maps_wholesale_services_request_quantity_quality_to_edi_quality_in_accordance_with_the_rules(
             ICollection<QuantityQuality> qualitySetFromWholesale,
             WholesaleServicesRequestSeries.Types.Resolution resolution,
+            bool hasPrice,
+            WholesaleServicesRequestSeries.Types.ChargeType chargeType,
             CalculatedQuantityQuality? expectedCalculatedQuantityQuality)
         {
             // Act
             var actual = CalculatedQuantityQualityMapper.MapForWholesaleServices(
                 qualitySetFromWholesale,
-                resolution);
+                resolution,
+                hasPrice,
+                chargeType);
 
             // Assert
             actual.Should().Be(expectedCalculatedQuantityQuality);
@@ -343,7 +603,27 @@ public sealed class CalculatedQuantityQualityMapperTests
             CalculatedQuantityQualityMapper.MapForEnergyResults(new[] { quantityQuality });
             CalculatedQuantityQualityMapper.MapForWholesaleServices(
                 new[] { quantityQuality },
-                WholesaleServicesRequestSeries.Types.Resolution.Day);
+                WholesaleServicesRequestSeries.Types.Resolution.Day,
+                true,
+                WholesaleServicesRequestSeries.Types.ChargeType.Tariff);
+        }
+
+        [Theory]
+        [MemberData(nameof(QuantityQualityWholesaleServiceMappingData))]
+        public void Maps_wholesale_services_quantity_quality_to_edi_quality_in_accordance_with_the_rules(
+            decimal? price,
+            IReadOnlyCollection<Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.DeltaTableConstants.QuantityQuality> qualities,
+            ChargeType? chargeType,
+            CalculatedQuantityQuality expectedCalculatedQuantityQuality)
+        {
+            // Act
+            var actual = QuantityQualitiesFactor.CreateQuantityQuality(
+                price,
+                qualities,
+                chargeType);
+
+            // Assert
+            actual.Should().Be(expectedCalculatedQuantityQuality);
         }
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
We didn't map quality correctly for amount results when charge types were fees and subscriptions. 

This PR updates the mapping of quality both for request and new calculation results according to this article: 
https://energinet.atlassian.net/wiki/spaces/D3/pages/529989633/QuantityQuality

> The subscription and fee has no QuantityQuality. Therefore, the QuantityQuality in RSM-019 is always 'calculated' unless the price is missing (null), in which case the QuantityQuality is 'Incomplete'.

> in general if the “Price” for a charge is not available (null), then the QuantityQuality must be “Incomplete (A05)” in CIM.

Be aware that CalculatedQuantityQuality.Missing is written as Incompleted in CIM

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/internal-repo/1193