### PR TITLE
build: Use matrix for execution of tests in CI

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -52,24 +52,9 @@ jobs:
             filter: empty # Means skip
             use_azure_functions_tools: true
             contentroot_variable_name: empty # Means skip
-          - name: Integration tests - split 1
+          - name: Integration tests
             paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
-            filter: DisplayName~Behaviours.IncomingRequests
-            use_azure_functions_tools: true
-            contentroot_variable_name: empty # Means skip
-          - name: Integration tests - split 2
-            paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
-            filter: DisplayName~Behaviours.IntegrationEvents
-            use_azure_functions_tools: true
-            contentroot_variable_name: empty # Means skip
-          - name: Integration tests - split 3
-            paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
-            filter: DisplayName~Infrastructure.Retention
-            use_azure_functions_tools: true
-            contentroot_variable_name: empty # Means skip
-          - name: Integration tests - split 4
-            paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
-            filter: (DisplayName!~Behaviours.IncomingRequests)&(DisplayName!~Behaviours.IntegrationEvents)&(DisplayName!~Infrastructure.Retention)
+            filter: empty # Means skip
             use_azure_functions_tools: true
             contentroot_variable_name: empty # Means skip
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -52,26 +52,26 @@ jobs:
             filter: empty # Means skip
             use_azure_functions_tools: true
             contentroot_variable_name: empty # Means skip
-          - name: Integration tests
+          - name: Integration tests - split 1
             paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
-            filter: empty # Means skip
+            filter: DisplayName~Behaviours.IncomingRequests
             use_azure_functions_tools: true
             contentroot_variable_name: empty # Means skip
-          # - name: Calculation Results - AggregatedTimeSeriesQueriesCsvTests split 1
-          #   paths: \source\dotnet\wholesale-api\CalculationResults\CalculationResults.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.Wholesale.CalculationResults.IntegrationTests.dll
-          #   filter: (DisplayName~AggregatedTimeSeriesQueriesCsvTests)&(DisplayName~BalanceResponsible)
-          #   use_azure_functions_tools: true
-          #   contentroot_variable_name: empty # Means skip
-          # - name: Calculation Results - AggregatedTimeSeriesQueriesCsvTests split 2
-          #   paths: \source\dotnet\wholesale-api\CalculationResults\CalculationResults.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.Wholesale.CalculationResults.IntegrationTests.dll
-          #   filter: (DisplayName~AggregatedTimeSeriesQueriesCsvTests)&(DisplayName!~BalanceResponsible)
-          #   use_azure_functions_tools: true
-          #   contentroot_variable_name: empty # Means skip
-          # - name: Calculation Results - Not AggregatedTimeSeriesQueriesCsvTests
-          #   paths: \source\dotnet\wholesale-api\CalculationResults\CalculationResults.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.Wholesale.CalculationResults.IntegrationTests.dll
-          #   filter: DisplayName!~AggregatedTimeSeriesQueriesCsvTests
-          #   use_azure_functions_tools: true
-          #   contentroot_variable_name: empty # Means skip
+          - name: Integration tests - split 2
+            paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
+            filter: DisplayName~Behaviours.IntegrationEvents
+            use_azure_functions_tools: true
+            contentroot_variable_name: empty # Means skip
+          - name: Integration tests - split 3
+            paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
+            filter: DisplayName~Infrastructure.Retention
+            use_azure_functions_tools: true
+            contentroot_variable_name: empty # Means skip
+          - name: Integration tests - split 4
+            paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
+            filter: (DisplayName!~Behaviours.IncomingRequests)&(DisplayName!~Behaviours.IntegrationEvents)&(DisplayName!~Infrastructure.Retention)
+            use_azure_functions_tools: true
+            contentroot_variable_name: empty # Means skip
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
     with:
       download_attempt_limit: 20

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -24,6 +24,25 @@ jobs:
     with:
       solution_file_path: source/EDI.sln
 
+  # Tests that do not require the integration test environment
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        tests_filter_expression:
+          - name: Architecture Tests
+            paths: \source\ArchitectureTests\bin\Release\net8.0\Energinet.DataHub.EDI.ArchitectureTests.dll
+          - name: Tests
+            paths: \source\Tests\bin\Release\net8.0\Energinet.DataHub.EDI.Tests.dll
+          - name: B2BApi AppTests
+            paths: \source\Tests\bin\Release\net8.0\Energinet.DataHub.EDI.B2BApi.AppTests.dll
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
+    with:
+      download_attempt_limit: 30
+      # Matrix parameters
+      job_name: ${{ matrix.tests_filter_expression.name }}
+      tests_dll_file_path: ${{ matrix.tests_filter_expression.paths }}
+
   # Run all tests in 'IntegrationTests.dll'
   integration_tests:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
@@ -37,28 +56,4 @@ jobs:
       azure_keyvault_url: ${{ vars.integration_test_azure_keyvault_url }}
       environment: AzureAuth
       run_integration_tests: true
