### PR TITLE
refac: Refactor flaky test

### DIFF
--- a/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
@@ -267,12 +267,14 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
         IEnumerable<ResponseMessage> results = await Task.WhenAll(task01, task02);
 
         // Assert
-        Assert.Multiple(
-            () => Assert.NotNull(results),
-            () => Assert.Single(results.Where(result => result.IsErrorResponse)),
-            () => Assert.Single(results.Where(result =>
-                result.MessageBody.Contains(exceptedDuplicateTransactionIdDetectedErrorCode, StringComparison.OrdinalIgnoreCase)
-                || result.MessageBody.Contains(exceptedDuplicateMessageIdDetectedErrorCode, StringComparison.OrdinalIgnoreCase))));
+        using var assertionScope = new AssertionScope();
+        results.Should().NotBeNullOrEmpty();
+        results.Should().ContainSingle(result => result.IsErrorResponse, because: "we expect the results contains exactly 1 error");
+
+        var errorResult = results.Single(result => result.IsErrorResponse);
+        errorResult.MessageBody.Should().ContainAny([
+            exceptedDuplicateTransactionIdDetectedErrorCode,
+            exceptedDuplicateMessageIdDetectedErrorCode]);
     }
 
     [Theory]


### PR DESCRIPTION
## Description

Refactor flaky test so we get more precise information in CI log if it fails.

Example of new output:
![image](https://github.com/user-attachments/assets/2f07b4fc-64d1-4ec1-835e-7b22bc97dc97)

## References

Part of:
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/279