### PR TITLE
feat: new feature flag to disable peek message

### DIFF
--- a/source/BuildingBlocks.Application/FeatureFlag/FeatureFlagName.cs
+++ b/source/BuildingBlocks.Application/FeatureFlag/FeatureFlagName.cs
@@ -24,4 +24,9 @@ public enum FeatureFlagName
     /// Whether to send audit logs to the audit log service
     /// </summary>
     UseAuditLog,
+
+    /// <summary>
+    /// Whether to disable peek messages
+    /// </summary>
+    PeekMessagesDisabled,
 }

--- a/source/BuildingBlocks.Application/FeatureFlag/IFeatureFlagManager.cs
+++ b/source/BuildingBlocks.Application/FeatureFlag/IFeatureFlagManager.cs
@@ -28,4 +28,9 @@ public interface IFeatureFlagManager
     /// Whether to send audit logs to the audit log service
     /// </summary>
     Task<bool> UseAuditLogAsync();
+
+    /// <summary>
+    /// Whether to disallow actors to peek messages.
+    /// </summary>
+    Task<bool> PeekMessagesDisabledAsync();
 }

--- a/source/BuildingBlocks.Application/FeatureFlag/MicrosoftFeatureFlagManager.cs
+++ b/source/BuildingBlocks.Application/FeatureFlag/MicrosoftFeatureFlagManager.cs
@@ -30,5 +30,7 @@ public class MicrosoftFeatureFlagManager : IFeatureFlagManager
 
     public Task<bool> UseAuditLogAsync() => IsEnabledAsync(FeatureFlagName.UseAuditLog);
 
+    public Task<bool> PeekMessagesDisabledAsync() => IsEnabledAsync(FeatureFlagName.PeekMessagesDisabled);
+
     private Task<bool> IsEnabledAsync(FeatureFlagName featureFlagName) => _featureManager.IsEnabledAsync(featureFlagName.ToString());
 }

--- a/source/IntegrationTests/TestDoubles/FeatureFlagManagerStub.cs
+++ b/source/IntegrationTests/TestDoubles/FeatureFlagManagerStub.cs
@@ -24,4 +24,6 @@ namespace Energinet.DataHub.EDI.IntegrationTests.TestDoubles;
 public class FeatureFlagManagerStub : IFeatureFlagManager
 {
     public Task<bool> UseAuditLogAsync() => Task.FromResult(true);
+
+    public Task<bool> PeekMessagesDisabledAsync() => Task.FromResult(false);
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
New feature flag to ensure actors can't peek message when enabled. 
## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task