### PR TITLE
test: fix flaky test to use correct error code

### DIFF
--- a/source/IncomingMessages.Domain/Validation/ValidationErrors/DuplicateTransactionIdDetected.cs
+++ b/source/IncomingMessages.Domain/Validation/ValidationErrors/DuplicateTransactionIdDetected.cs
@@ -22,7 +22,7 @@ public class DuplicateTransactionIdDetected : ValidationError
     }
 
     public DuplicateTransactionIdDetected()
-        : base("Duplicated transaction id found", "00110", "TransactionId")
+        : base("Duplicated transaction id found", "00102", "TransactionId")
     {
     }
 }

--- a/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
+++ b/source/IntegrationTests/Application/IncomingMessages/WhenIncomingMessagesIsReceivedTests.cs
@@ -228,7 +228,7 @@ public class WhenIncomingMessagesIsReceivedTests : TestBase
     public async Task Second_request_with_same_transactionId_and_messageId_is_rejected(DocumentFormat format, IncomingDocumentType incomingDocumentType, IncomingMarketMessageStream incomingMarketMessageStream)
     {
         // Arrange
-        var exceptedDuplicateTransactionIdDetectedErrorCode = "00110";
+        var exceptedDuplicateTransactionIdDetectedErrorCode = "00102";
         var exceptedDuplicateMessageIdDetectedErrorCode = "00101";
         var authenticatedActor = GetService<AuthenticatedActor>();
         var senderActorNumber = ActorNumber.Create("5799999933318");


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
When DuplicateMessageIdDetected is triggered tests are green. However, since DuplicateTransactionIdDetected had a wrong error code in one of the two constructors tests will then be red. 

## References
