### PR TITLE
refac: Use ServiceBus IAM

### DIFF
--- a/source/AcceptanceTests/AcceptanceTests.csproj
+++ b/source/AcceptanceTests/AcceptanceTests.csproj
@@ -29,7 +29,7 @@
     <ItemGroup>
         <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
         <PackageReference Include="Dapper" Version="2.1.35" />
-        <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="6.2.0" />
+        <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="6.3.0" />
         <PackageReference Include="Energinet.DataHub.Wholesale.Contracts" Version="10.0.0" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">

--- a/source/ArchitectureTests/RegistrationTests.cs
+++ b/source/ArchitectureTests/RegistrationTests.cs
@@ -57,9 +57,7 @@ public class RegistrationTests
         // The following declaration slows down the test execution, since creating a new Uri is a heavy operation
         Environment.SetEnvironmentVariable("AZURE_STORAGE_ACCOUNT_URL", TestEnvironment.CreateFakeStorageUrl());
 
-        Environment.SetEnvironmentVariable($"{ServiceBusOptions.SectionName}__{nameof(ServiceBusOptions.ManageConnectionString)}", TestEnvironment.CreateFakeServiceBusConnectionString());
-        Environment.SetEnvironmentVariable($"{ServiceBusOptions.SectionName}__{nameof(ServiceBusOptions.ListenConnectionString)}", TestEnvironment.CreateFakeServiceBusConnectionString());
-        Environment.SetEnvironmentVariable($"{ServiceBusOptions.SectionName}__{nameof(ServiceBusOptions.SendConnectionString)}", TestEnvironment.CreateFakeServiceBusConnectionString());
+        Environment.SetEnvironmentVariable($"{ServiceBusOptions.SectionName}__{nameof(ServiceBusOptions.FullyQualifiedNamespace)}", TestEnvironment.CreateFakeServiceBusFullyQualifiedNamespace());
 
         Environment.SetEnvironmentVariable(nameof(DatabricksSqlStatementOptions.WorkspaceUrl), "https://adb-1000.azuredatabricks.net/");
         Environment.SetEnvironmentVariable(nameof(DatabricksSqlStatementOptions.WorkspaceToken), "FakeToken");
