### PR TITLE
docs: A bit better guidance for OutgoingMessage idempotency

### DIFF
--- a/source/BuildingBlocks.Domain/Models/ExternalId.cs
+++ b/source/BuildingBlocks.Domain/Models/ExternalId.cs
@@ -18,6 +18,9 @@ namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 
 /// <summary>
 /// An ExternalId to represent what the systems external source uses as an identifier
+/// The value provided must not change even if operation fails.
+/// This is to ensure that the same external id is used for the same operation.
+/// An 
 /// </summary>
 [Serializable]
 public record ExternalId

--- a/source/BuildingBlocks.Domain/Models/ExternalId.cs
+++ b/source/BuildingBlocks.Domain/Models/ExternalId.cs
@@ -20,7 +20,7 @@ namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 /// An ExternalId to represent what the systems external source uses as an identifier
 /// The value provided must not change even if operation fails.
 /// This is to ensure that the same external id is used for the same operation.
-/// An 
+/// So a message can only be delivered once for a given external id. (Unless additional logic is provided to check for idempotency)
 /// </summary>
 [Serializable]
 public record ExternalId

--- a/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
+++ b/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessage.cs
@@ -151,6 +151,10 @@ public class OutgoingMessage
 
     public Guid? CalculationId { get; }
 
+    /// <summary>
+    /// In case a series is provided for the outgoing message, the start of the series period should be provided.
+    /// It is used to determine if a actor already have received the message.
+    /// </summary>
     public Instant? PeriodStartedAt { get; }
 
     public void AssignToBundle(BundleId bundleId)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
This PR will aim to provide more insight of the importance of `ExternalId` for `OutgoingMessage` idempotency

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/242
## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task