### PR TITLE
fix: Allow longer charge type ids in the database

### DIFF
--- a/source/ApplyDBMigrationsApp/Scripts/Model/202409121115 Change Id length for ChargeType.sql
+++ b/source/ApplyDBMigrationsApp/Scripts/Model/202409121115 Change Id length for ChargeType.sql
@@ -1,0 +1,2 @@
+ALTER TABLE WholesaleServicesProcessChargeTypes
+ALTER COLUMN Id NVARCHAR(37);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

The charge type id cannot be longer than 10. However, it is possible for an actor to provide a request of an id of arbitrary length. In order to ensure, or at least for the most part ensure, that the actor receives the corresponding "too long" async message, EDI needs to be able to store these long ids in order to send them to wholesale.
To avoid the case of "arbitrary long" we have settled on UUID + 1, i.e. 37 chars. If the request contains an id longer than this, the request will end up on the dead-letter queue without notifying the actor. This is agreed upon behaviour, as the dead-letter queue is monitored by DataHub.

## References

## Checklist
- [x] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
  - As we increase the length of the field, there should be no data loss. In the case we have to shrink it again, any stored id longer than the new length would cause issues that cannot be trivially solved.
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [ ] Reference to the task