@@ -197,9 +195,7 @@ public class RegistrationTests
             .AddInMemoryCollection(
                 new Dictionary<string, string?>
                 {
-                    [$"{ServiceBusOptions.SectionName}__{nameof(ServiceBusOptions.ManageConnectionString)}"] = "Fake",
-                    [$"{ServiceBusOptions.SectionName}__{nameof(ServiceBusOptions.ListenConnectionString)}"] = "Fake",
-                    [$"{ServiceBusOptions.SectionName}__{nameof(ServiceBusOptions.SendConnectionString)}"] = "Fake",
+                    [$"{ServiceBusOptions.SectionName}__{nameof(ServiceBusOptions.FullyQualifiedNamespace)}"] = "Fake",
 
                     [$"{UserAuthenticationOptions.SectionName}:{nameof(UserAuthenticationOptions.MitIdExternalMetadataAddress)}"] = "NotEmpty",
                     [$"{UserAuthenticationOptions.SectionName}:{nameof(UserAuthenticationOptions.ExternalMetadataAddress)}"] = "NotEmpty",
@@ -267,10 +263,10 @@ public class RegistrationTests
     private sealed class TestEnvironment : RuntimeEnvironment
     {
         public override string? ServiceBus__SendConnectionString =>
-            CreateFakeServiceBusConnectionString();
+            CreateFakeServiceBusFullyQualifiedNamespace();
 
         public override string? REQUEST_RESPONSE_LOGGING_CONNECTION_STRING =>
-            CreateFakeServiceBusConnectionString();
+            CreateFakeServiceBusFullyQualifiedNamespace();
 
         public override string? DB_CONNECTION_STRING =>
             CreateConnectionString();
@@ -279,12 +275,10 @@ public class RegistrationTests
 
         public override string AZURE_FUNCTIONS_ENVIRONMENT => "Development";
 
-        public static string CreateFakeServiceBusConnectionString()
+        public static string CreateFakeServiceBusFullyQualifiedNamespace()
         {
             return new StringBuilder()
-                .Append(CultureInfo.InvariantCulture, $"Endpoint=sb://sb-{Guid.NewGuid():N}.servicebus.windows.net/;")
-                .Append("SharedAccessKeyName=send;")
-                .Append(CultureInfo.InvariantCulture, $"SharedAccessKey={Guid.NewGuid():N}")
+                .Append(CultureInfo.InvariantCulture, $"sb://sb-{Guid.NewGuid():N}.servicebus.windows.net/")
                 .ToString();
         }
 

--- a/source/B2BApi.AppTests/B2BApi.AppTests.csproj
+++ b/source/B2BApi.AppTests/B2BApi.AppTests.csproj
@@ -14,7 +14,7 @@
     </PackageReference>
     <PackageReference Include="CsvHelper" Version="33.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.5" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="6.2.0" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="6.3.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/B2BApi.AppTests/Fixtures/B2BApiAppFixture.cs
+++ b/source/B2BApi.AppTests/Fixtures/B2BApiAppFixture.cs
@@ -79,13 +79,13 @@ public class B2BApiAppFixture : IAsyncLifetime
         LogStopwatch(stopwatch, nameof(DatabaseManager));
 
         ServiceBusResourceProvider = new ServiceBusResourceProvider(
-            IntegrationTestConfiguration.ServiceBusConnectionString,
-            TestLogger);
+            TestLogger,
+            IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace);
         LogStopwatch(stopwatch, nameof(ServiceBusResourceProvider));
 
         ServiceBusListenerMock = new ServiceBusListenerMock(
-            IntegrationTestConfiguration.ServiceBusConnectionString,
-            TestLogger);
+            TestLogger,
+            IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace);
         LogStopwatch(stopwatch, nameof(ServiceBusListenerMock));
 
         HostConfigurationBuilder = new FunctionAppHostConfigurationBuilder();
@@ -383,14 +383,8 @@ public class B2BApiAppFixture : IAsyncLifetime
 
         // ServiceBus connection strings
         appHostSettings.ProcessEnvironmentVariables.Add(
-            $"{ServiceBusOptions.SectionName}__{nameof(ServiceBusOptions.ManageConnectionString)}",
-            ServiceBusResourceProvider.ConnectionString);
-        appHostSettings.ProcessEnvironmentVariables.Add(
-            $"{ServiceBusOptions.SectionName}__{nameof(ServiceBusOptions.ListenConnectionString)}",
-            ServiceBusResourceProvider.ConnectionString);
-        appHostSettings.ProcessEnvironmentVariables.Add(
-            $"{ServiceBusOptions.SectionName}__{nameof(ServiceBusOptions.SendConnectionString)}",
-            ServiceBusResourceProvider.ConnectionString);
+            $"{ServiceBusOptions.SectionName}__{nameof(ServiceBusOptions.FullyQualifiedNamespace)}",
+            ServiceBusResourceProvider.FullyQualifiedNamespace);
 
         // Feature Flags: Default values
         appHostSettings.ProcessEnvironmentVariables.Add(

--- a/source/B2BApi/EventListeners/InboxEventListener.cs
+++ b/source/B2BApi/EventListeners/InboxEventListener.cs
@@ -50,7 +50,7 @@ public class InboxEventListener
     public async Task RunAsync(
         [ServiceBusTrigger(
             $"%{EdiInboxOptions.SectionName}:{nameof(EdiInboxOptions.QueueName)}%",
-            Connection = $"{ServiceBusOptions.SectionName}:{nameof(ServiceBusOptions.ManageConnectionString)}")]
+            Connection = ServiceBusOptions.SectionName)]
         byte[] message,
         FunctionContext context,
         CancellationToken hostCancellationToken)

