### PR TITLE
fix: external id is not unique for idempotent field

### DIFF
--- a/source/ApplyDBMigrationsApp/Scripts/Model/202408141237 Add IdempotentId to OutgoingMessages.sql
+++ b/source/ApplyDBMigrationsApp/Scripts/Model/202408141237 Add IdempotentId to OutgoingMessages.sql
@@ -3,7 +3,7 @@ ALTER TABLE [dbo].[OutgoingMessages]
 GO
 
 UPDATE [dbo].[OutgoingMessages]
-SET [IdempotentId] = [ExternalId]
+SET [IdempotentId] = NEWID()
 WHERE [IdempotentId] IS NULL;
 GO
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
FIX: The CREATE UNIQUE INDEX statement terminated because a duplicate key was found for the object name 'dbo.OutgoingMessages' and the index name 'IDX_OutgoingMessageIdempotency'. The duplicate key value is (449478DA-516A-47B7-B7B0-63294771485C).

## References
