### PR TITLE
feat: Use unity catalog instead of hive metastore

### DIFF
--- a/source/ArchitectureTests/ArchitectureTests.csproj
+++ b/source/ArchitectureTests/ArchitectureTests.csproj
@@ -53,6 +53,7 @@ limitations under the License.
       <ProjectReference Include="..\IncomingMessages.Infrastructure\IncomingMessages.Infrastructure.csproj" />
       <ProjectReference Include="..\OutgoingMessages.Application\OutgoingMessages.Application.csproj" />
       <ProjectReference Include="..\OutgoingMessages.Domain\OutgoingMessages.Domain.csproj" />
+      <ProjectReference Include="..\OutgoingMessages.Infrastructure\OutgoingMessages.Infrastructure.csproj" />
       <ProjectReference Include="..\Process.Application\Process.Application.csproj" />
       <ProjectReference Include="..\Process.Infrastructure\Process.Infrastructure.csproj" />
     </ItemGroup>

--- a/source/ArchitectureTests/RegistrationTests.cs
+++ b/source/ArchitectureTests/RegistrationTests.cs
@@ -27,6 +27,7 @@ using Energinet.DataHub.EDI.OutgoingMessages.Application.UseCases;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.DocumentWriters;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.DocumentWriters.NotifyAggregatedMeasureData;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.DocumentWriters.NotifyWholesaleServices;
+using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Extensions.Options;
 using Energinet.DataHub.EDI.Process.Application.Transactions.AggregatedMeasureData;
 using Energinet.DataHub.EDI.Process.Infrastructure.Configuration.Options;
 using FluentAssertions;
@@ -63,6 +64,7 @@ public class RegistrationTests
         Environment.SetEnvironmentVariable(nameof(DatabricksSqlStatementOptions.WorkspaceUrl), "https://adb-1000.azuredatabricks.net/");
         Environment.SetEnvironmentVariable(nameof(DatabricksSqlStatementOptions.WorkspaceToken), "FakeToken");
         Environment.SetEnvironmentVariable(nameof(DatabricksSqlStatementOptions.WarehouseId), Guid.NewGuid().ToString());
+        Environment.SetEnvironmentVariable($"{EdiDatabricksOptions.SectionName}__{nameof(EdiDatabricksOptions.CatalogName)}", "FakeCatalogName");
 
         _host = HostFactory.CreateHost(Program.TokenValidationParameters);
     }

--- a/source/B2BApi.AppTests/Fixtures/B2BApiAppFixture.cs
+++ b/source/B2BApi.AppTests/Fixtures/B2BApiAppFixture.cs
@@ -377,6 +377,9 @@ public class B2BApiAppFixture : IAsyncLifetime
         appHostSettings.ProcessEnvironmentVariables.Add(
             $"{EdiDatabricksOptions.SectionName}:{nameof(EdiDatabricksOptions.DatabaseName)}",
             DatabricksSchemaManager.SchemaName);
+        appHostSettings.ProcessEnvironmentVariables.Add(
+            $"{EdiDatabricksOptions.SectionName}:{nameof(EdiDatabricksOptions.CatalogName)}",
+            "hive_metastore");
 
         // ServiceBus connection strings
         appHostSettings.ProcessEnvironmentVariables.Add(

--- a/source/B2BApi/local.settings.sample.json
+++ b/source/B2BApi/local.settings.sample.json
@@ -35,6 +35,7 @@
     "WorkspaceToken": "<Databricks workspace token>",
     "WorkspaceUrl": "<Databricks workspace url>",
     "WarehouseId": "<Databricks warehouse id>",
+    "EdiDatabricks__CatalogName": "<Databricks unity catalog name>",
 
     // Durable Functions Task Hub Name
     // See naming constraints: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-task-hubs?tabs=csharp#task-hub-names

--- a/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
+++ b/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
@@ -443,6 +443,7 @@ public class BehavioursTestBase : IDisposable
 
                     // => EDI views
                     [$"{EdiDatabricksOptions.SectionName}:{nameof(EdiDatabricksOptions.DatabaseName)}"] = _integrationTestFixture.DatabricksSchemaManager.SchemaName,
+                    [$"{EdiDatabricksOptions.SectionName}:{nameof(EdiDatabricksOptions.CatalogName)}"] = "hive_metastore",
                 })
             .Build();
 

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -307,6 +307,7 @@ public class TestBase : IDisposable
                     [nameof(DatabricksSqlStatementOptions.WarehouseId)] = Fixture.IntegrationTestConfiguration.DatabricksSettings.WarehouseId,
                     // => EDI views
                     [$"{EdiDatabricksOptions.SectionName}:{nameof(EdiDatabricksOptions.DatabaseName)}"] = Fixture.DatabricksSchemaManager.SchemaName,
+                    [$"{EdiDatabricksOptions.SectionName}:{nameof(EdiDatabricksOptions.CatalogName)}"] = "hive_metastore",
                 })
             .Build();
 