--- a/source/B2BApi/EventListeners/IntegrationEventListener.cs
+++ b/source/B2BApi/EventListeners/IntegrationEventListener.cs
@@ -45,7 +45,7 @@ public class IntegrationEventListener
         [ServiceBusTrigger(
             $"%{IntegrationEventsOptions.SectionName}:{nameof(IntegrationEventsOptions.TopicName)}%",
             $"%{IntegrationEventsOptions.SectionName}:{nameof(IntegrationEventsOptions.SubscriptionName)}%",
-            Connection = $"{ServiceBusOptions.SectionName}:{nameof(ServiceBusOptions.ManageConnectionString)}")]
+            Connection = ServiceBusOptions.SectionName)]
         byte[] eventData,
         FunctionContext context)
     {

--- a/source/B2BApi/EventListeners/ProcessInitializationListener.cs
+++ b/source/B2BApi/EventListeners/ProcessInitializationListener.cs
@@ -48,7 +48,7 @@ public class ProcessInitializationListener
     public async Task RunAsync(
         [ServiceBusTrigger(
             $"%{IncomingMessagesQueueOptions.SectionName}:{nameof(IncomingMessagesQueueOptions.QueueName)}%",
-            Connection = $"{ServiceBusOptions.SectionName}:{nameof(ServiceBusOptions.ManageConnectionString)}")]
+            Connection = ServiceBusOptions.SectionName)]
         ServiceBusReceivedMessage message)
     {
         ArgumentNullException.ThrowIfNull(message);

--- a/source/B2CWebApi.AppTests/B2CWebApi.AppTests.csproj
+++ b/source/B2CWebApi.AppTests/B2CWebApi.AppTests.csproj
@@ -12,7 +12,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="6.2.0" />
+        <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="6.3.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/B2CWebApi.AppTests/Fixture/B2CWebApiFixture.cs
+++ b/source/B2CWebApi.AppTests/Fixture/B2CWebApiFixture.cs
@@ -15,6 +15,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using Azure.Storage.Blobs;
+using BuildingBlocks.Application.Extensions.Options;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Azurite;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.OpenIdJwt;
@@ -39,8 +40,8 @@ public class B2CWebApiFixture : IAsyncLifetime
         AzuriteManager = new AzuriteManager();
         OpenIdJwtManager = new OpenIdJwtManager(IntegrationTestConfiguration.B2CSettings);
         ServiceBusResourceProvider = new ServiceBusResourceProvider(
-            IntegrationTestConfiguration.ServiceBusConnectionString,
-            TestLogger);
+            TestLogger,
+            IntegrationTestConfiguration.ServiceBusFullyQualifiedNamespace);
         AuditLogMockServer = new AuditLogMockServer();
 
         B2CWebApiApplicationFactory = new B2CWebApiApplicationFactory();
@@ -124,9 +125,7 @@ public class B2CWebApiFixture : IAsyncLifetime
             { "UserAuthentication:ExternalMetadataAddress", OpenIdJwtManager.ExternalMetadataAddress },
             { "UserAuthentication:InternalMetadataAddress", OpenIdJwtManager.InternalMetadataAddress },
             { "UserAuthentication:BackendBffAppId", OpenIdJwtManager.TestBffAppId },
-            { "ServiceBus:ManageConnectionString", ServiceBusResourceProvider.ConnectionString },
-            { "ServiceBus:ListenConnectionString", ServiceBusResourceProvider.ConnectionString },
-            { "ServiceBus:SendConnectionString", ServiceBusResourceProvider.ConnectionString },
+            { $"{ServiceBusOptions.SectionName}:{nameof(ServiceBusOptions.FullyQualifiedNamespace)}", ServiceBusResourceProvider.FullyQualifiedNamespace },
             { "AuditLog:IngestionUrl", AuditLogMockServer.IngestionUrl },
             { "IncomingMessages:QueueName", incomingMessagesQueueName },
             { "OrchestrationsStorageAccountConnectionString", AzuriteManager.FullConnectionString },

--- a/source/BuildingBlocks.Application/BuildingBlocks.Application.csproj
+++ b/source/BuildingBlocks.Application/BuildingBlocks.Application.csproj
@@ -14,6 +14,7 @@
       <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="13.1.0" />
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
       <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.5" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
       <PackageReference Include="Microsoft.FeatureManagement" Version="3.5.0" />

