### PR TITLE
fix: return no-content when peek is disabled

### DIFF
--- a/source/B2BApi/OutgoingMessages/PeekRequestListener.cs
+++ b/source/B2BApi/OutgoingMessages/PeekRequestListener.cs
@@ -72,9 +72,9 @@ public class PeekRequestListener
         ArgumentNullException.ThrowIfNull(request);
         if (!await _featureFlagManager.UsePeekMessagesAsync().ConfigureAwait(false))
         {
-            var notFoundResponse = HttpResponseData.CreateResponse(request);
-            notFoundResponse.StatusCode = HttpStatusCode.NotFound;
-            return notFoundResponse;
+            var noContentResponse = HttpResponseData.CreateResponse(request);
+            noContentResponse.StatusCode = HttpStatusCode.NoContent;
+            return noContentResponse;
         }
 
         var cancellationToken = request.GetCancellationToken(hostCancellationToken);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
When external actors peeks, we should not return 404 but 204 instead to tell their connection is established.
## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [ ] Reference to the task