-      download_attempt_limit: 20 # 20 retries with 15 seconds delay = 5 minutes wait before timeout
-
-  # Run all tests in 'ArchitectureTests.dll'
-  architecture_tests:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
-    with:
-      job_name: Architecture tests
-      tests_dll_file_path: \source\ArchitectureTests\bin\Release\net8.0\Energinet.DataHub.EDI.ArchitectureTests.dll
-      download_attempt_limit: 20 # 20 retries with 15 seconds delay = 5 minutes wait before timeout
-
-  # Run all tests in 'Tests.dll'
-  tests:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
-    with:
-      job_name: Tests
-      tests_dll_file_path: \source\Tests\bin\Release\net8.0\Energinet.DataHub.EDI.Tests.dll
-      download_attempt_limit: 20 # 20 retries with 15 seconds delay = 5 minutes wait before timeout
-
-  # Run all tests in 'Tests.dll'
-  b2bapi_apptests:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
-    with:
-      job_name: B2BApi AppTests
-      tests_dll_file_path: \source\Tests\bin\Release\net8.0\Energinet.DataHub.EDI.B2BApi.AppTests.dll
       download_attempt_limit: 20 # 20 retries with 15 seconds delay = 5 minutes wait before timeout

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -61,11 +61,4 @@ jobs:
     with:
       job_name: B2BApi AppTests
       tests_dll_file_path: \source\Tests\bin\Release\net8.0\Energinet.DataHub.EDI.B2BApi.AppTests.dll
-      use_azure_functions_tools: true
-      azure_integrationtest_tenant_id: ${{ vars.integration_test_azure_tenant_id }}
-      azure_integrationtest_subscription_id: ${{ vars.integration_test_azure_subscription_id }}
-      azure_integrationtest_spn_id: ${{ vars.integration_test_azure_spn_id_oidc }}
-      azure_keyvault_url: ${{ vars.integration_test_azure_keyvault_url }}
-      environment: AzureAuth
-      run_integration_tests: true
       download_attempt_limit: 20 # 20 retries with 15 seconds delay = 5 minutes wait before timeout

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -34,8 +34,6 @@ jobs:
             paths: \source\ArchitectureTests\bin\Release\net8.0\Energinet.DataHub.EDI.ArchitectureTests.dll
           - name: Tests
             paths: \source\Tests\bin\Release\net8.0\Energinet.DataHub.EDI.Tests.dll
-          - name: B2BApi AppTests
-            paths: \source\Tests\bin\Release\net8.0\Energinet.DataHub.EDI.B2BApi.AppTests.dll
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
     with:
       download_attempt_limit: 30
@@ -43,17 +41,50 @@ jobs:
       job_name: ${{ matrix.tests_filter_expression.name }}
       tests_dll_file_path: ${{ matrix.tests_filter_expression.paths }}
 
-  # Run all tests in 'IntegrationTests.dll'
+  # Tests that require the integration test environment
   integration_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        tests_filter_expression:
+          - name: B2BApi AppTests
+            paths: \source\Tests\bin\Release\net8.0\Energinet.DataHub.EDI.B2BApi.AppTests.dll
+            filter: empty # Means skip
+            use_azure_functions_tools: true
+            contentroot_variable_name: empty # Means skip
+          - name: Integration tests
+            paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
+            filter: empty # Means skip
+            use_azure_functions_tools: true
+            contentroot_variable_name: empty # Means skip
+          # - name: Calculation Results - AggregatedTimeSeriesQueriesCsvTests split 1
+          #   paths: \source\dotnet\wholesale-api\CalculationResults\CalculationResults.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.Wholesale.CalculationResults.IntegrationTests.dll
+          #   filter: (DisplayName~AggregatedTimeSeriesQueriesCsvTests)&(DisplayName~BalanceResponsible)
+          #   use_azure_functions_tools: true
+          #   contentroot_variable_name: empty # Means skip
+          # - name: Calculation Results - AggregatedTimeSeriesQueriesCsvTests split 2
+          #   paths: \source\dotnet\wholesale-api\CalculationResults\CalculationResults.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.Wholesale.CalculationResults.IntegrationTests.dll
+          #   filter: (DisplayName~AggregatedTimeSeriesQueriesCsvTests)&(DisplayName!~BalanceResponsible)
+          #   use_azure_functions_tools: true
+          #   contentroot_variable_name: empty # Means skip
+          # - name: Calculation Results - Not AggregatedTimeSeriesQueriesCsvTests
+          #   paths: \source\dotnet\wholesale-api\CalculationResults\CalculationResults.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.Wholesale.CalculationResults.IntegrationTests.dll
+          #   filter: DisplayName!~AggregatedTimeSeriesQueriesCsvTests
+          #   use_azure_functions_tools: true
+          #   contentroot_variable_name: empty # Means skip
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
     with:
-      job_name: Integration tests
-      tests_dll_file_path: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
-      use_azure_functions_tools: true
+      download_attempt_limit: 20
       azure_integrationtest_tenant_id: ${{ vars.integration_test_azure_tenant_id }}
       azure_integrationtest_subscription_id: ${{ vars.integration_test_azure_subscription_id }}
       azure_integrationtest_spn_id: ${{ vars.integration_test_azure_spn_id_oidc }}
       azure_keyvault_url: ${{ vars.integration_test_azure_keyvault_url }}
       environment: AzureAuth
       run_integration_tests: true
-      download_attempt_limit: 20 # 20 retries with 15 seconds delay = 5 minutes wait before timeout
+      # Matrix parameters
+      job_name: ${{ matrix.tests_filter_expression.name }}
+      tests_dll_file_path: ${{ matrix.tests_filter_expression.paths }}
+      tests_filter_expression: ${{ matrix.tests_filter_expression.filter }}
+      use_azure_functions_tools: ${{ matrix.tests_filter_expression.use_azure_functions_tools }}
+      aspnetcore_test_contentroot_variable_name: ${{ matrix.tests_filter_expression.contentroot_variable_name }}
+      aspnetcore_test_contentroot_variable_value: ${{ matrix.tests_filter_expression.contentroot_variable_value }}

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -22,7 +22,6 @@ limitations under the License.
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="6.1.0" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
           <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Description

Use matrix for execution of tests in CI.

PoC'ed splitting the IntegrationTests execution up, but it didn't improve the build time much, so decided not to add it ATM.

## References

Part of:
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/279