### PR TITLE
feat: avoid enqueue message for internal calculations

### DIFF
--- a/source/IntegrationEvents.Infrastructure/EventProcessors/CalculationCompletedV1Processor.cs
+++ b/source/IntegrationEvents.Infrastructure/EventProcessors/CalculationCompletedV1Processor.cs
@@ -46,11 +46,13 @@ public sealed class CalculationCompletedV1Processor : IIntegrationEventProcessor
         var instanceId = await durableClient.StartNewAsync("EnqueueMessagesOrchestration", orchestrationInput).ConfigureAwait(false);
 
         _logger.LogInformation(
-            "Started 'EnqueueMessagesOrchestration' (id '{OrchestrationInstanceId}', calculation id: {CalculationId}, calculation type: {CalculationType}, calculation orchestration id: {CalculationOrchestrationId}.",
+            "Started 'EnqueueMessagesOrchestration' (id '{OrchestrationInstanceId}', calculation id: {CalculationId}, calculation type: {CalculationType}, calculation orchestration id: {CalculationOrchestrationId}. is calculation internal: {IsInternalCalculation})",
             instanceId,
             message.CalculationId,
             message.CalculationType,
-            message.InstanceId);
+            message.InstanceId,
+            false);
+            //TODO: message.IsInternalCalculation);
     }
 
     private static EnqueueMessagesOrchestrationInput CreateOrchestrationInput(CalculationCompletedV1 message, Guid eventIdentification)
@@ -58,6 +60,8 @@ public sealed class CalculationCompletedV1Processor : IIntegrationEventProcessor
         return new EnqueueMessagesOrchestrationInput(
             CalculationOrchestrationId: message.InstanceId,
             CalculationId: Guid.Parse(message.CalculationId),
-            EventId: eventIdentification);
+            EventId: eventIdentification,
+            IsInternalCalculation: false);
+            //TODO: IsInternalCalculation: message.IsInternalCalculation);
     }
 }

--- a/source/IntegrationEvents.Infrastructure/Model/EnqueueMessagesOrchestrationInput.cs
+++ b/source/IntegrationEvents.Infrastructure/Model/EnqueueMessagesOrchestrationInput.cs
@@ -22,4 +22,5 @@ namespace Energinet.DataHub.EDI.IntegrationEvents.Infrastructure.Model;
 public sealed record EnqueueMessagesOrchestrationInput(
     string CalculationOrchestrationId,
     Guid CalculationId,
-    Guid EventId);
+    Guid EventId,
+    bool IsInternalCalculation);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Ensure we skip enqueue calculation results if the calculation is an internal calculation.

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/280