### PR TITLE
refac: MasterDataFixture deletes DB after run

### DIFF
--- a/source/MasterData.IntegrationTests/Fixture/MasterDataFixture.cs
+++ b/source/MasterData.IntegrationTests/Fixture/MasterDataFixture.cs
@@ -27,9 +27,8 @@ public sealed class MasterDataFixture : IAsyncLifetime
         await DatabaseManager.CreateDatabaseAsync();
     }
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
-        DatabaseManager.CleanupDatabase();
-        return Task.CompletedTask;
+        await DatabaseManager.DeleteDatabaseAsync();
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Fixtures should delete the database generated for the testrun after execution.

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/308

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task