### PR TITLE
fix: returned to many records when sorting with a filter on

### DIFF
--- a/source/ArchivedMessages.Infrastructure/QueryBuilder.cs
+++ b/source/ArchivedMessages.Infrastructure/QueryBuilder.cs
@@ -115,12 +115,12 @@ internal sealed class QueryBuilder
                 : directionToSortBy.Identifier == DirectionToSortBy.Descending.Identifier ? ">" : "<";
         return isForward
             ? $"""
-                  ({fieldToSortBy.Identifier} = '{cursor.SortedFieldValue}' AND (RecordId < {cursor.RecordId} OR {cursor.RecordId} = 0)) 
-                  OR ({fieldToSortBy.Identifier} {sortingDirection} '{cursor.SortedFieldValue}')
+                  (({fieldToSortBy.Identifier} = '{cursor.SortedFieldValue}' AND (RecordId < {cursor.RecordId} OR {cursor.RecordId} = 0)) 
+                  OR ({fieldToSortBy.Identifier} {sortingDirection} '{cursor.SortedFieldValue}'))
               """
             : $"""
-                   ({fieldToSortBy.Identifier} = '{cursor.SortedFieldValue}' AND (RecordId > {cursor.RecordId} OR {cursor.RecordId} = 0)) 
-                   OR ({fieldToSortBy.Identifier} {sortingDirection} '{cursor.SortedFieldValue}') 
+                   (({fieldToSortBy.Identifier} = '{cursor.SortedFieldValue}' AND (RecordId > {cursor.RecordId} OR {cursor.RecordId} = 0)) 
+                   OR ({fieldToSortBy.Identifier} {sortingDirection} '{cursor.SortedFieldValue}')) 
                """;
     }
 

--- a/source/ArchivedMessages.IntegrationTests/SearchMessagesWithoutRestrictionTests.cs
+++ b/source/ArchivedMessages.IntegrationTests/SearchMessagesWithoutRestrictionTests.cs
@@ -864,6 +864,97 @@ public class SearchMessagesWithoutRestrictionTests : IAsyncLifetime
             .Equal(orderedMessages.Select(x => x.MessageId), $"Message is sorted by {sortedBy.Identifier} {sortedDirection.Identifier}");
     }
 
