### PR TITLE
feat: improve performance on idempotent check for outgoing messages

### DIFF
--- a/source/ApplyDBMigrationsApp/ApplyDBMigrationsApp.csproj
+++ b/source/ApplyDBMigrationsApp/ApplyDBMigrationsApp.csproj
@@ -193,6 +193,8 @@ limitations under the License.
     <EmbeddedResource Include="Scripts\Model\202407011050 Create index for OutgoingMessages AssignedBundleId.sql" />
     <EmbeddedResource Include="Scripts\Model\202407311435 Create index for ReceivedIntegrationEvents OccurredOn.sql" />
     <EmbeddedResource Include="Scripts\Model\202408141237 Add IdempotentId to OutgoingMessages.sql" />
+    <EmbeddedResource Include="Scripts\Model\202408201254 Add Idempontent index to OutgoingMessages.sql" />
+    <EmbeddedResource Include="Scripts\Model\202408201253 Add PeriodStartedAt to OutgoingMessages.sql" />
     <None Remove="Scripts\Model\202227101333 Add AggregatedTimeSeriesTransactions table.sql" />
     <None Remove="Scripts\Model\202310201142 resize ActorNumber nvarchar on Actor.sql" />
     <None Remove="Scripts\Model\202310231329 Alter Bundles1.sql" />

--- a/source/ApplyDBMigrationsApp/Scripts/Model/202408201253 Add PeriodStartedAt to OutgoingMessages.sql
+++ b/source/ApplyDBMigrationsApp/Scripts/Model/202408201253 Add PeriodStartedAt to OutgoingMessages.sql
@@ -1,0 +1,3 @@
+ALTER TABLE [dbo].[OutgoingMessages]
+    ADD [PeriodStartedAt] DATETIME2 NOT NULL DEFAULT dateadd(DD,-14,getdate());
+GO

--- a/source/ApplyDBMigrationsApp/Scripts/Model/202408201253 Add PeriodStartedAt to OutgoingMessages.sql
+++ b/source/ApplyDBMigrationsApp/Scripts/Model/202408201253 Add PeriodStartedAt to OutgoingMessages.sql
@@ -1,3 +1,3 @@
 ALTER TABLE [dbo].[OutgoingMessages]
-    ADD [PeriodStartedAt] DATETIME2 NOT NULL DEFAULT dateadd(DD,-14,getdate());
+    ADD [PeriodStartedAt] DATETIME2 NULL DEFAULT dateadd(DD,-14,getdate());
 GO

--- a/source/ApplyDBMigrationsApp/Scripts/Model/202408201254 Add Idempontent index to OutgoingMessages.sql
+++ b/source/ApplyDBMigrationsApp/Scripts/Model/202408201254 Add Idempontent index to OutgoingMessages.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX IDX_OutgoingMessage_ReceiverRole_ExternalId_PeriodStartedAt ON [dbo].[OutgoingMessages] (ExternalId, ReceiverRole, PeriodStartedAt);

--- a/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageTests.cs
+++ b/source/IntegrationTests/Application/OutgoingMessages/WhenEnqueueingOutgoingMessageTests.cs
@@ -125,6 +125,7 @@ public class WhenEnqueueingOutgoingMessageTests : TestBase
             () => Assert.Equal(message.ExternalId.Value, messageFromDatabase.ExternalId),
             () => Assert.Equal(message.CalculationId, messageFromDatabase.CalculationId),
             () => Assert.Equal(messageFromDatabase.IdempotentId, expectedOutgoingMessageIdempotentId),
+            () => Assert.NotNull(messageFromDatabase.PeriodStartedAt),
         };
 
         Assert.Multiple(propertyAssertions);

--- a/source/OutgoingMessages.Application/UseCases/EnqueueMessage.cs
+++ b/source/OutgoingMessages.Application/UseCases/EnqueueMessage.cs
@@ -61,7 +61,11 @@ public class EnqueueMessage
         messageToEnqueue = await _delegateMessage.DelegateAsync(messageToEnqueue, cancellationToken)
                 .ConfigureAwait(false);
 
-        var existingMessage = await _outgoingMessageRepository.GetAsync(messageToEnqueue.IdempotentId).ConfigureAwait(false);
+        var existingMessage = await _outgoingMessageRepository.GetAsync(
+                messageToEnqueue.Receiver.ActorRole,
+                messageToEnqueue.ExternalId,
+                messageToEnqueue.PeriodStartedAt)
+            .ConfigureAwait(false);
         if (existingMessage != null) // Message is already enqueued, do nothing (idempotency check)
             return existingMessage.Id;
 

