### PR TITLE
enable MasterData/IntegrationEvents IntegrationTests in CI

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -99,13 +99,12 @@ jobs:
             filter: empty # Means skip
             use_azure_functions_tools: true
             contentroot_variable_name: empty # Means skip
-        
+
           - name: MasterData - integration tests
             paths: \source\MasterData.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.MasterData.IntegrationTests.dll
             filter: empty # Means skip
             use_azure_functions_tools: true
             contentroot_variable_name: empty # Means skip
-
 
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
     with:

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -95,10 +95,16 @@ jobs:
             contentroot_variable_name: empty # Means skip
 
           - name: IntegrationEvents - integration tests
-           paths: \source\IntegrationEvents.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationEvents.IntegrationTests.dll
-           filter: empty # Means skip
-           use_azure_functions_tools: true
-           contentroot_variable_name: empty # Means skip
+            paths: \source\IntegrationEvents.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationEvents.IntegrationTests.dll
+            filter: empty # Means skip
+            use_azure_functions_tools: true
+            contentroot_variable_name: empty # Means skip
+        
+          - name: MasterData - integration tests
+            paths: \source\MasterData.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.MasterData.IntegrationTests.dll
+            filter: empty # Means skip
+            use_azure_functions_tools: true
+            contentroot_variable_name: empty # Means skip
 
 
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -94,6 +94,18 @@ jobs:
             use_azure_functions_tools: true
             contentroot_variable_name: empty # Means skip
 
+            - name: IntegrationEvents - integration tests
+            paths: \source\IntegrationEvents.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationEvents.IntegrationTests.dll
+            filter: empty # Means skip
+            use_azure_functions_tools: true
+            contentroot_variable_name: empty # Means skip
+
+            - name: MasterData - integration tests
+            paths: \source\MasterData.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.MasterData.IntegrationTests.dll
+            filter: empty # Means skip
+            use_azure_functions_tools: true
+            contentroot_variable_name: empty # Means skip
+
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
     with:
       download_attempt_limit: 20

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -94,17 +94,12 @@ jobs:
             use_azure_functions_tools: true
             contentroot_variable_name: empty # Means skip
 
-            - name: IntegrationEvents - integration tests
-            paths: \source\IntegrationEvents.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationEvents.IntegrationTests.dll
-            filter: empty # Means skip
-            use_azure_functions_tools: true
-            contentroot_variable_name: empty # Means skip
+          - name: IntegrationEvents - integration tests
+           paths: \source\IntegrationEvents.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationEvents.IntegrationTests.dll
+           filter: empty # Means skip
+           use_azure_functions_tools: true
+           contentroot_variable_name: empty # Means skip
 
-            - name: MasterData - integration tests
-            paths: \source\MasterData.IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.MasterData.IntegrationTests.dll
-            filter: empty # Means skip
-            use_azure_functions_tools: true
-            contentroot_variable_name: empty # Means skip
 
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
     with:


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
These IntegrationTests project were never implanted in the CI which was a major blunder. The PR will introduce the `MasterData` and `IntegrationEvents` integrationtests into the CI

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/308
## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task