+    [Fact]
+    public async Task Given_ArchivedMessages_When_OneIsOlderThenSearchCriteriaAndNavigatingForwardIsTrue_Then_ExpectedAmountOfMessagesAreReturned()
+    {
+        // Arrange
+        var expectedPeriodStartedAt = CreatedAt("2023-04-02T22:00:00Z");
+        var expectedPeriodEndedAt = CreatedAt("2023-04-06T22:00:00Z");
+        var messages = new List<(Instant CreatedAt, string MessageId)>()
+        {
+            new(CreatedAt("2023-04-01T22:00:00Z"), Guid.NewGuid().ToString()),
+            new(CreatedAt("2023-04-02T22:00:00Z"), Guid.NewGuid().ToString()),
+            new(CreatedAt("2023-04-03T22:00:00Z"), Guid.NewGuid().ToString()),
+            new(CreatedAt("2023-04-04T22:00:00Z"), Guid.NewGuid().ToString()),
+            new(CreatedAt("2023-04-05T22:00:00Z"), Guid.NewGuid().ToString()),
+            new(CreatedAt("2023-04-06T22:00:00Z"), Guid.NewGuid().ToString()),
+            new(CreatedAt("2023-04-07T22:00:00Z"), Guid.NewGuid().ToString()),
+        };
+        foreach (var exceptedMessage in messages.OrderBy(_ => Random.Shared.Next()))
+        {
+            await _fixture.CreateArchivedMessageAsync(
+                timestamp: exceptedMessage.CreatedAt,
+                messageId: exceptedMessage.MessageId);
+        }
+
+        var pagination = new SortedCursorBasedPagination(
+            pageSize: 10,
+            navigationForward: true);
+
+        // Act
+        var result = await _sut.SearchAsync(
+            new GetMessagesQuery(
+                pagination,
+                new MessageCreationPeriod(
+                expectedPeriodStartedAt,
+                expectedPeriodEndedAt)),
+            CancellationToken.None);
+
+        // Assert
+        result.Messages.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task Given_SecondPageIsRequest_When_NavigatingForwardIsTrueAndSortingOnSenderAndAMessageForADifferentSenderExists_Then_ExpectedMessageAreReturned()
+    {
+        // Arrange
+        var pageSize = 3;
+        var pageNumber = 2;
+
+        var messages = new List<(Instant CreatedAt, string MessageId, string SenderNumber)>()
+        {
+            // page 1 <- the previous page
+            new(CreatedAt("2023-04-06T22:00:00Z"), Guid.NewGuid().ToString(), "1234512345123"),
+            new(CreatedAt("2023-04-05T22:00:00Z"), Guid.NewGuid().ToString(), "1234512345123"), // <- cursor points here
+            new(CreatedAt("2023-04-04T22:00:00Z"), Guid.NewGuid().ToString(), "1234512345123"),
+            // page 2
+            new(CreatedAt("2023-04-03T22:00:00Z"), Guid.NewGuid().ToString(), "1234512345123"),
+            new(CreatedAt("2023-04-02T22:00:00Z"), Guid.NewGuid().ToString(), "1234512345123"),
+            // has a different sender
+            new(CreatedAt("2023-04-01T22:00:00Z"), Guid.NewGuid().ToString(), "1234512345122"),
+        };
+
+        // Create messages in order when they were created at
+        foreach (var messageToCreate in messages.OrderBy(x => x.CreatedAt))
+        {
+            await _fixture.CreateArchivedMessageAsync(
+                timestamp: messageToCreate.CreatedAt,
+                messageId: messageToCreate.MessageId,
+                senderNumber: messageToCreate.SenderNumber);
+        }
+
+        var firstPageMessages = await SkipFirstPage(pageSize, navigatingForward: true, orderByField: FieldToSortBy.SenderNumber);
+        // The cursor points at the last item of the previous page, when navigating backward
+        var lastMessageInOnThePreviousPage = firstPageMessages.Messages.Last();
+        var cursor = new SortingCursor(RecordId: lastMessageInOnThePreviousPage.RecordId, SortedFieldValue: lastMessageInOnThePreviousPage.SenderNumber);
+
+        var pagination = new SortedCursorBasedPagination(
+            cursor: cursor,
+            pageSize: pageSize,
+            navigationForward: true,
+            fieldToSortBy: FieldToSortBy.SenderNumber,
+            directionSortBy: DirectionToSortBy.Descending);
+
+        // Act
+        var result = await _sut.SearchAsync(
+            new GetMessagesQuery(
+                pagination),
+            CancellationToken.None);
+
+        // Assert
+        result.Messages.Should().HaveCount(pageNumber);
+    }
+
     #endregion
 
     private static Instant CreatedAt(string date)
@@ -918,9 +1009,12 @@ public class SearchMessagesWithoutRestrictionTests : IAsyncLifetime
         return orderedMessages;
     }
 
-    private async Task<MessageSearchResult> SkipFirstPage(int pageSize, bool navigatingForward)
+    private async Task<MessageSearchResult> SkipFirstPage(
+        int pageSize,
+        bool navigatingForward,
+        FieldToSortBy? orderByField = null)
     {
-        var pagination = new SortedCursorBasedPagination(pageSize: pageSize, navigationForward: navigatingForward);
+        var pagination = new SortedCursorBasedPagination(pageSize: pageSize, navigationForward: navigatingForward, fieldToSortBy: orderByField, directionSortBy: DirectionToSortBy.Descending);
         return await _sut.SearchAsync(
             new GetMessagesQuery(pagination),
             CancellationToken.None);

--- a/source/ArchivedMessages.IntegrationTests/SearchMessagesWithoutRestrictionTests.cs
+++ b/source/ArchivedMessages.IntegrationTests/SearchMessagesWithoutRestrictionTests.cs
@@ -905,9 +905,11 @@ public class SearchMessagesWithoutRestrictionTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Given_SecondPageIsRequest_When_NavigatingForwardIsTrueAndSortingOnSenderAndAMessageForADifferentSenderExists_Then_ExpectedMessageAreReturned()
+    public async Task Given_SecondPageIsRequest_When_NavigatingForwardIsTrueAndSortingOnSenderAndAMessageForADifferentSenderExistsWithPeriodSearchCritieria_Then_ExpectedMessageAreReturned()
     {
         // Arrange
+        var expectedPeriodStartedAt = CreatedAt("2023-04-02T22:00:00Z");
+        var expectedPeriodEndedAt = CreatedAt("2023-04-06T22:00:00Z");
         var pageSize = 3;
         var pageNumber = 2;
 
@@ -948,7 +950,8 @@ public class SearchMessagesWithoutRestrictionTests : IAsyncLifetime
         // Act
         var result = await _sut.SearchAsync(
             new GetMessagesQuery(
-                pagination),
+                pagination,
+                new MessageCreationPeriod(expectedPeriodStartedAt, expectedPeriodEndedAt)),
             CancellationToken.None);
 
         // Assert


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Returned to many records

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task