--- a/source/OutgoingMessages.Infrastructure/Databricks/CalculationResultQueryBase.cs
+++ b/source/OutgoingMessages.Infrastructure/Databricks/CalculationResultQueryBase.cs
@@ -31,7 +31,7 @@ public abstract class CalculationResultQueryBase<TResult>(
     /// <summary>
     /// Name of database to query in.
     /// </summary>
-    public string DatabaseName => ediDatabricksOptions.DatabaseName;
+    public string DatabaseName => $"{ediDatabricksOptions.CatalogName}.{ediDatabricksOptions.DatabaseName}";
 
     /// <summary>
     /// Name of view or table to query in.

--- a/source/OutgoingMessages.Infrastructure/Databricks/EnergyResults/Queries/EnergyResultPerBalanceResponsiblePerGridAreaQuery.cs
+++ b/source/OutgoingMessages.Infrastructure/Databricks/EnergyResults/Queries/EnergyResultPerBalanceResponsiblePerGridAreaQuery.cs
@@ -45,7 +45,7 @@ public class EnergyResultPerBalanceResponsiblePerGridAreaQuery(
 {
     private readonly EventId _eventId = eventId;
 
-    public override string DataObjectName => "energy_per_brp_ga_v1";
+    public override string DataObjectName => "energy_per_brp_v1";
 
     public override Dictionary<string, (string DataType, bool IsNullable)> SchemaDefinition => new()
     {

--- a/source/OutgoingMessages.Infrastructure/Databricks/EnergyResults/Queries/EnergyResultPerEnergySupplierPerBalanceResponsiblePerGridAreaQuery.cs
+++ b/source/OutgoingMessages.Infrastructure/Databricks/EnergyResults/Queries/EnergyResultPerEnergySupplierPerBalanceResponsiblePerGridAreaQuery.cs
@@ -45,7 +45,7 @@ public class EnergyResultPerEnergySupplierPerBalanceResponsiblePerGridAreaQuery(
 {
     private readonly EventId _eventId = eventId;
 
-    public override string DataObjectName => "energy_per_es_brp_ga_v1";
+    public override string DataObjectName => "energy_per_es_v1";
 
     public override Dictionary<string, (string DataType, bool IsNullable)> SchemaDefinition => new()
     {

--- a/source/OutgoingMessages.Infrastructure/Databricks/EnergyResults/Queries/EnergyResultPerGridAreaQuery.cs
+++ b/source/OutgoingMessages.Infrastructure/Databricks/EnergyResults/Queries/EnergyResultPerGridAreaQuery.cs
@@ -47,7 +47,7 @@ public class EnergyResultPerGridAreaQuery(
     private readonly IMasterDataClient _masterDataClient = masterDataClient;
     private readonly EventId _eventId = eventId;
 
-    public override string DataObjectName => "energy_per_ga_v1";
+    public override string DataObjectName => "energy_v1";
 
     public override Dictionary<string, (string DataType, bool IsNullable)> SchemaDefinition => new()
     {

--- a/source/OutgoingMessages.Infrastructure/Extensions/Options/EdiDatabricksOptions.cs
+++ b/source/OutgoingMessages.Infrastructure/Extensions/Options/EdiDatabricksOptions.cs
@@ -27,5 +27,12 @@ public class EdiDatabricksOptions
     /// Name of the database in which the views for EDI are located.
     /// </summary>
     [Required]
-    public string DatabaseName { get; set; } = "wholesale_calculation_results";
+    public string DatabaseName { get; set; } = "wholesale_results";
+
+    /// <summary>
+    /// Name of the catalog in which the views for EDI are located.
+    /// Should point at the unity catalog when running in Azure, and use hive_metastore when running in tests
+    /// </summary>
+    [Required]
+    public string CatalogName { get; set; } = null!;
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Use unity catalog instead of hive metastore when getting data from views in databricks

- Use `CatalogName` appsetting when running in Azure (populated from infrastructure)
- Use `hive_metastore` as `CatalogName` when running tests

I've verified that the subsystem test queries on dev002 actually are querying the unity catalog instead of hive metastore:
![image](https://github.com/user-attachments/assets/a18e58eb-0213-4705-9009-0167ba5d02fd)
`ctl_shres_d_we_002` is the name of the unity catalog on d002

## References

- [x] Required infrastructure PR: https://github.com/Energinet-DataHub/dh3-infrastructure/pull/1907
- [x] Required automations PR for d001: https://github.com/Energinet-DataHub/dh3-automation/pull/459
- [x] Required automations PR for d002: https://github.com/Energinet-DataHub/dh3-automation/pull/457
- Task: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/252 => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/10524051443/job/29160300618


## Checklist
- ~~[ ] Should the change be behind a feature flag?~~
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/10524051443/job/29160300618
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/252