### PR TITLE
fix: request payload is logged in audit log

### DIFF
--- a/source/B2BApi.AppTests/IncomingMessages/IncomingMessageReceiverTests.cs
+++ b/source/B2BApi.AppTests/IncomingMessages/IncomingMessageReceiverTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Dynamic;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
@@ -151,7 +152,10 @@ public class IncomingMessageReceiverTests : IAsyncLifetime
         auditLogPayload.OccuredOn.Should().NotBeNull();
         auditLogPayload.Activity.Should().Be(AuditLogActivity.RequestCalculationResults.Identifier);
         auditLogPayload.Origin.Should().Be(request.RequestUri?.AbsoluteUri);
-        auditLogPayload.Payload.Should().NotBeNull();
         auditLogPayload.AffectedEntityType.Should().NotBeNullOrWhiteSpace();
+        auditLogPayload.Payload.Should().NotBeNull();
+        dynamic payload = serializer.Deserialize<ExpandoObject>(auditLogPayload.Payload!.ToString()!);
+        ((string)payload.IncomingDocumentType).Should().Be(documentTypeName);
+        ((string)payload.Message).Should().NotBeNull();
     }
 }

--- a/source/B2BApi/IncomingMessages/IncomingMessageReceiver.cs
+++ b/source/B2BApi/IncomingMessages/IncomingMessageReceiver.cs
@@ -143,7 +143,7 @@ public class IncomingMessageReceiver
                 logId: AuditLogId.New(),
                 activity: AuditLogActivity.RequestCalculationResults,
                 activityOrigin: request.Url.ToString(),
-                activityPayload: (incomingDocumentTypeName, incomingMessage),
+                activityPayload: new { IncomingDocumentType = incomingDocumentTypeName, Message = incomingMessage },
                 affectedEntityType: affectedEntityType,
                 affectedEntityKey: null)
             .ConfigureAwait(false);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Payload values from requests were not logged in the audit log. 

![image](https://github.com/user-attachments/assets/8ec3775e-f7fd-4fea-8e93-94eb9235090e)

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/10881763373
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/288