### PR TITLE
fix: Remove dead-letter health check from wholesale inbox

### DIFF
--- a/source/Process.Application/Extensions/DependencyInjection/WholesaleInboxExtensions.cs
+++ b/source/Process.Application/Extensions/DependencyInjection/WholesaleInboxExtensions.cs
@@ -63,13 +63,7 @@ public static class WholesaleInboxExtensions
                 sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
                 sp => sp.GetRequiredService<IOptions<WholesaleInboxQueueOptions>>().Value.QueueName,
                 _ => defaultAzureCredential,
-                name: wholesaleInboxQueueOptions.QueueName)
-            .AddServiceBusQueueDeadLetter(
-                sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
-                sp => sp.GetRequiredService<IOptions<WholesaleInboxQueueOptions>>().Value.QueueName,
-                _ => defaultAzureCredential,
-                "Dead-letter (wholesale inbox)",
-                [HealthChecksConstants.StatusHealthCheckTag]);
+                name: wholesaleInboxQueueOptions.QueueName);
 
         return services;
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

The health check (introduced in #1210) has been removed from EDI and added to the wholesale subsystem where it belongs.

## References

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/303

## Checklist
- [x] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task