--- a/source/BuildingBlocks.Application/Extensions/DependencyInjection/BuildingBlockExtensions.cs
+++ b/source/BuildingBlocks.Application/Extensions/DependencyInjection/BuildingBlockExtensions.cs
@@ -21,7 +21,7 @@ public static class BuildingBlockExtensions
 {
     public static IServiceCollection AddBuildingBlocks(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddServiceBus(configuration)
+        services.AddServiceBusClientForApplication(configuration)
             .AddFileStorage(configuration)
             .AddFeatureFlags();
         return services;

--- a/source/BuildingBlocks.Application/Extensions/DependencyInjection/HealtCheckExtensions.cs
+++ b/source/BuildingBlocks.Application/Extensions/DependencyInjection/HealtCheckExtensions.cs
@@ -23,10 +23,11 @@ public static class HealtCheckExtensions
     /// <summary>
     /// Used for Service Bus queues where the app have peek (receiver) permissions
     /// </summary>
-    public static IServiceCollection TryAddExternalDomainServiceBusQueuesHealthCheck(this IServiceCollection services, string serviceBusConnectionString, params string[] queueNames)
+    public static IServiceCollection TryAddExternalDomainServiceBusQueuesHealthCheck(this IServiceCollection services, string serviceBusFullyQualifiedNamespace, params string[] queueNames)
     {
-        ArgumentNullException.ThrowIfNull(serviceBusConnectionString);
+        ArgumentNullException.ThrowIfNull(serviceBusFullyQualifiedNamespace);
         ArgumentNullException.ThrowIfNull(queueNames);
+
         foreach (var name in queueNames)
         {
             services.TryAddHealthChecks(
@@ -35,8 +36,9 @@ public static class HealtCheckExtensions
                 {
                     builder.AddAzureServiceBusQueue(
                         name: key,
-                        connectionString: serviceBusConnectionString,
-                        queueName: key);
+                        fullyQualifiedNamespace: serviceBusFullyQualifiedNamespace,
+                        queueName: key,
+                        tokenCredential: new DefaultAzureCredential());
                 });
         }
 

--- a/source/BuildingBlocks.Application/Extensions/Options/ServiceBusOptions.cs
+++ b/source/BuildingBlocks.Application/Extensions/Options/ServiceBusOptions.cs
@@ -16,9 +16,15 @@ using System.ComponentModel.DataAnnotations;
 
 namespace BuildingBlocks.Application.Extensions.Options;
 
+/// <summary>
+/// Options for the ServiceBus namespace used in the DH3 system.
+/// </summary>
 public class ServiceBusOptions
 {
     public const string SectionName = "ServiceBus";
+
+    [Required]
+    public string FullyQualifiedNamespace { get; set; } = string.Empty;
 
     [Required]
     public string ManageConnectionString { get; set; } = string.Empty;

--- a/source/BuildingBlocks.Application/Extensions/Options/ServiceBusOptions.cs
+++ b/source/BuildingBlocks.Application/Extensions/Options/ServiceBusOptions.cs
@@ -25,13 +25,4 @@ public class ServiceBusOptions
 
     [Required]
     public string FullyQualifiedNamespace { get; set; } = string.Empty;
-
-    [Required]
-    public string ManageConnectionString { get; set; } = string.Empty;
-
-    [Required]
-    public string ListenConnectionString { get; set; } = string.Empty;
-
-    [Required]
-    public string SendConnectionString { get; set; } = string.Empty;
 }

--- a/source/IncomingMessages.Application/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
+++ b/source/IncomingMessages.Application/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
@@ -51,7 +51,7 @@ public static class IncomingMessagesExtensions
 
         services
             .AddFeatureFlags()
-            .AddServiceBus(configuration)
+            .AddServiceBusClientForApplication(configuration)
             .AddDapperConnectionToDatabase(configuration)
             .AddScopedSqlDbContext<IncomingMessagesContext>(configuration)
             .AddScoped<IIncomingMessageClient, IncomingMessageClient>()

--- a/source/IncomingMessages.Application/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
+++ b/source/IncomingMessages.Application/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
@@ -87,7 +87,7 @@ public static class IncomingMessagesExtensions
 
             // Health checks
             .TryAddExternalDomainServiceBusQueuesHealthCheck(
-                configuration.GetSection(ServiceBusOptions.SectionName).Get<ServiceBusOptions>()!.ListenConnectionString,
+                configuration.GetSection(ServiceBusOptions.SectionName).Get<ServiceBusOptions>()!.FullyQualifiedNamespace,
                 configuration.GetSection(IncomingMessagesQueueOptions.SectionName).Get<IncomingMessagesQueueOptions>()!.QueueName);
 
         return services;

--- a/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
+++ b/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
@@ -427,9 +427,7 @@ public class BehavioursTestBase : IDisposable
             .AddInMemoryCollection(
                 new Dictionary<string, string?>
                 {
-                    [$"{ServiceBusOptions.SectionName}:{nameof(ServiceBusOptions.ManageConnectionString)}"] = MockServiceBusName,
-                    [$"{ServiceBusOptions.SectionName}:{nameof(ServiceBusOptions.ListenConnectionString)}"] = MockServiceBusName,
-                    [$"{ServiceBusOptions.SectionName}:{nameof(ServiceBusOptions.SendConnectionString)}"] = MockServiceBusName,
+                    [$"{ServiceBusOptions.SectionName}:{nameof(ServiceBusOptions.FullyQualifiedNamespace)}"] = MockServiceBusName,
                     [$"{EdiInboxOptions.SectionName}:{nameof(EdiInboxOptions.QueueName)}"] = MockServiceBusName,
                     [$"{WholesaleInboxOptions.SectionName}:{nameof(WholesaleInboxOptions.QueueName)}"] = MockServiceBusName,
                     [$"{IncomingMessagesQueueOptions.SectionName}:{nameof(IncomingMessagesQueueOptions.QueueName)}"] = MockServiceBusName,

--- a/source/IntegrationTests/IntegrationTests.csproj
+++ b/source/IntegrationTests/IntegrationTests.csproj
@@ -23,7 +23,7 @@ limitations under the License.
 
     <ItemGroup>
         <PackageReference Include="CsvHelper" Version="33.0.1" />
-        <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="6.2.0" />
+        <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="6.3.0" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
           <PrivateAssets>all</PrivateAssets>

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -292,9 +292,7 @@ public class TestBase : IDisposable
             .AddInMemoryCollection(
                 new Dictionary<string, string?>
                 {
-                    [$"{ServiceBusOptions.SectionName}:{nameof(ServiceBusOptions.ManageConnectionString)}"] = "Fake",
-                    [$"{ServiceBusOptions.SectionName}:{nameof(ServiceBusOptions.ListenConnectionString)}"] = "Fake",
-                    [$"{ServiceBusOptions.SectionName}:{nameof(ServiceBusOptions.SendConnectionString)}"] = "Fake",
+                    [$"{ServiceBusOptions.SectionName}:{nameof(ServiceBusOptions.FullyQualifiedNamespace)}"] = "Fake",
                     [$"{EdiInboxOptions.SectionName}:{nameof(EdiInboxOptions.QueueName)}"] = "Fake",
                     [$"{WholesaleInboxOptions.SectionName}:{nameof(WholesaleInboxOptions.QueueName)}"] = "Fake",
                     [$"{IncomingMessagesQueueOptions.SectionName}:{nameof(IncomingMessagesQueueOptions.QueueName)}"] = "Fake",

--- a/source/Process.Application/Extensions/DependencyInjection/ProcessExtensions.cs
+++ b/source/Process.Application/Extensions/DependencyInjection/ProcessExtensions.cs
@@ -124,7 +124,7 @@ public static class ProcessExtensions
 
             // health checks
             .TryAddExternalDomainServiceBusQueuesHealthCheck(
-                configuration.GetSection(ServiceBusOptions.SectionName).Get<ServiceBusOptions>()!.ListenConnectionString,
+                configuration.GetSection(ServiceBusOptions.SectionName).Get<ServiceBusOptions>()!.FullyQualifiedNamespace,
                 configuration.GetSection(EdiInboxOptions.SectionName).Get<EdiInboxOptions>()!.QueueName,
                 configuration.GetSection(WholesaleInboxOptions.SectionName).Get<WholesaleInboxOptions>()!.QueueName);
         return services;

--- a/source/SystemTests/SystemTests.csproj
+++ b/source/SystemTests/SystemTests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
       <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
-      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="6.2.0" />
+      <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="6.3.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />


### PR DESCRIPTION
## Description

Refactor any use of ServiceBus to identity access management (IAM) instead of shared access policies (connection strings).

**Important changes:**
- When using `ServiceBusTrigger` we must configure a setting with the name `<SectionName>_FullyQualifiedNamespace` and configure the trigger parameter `Connection` with the `<SectionName>` value.
- When configuring `AddAzureClients()` we must use the `UseCredential()` and `AddServiceBusClientWithNamespace()` to configure the top level `ServiceBusClient`. Any place where we need a service bus sender/receiver/processor we must inject `ServiceBusClient` and use it to create the lower level clients.
- When configuring health checks we must use the overloads where we specify the parameters `fullyQualifiedNamespaceFactory` and `tokenCredentialFactory`. Set `tokenCredentialFactory` to `new DefaultAzureCredential()` - which isn't costly as under the hood the health checks will cache the `ServiceBusClient` using the `FullyQualifiedNamespace` as key.

Deployed to `dev_002`: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/10703545430

## References

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/293

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task