--- a/source/OutgoingMessages.Domain/Models/OutgoingMessages/IOutgoingMessageRepository.cs
+++ b/source/OutgoingMessages.Domain/Models/OutgoingMessages/IOutgoingMessageRepository.cs
@@ -15,6 +15,7 @@
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.ActorMessagesQueues;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.Bundles;
+using NodaTime;
 
 namespace Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.OutgoingMessages;
 
@@ -42,6 +43,11 @@ public interface IOutgoingMessageRepository
     /// Get message in the database for the idempotency id.
     /// </summary>
     Task<OutgoingMessage?> GetAsync(OutgoingMessageIdempotentId idempotentId);
+
+    /// <summary>
+    /// Get message in the database for the designated receiver role and the external id and period started at.
+    /// </summary>
+    Task<OutgoingMessage?> GetAsync(ActorRole receiverRole, ExternalId externalId, Instant? periodStartedAt);
 
     /// <summary>
     /// Delete outgoing messages if they exists

--- a/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
+++ b/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
@@ -62,6 +62,7 @@ public class OutgoingMessage
             periodStartedAt);
         ExternalId = externalId;
         CalculationId = calculationId;
+        PeriodStartedAt = periodStartedAt;
     }
 
     /// <summary>
@@ -83,7 +84,8 @@ public class OutgoingMessage
         string? gridAreaCode,
         ExternalId externalId,
         Guid? calculationId,
-        OutgoingMessageIdempotentId idempotentId)
+        OutgoingMessageIdempotentId idempotentId,
+        Instant? periodStartedAt)
     {
         Id = id;
         DocumentType = documentType;
@@ -99,6 +101,7 @@ public class OutgoingMessage
         ExternalId = externalId;
         CalculationId = calculationId;
         IdempotentId = idempotentId;
+        PeriodStartedAt = periodStartedAt;
         // DocumentReceiver, EF will set this after the constructor
         // Receiver, EF will set this after the constructor
         // _serializedContent is set later in OutgoingMessageRepository, by getting the message from File Storage
@@ -153,6 +156,8 @@ public class OutgoingMessage
     public ExternalId ExternalId { get; }
 
     public Guid? CalculationId { get; }
+
+    public Instant? PeriodStartedAt { get; }
 
     public OutgoingMessageIdempotentId IdempotentId { get; set; }
 

--- a/source/OutgoingMessages.Infrastructure/Repositories/OutgoingMessages/OutgoingMessageEntityConfiguration.cs
+++ b/source/OutgoingMessages.Infrastructure/Repositories/OutgoingMessages/OutgoingMessageEntityConfiguration.cs
@@ -126,6 +126,7 @@ public class OutgoingMessageEntityConfiguration : IEntityTypeConfiguration<Outgo
                     .HasColumnName("ReceiverRole");
             });
 
+        builder.Property(x => x.PeriodStartedAt);
         builder.Property(x => x.CreatedAt);
 
         builder.Property<string>("CreatedBy");

--- a/source/OutgoingMessages.Infrastructure/Repositories/OutgoingMessages/OutgoingMessageRepository.cs
+++ b/source/OutgoingMessages.Infrastructure/Repositories/OutgoingMessages/OutgoingMessageRepository.cs
@@ -20,6 +20,7 @@ using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.Bundles;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.OutgoingMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Configuration.DataAccess;
 using Microsoft.EntityFrameworkCore;
+using NodaTime;
 
 namespace Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Repositories.OutgoingMessages;
 
@@ -84,6 +85,14 @@ public class OutgoingMessageRepository : IOutgoingMessageRepository
     public async Task<OutgoingMessage?> GetAsync(OutgoingMessageIdempotentId idempotentId)
     {
         return await _context.OutgoingMessages.FirstOrDefaultAsync(x => x.IdempotentId == idempotentId).ConfigureAwait(false);
+    }
+
+    public async Task<OutgoingMessage?> GetAsync(ActorRole receiverRole, ExternalId externalId, Instant? periodStartedAt)
+    {
+        return await _context.OutgoingMessages
+            .FirstOrDefaultAsync(x => x.Receiver.ActorRole == receiverRole &&
+                                                    x.ExternalId == externalId &&
+                                                    x.PeriodStartedAt == periodStartedAt).ConfigureAwait(false);
     }
 
     public async Task DeleteOutgoingMessagesIfExistsAsync(IReadOnlyCollection<BundleId> bundleMessageIds)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
4mio outgoing messages in db
Perf with Idempotent id field on outgoing messages 
=> Enqueue 291 messages => Orchestration completed in 00:01:27.4812993
Perf with this PR 
=> Enqueue 291 messages => Orchestration completed in 00:00:22.0314863

## References
