### PR TITLE
feat: sender and receiver role code filter on archived messages

### DIFF
--- a/source/ArchivedMessages.Infrastructure/QueryBuilder.cs
+++ b/source/ArchivedMessages.Infrastructure/QueryBuilder.cs
@@ -71,6 +71,26 @@ internal sealed class QueryBuilder
                 new KeyValuePair<string, object>("ReceiverNumber", query.ReceiverNumber));
         }
 
+        if (query.SenderRoleCode is not null && query.ReceiverRoleCode is not null)
+        {
+            AddFilter(
+                "(SenderRoleCode=@SenderRoleCode OR ReceiverRoleCode=@ReceiverRoleCode)",
+                new KeyValuePair<string, object>("SenderRoleCode", query.SenderRoleCode),
+                new KeyValuePair<string, object>("ReceiverRoleCode", query.ReceiverRoleCode));
+        }
+        else if (query.SenderRoleCode is not null)
+        {
+            AddFilter(
+                "SenderRoleCode=@SenderRoleCode",
+                new KeyValuePair<string, object>("SenderRoleCode", query.SenderRoleCode));
+        }
+        else if (query.ReceiverRoleCode is not null)
+        {
+            AddFilter(
+                "ReceiverRoleCode=@ReceiverRoleCode",
+                new KeyValuePair<string, object>("ReceiverRoleCode", query.ReceiverRoleCode));
+        }
+
         if (query.DocumentTypes is not null)
         {
             AddFilter(

--- a/source/ArchivedMessages.IntegrationTests/ArchivedMessagesWithoutRestrictionTests.cs
+++ b/source/ArchivedMessages.IntegrationTests/ArchivedMessagesWithoutRestrictionTests.cs
@@ -214,6 +214,75 @@ public class ArchivedMessagesWithoutRestrictionTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Given_TwoArchivedMessages_When_SearchingBySenderRole_Then_ReturnsExpectedMessage()
+    {
+        // Arrange
+        var expectedSenderRole = ActorRole.SystemOperator;
+        await _fixture.CreateArchivedMessageAsync(senderRole: expectedSenderRole);
+        await _fixture.CreateArchivedMessageAsync();
+
+        // Act
+        var result = await _sut.SearchAsync(
+        new GetMessagesQuery(
+        new SortedCursorBasedPagination(),
+        SenderRoleCode: expectedSenderRole.Code),
+        CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        using var assertionScope = new AssertionScope();
+        result.Messages.Should().ContainSingle()
+        .Which.SenderRoleCode.Should().Be(expectedSenderRole.Code);
+    }
+
+    [Fact]
+    public async Task Given_TwoArchivedMessages_When_SearchingByReceiverRole_Then_ReturnsExpectedMessage()
+    {
+        // Arrange
+        var expectedReceiverRole = ActorRole.SystemOperator;
+        await _fixture.CreateArchivedMessageAsync(receiverRole: expectedReceiverRole);
+        await _fixture.CreateArchivedMessageAsync();
+
+        // Act
+        var result = await _sut.SearchAsync(
+        new GetMessagesQuery(
+        new SortedCursorBasedPagination(),
+        ReceiverRoleCode: expectedReceiverRole.Code),
+        CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        using var assertionScope = new AssertionScope();
+        result.Messages.Should().ContainSingle()
+        .Which.ReceiverRoleCode.Should().Be(expectedReceiverRole.Code);
+    }
+
+    [Fact]
+    public async Task Given_TwoArchivedMessages_When_SearchingBySenderRoleAndReceiverRole_Then_ReturnsExpectedMessage()
+    {
+        // Arrange
+        var expectedSenderRole = ActorRole.Delegated;
+        var expectedReceiverRole = ActorRole.SystemOperator;
+        await _fixture.CreateArchivedMessageAsync(senderRole: expectedSenderRole, receiverRole: expectedReceiverRole);
+        await _fixture.CreateArchivedMessageAsync();
+
+        // Act
+        var result = await _sut.SearchAsync(
+        new GetMessagesQuery(
+        new SortedCursorBasedPagination(),
+        ReceiverRoleCode: expectedReceiverRole.Code),
+        CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        using var assertionScope = new AssertionScope();
+        result.Messages.Should().ContainSingle()
+            .Which.Should().Match<MessageInfo>(messageInfo =>
+                messageInfo.SenderRoleCode == expectedSenderRole.Code
+                && messageInfo.ReceiverRoleCode == expectedReceiverRole.Code);
+    }
+
+    [Fact]
     public async Task Given_TwoArchivedMessages_When_SearchingByReceiverNumber_Then_ReturnsExpectedMessage()
     {
         // Arrange

--- a/source/ArchivedMessages.Interfaces/GetMessagesQuery.cs
+++ b/source/ArchivedMessages.Interfaces/GetMessagesQuery.cs
@@ -18,20 +18,14 @@ namespace Energinet.DataHub.EDI.ArchivedMessages.Interfaces;
 /// Represents a query options for retrieving messages.
 /// Including the pagination for the specific query.
 /// </summary>
-/// <param name="Pagination"></param>
-/// <param name="CreationPeriod"></param>
-/// <param name="MessageId"></param>
-/// <param name="SenderNumber"></param>
-/// <param name="ReceiverNumber"></param>
-/// <param name="DocumentTypes"></param>
-/// <param name="BusinessReasons"></param>
-/// <param name="IncludeRelatedMessages"></param>
 public sealed record GetMessagesQuery(
     SortedCursorBasedPagination Pagination,
     MessageCreationPeriod? CreationPeriod = null,
     string? MessageId = null,
     string? SenderNumber = null,
+    string? SenderRoleCode = null,
     string? ReceiverNumber = null,
+    string? ReceiverRoleCode = null,
     IReadOnlyCollection<string>? DocumentTypes = null,
     IReadOnlyCollection<string>? BusinessReasons = null,
     bool IncludeRelatedMessages = false);

--- a/source/B2CWebApi/Controllers/ArchivedMessageSearchController.cs
+++ b/source/B2CWebApi/Controllers/ArchivedMessageSearchController.cs
@@ -70,7 +70,9 @@ public class ArchivedMessageSearchController : ControllerBase
             messageCreationPeriod,
             request.MessageId,
             request.SenderNumber,
+            null,
             request.ReceiverNumber,
+            null,
             request.DocumentTypes,
             request.BusinessReasons,
             request.IncludeRelatedMessages);
@@ -128,7 +130,9 @@ public class ArchivedMessageSearchController : ControllerBase
             messageCreationPeriod,
             request.SearchCriteria.MessageId,
             request.SearchCriteria.SenderNumber,
+            null,
             request.SearchCriteria.ReceiverNumber,
+            null,
             request.SearchCriteria.DocumentTypes,
             request.SearchCriteria.BusinessReasons,
             request.SearchCriteria.IncludeRelatedMessages);
@@ -190,7 +194,9 @@ public class ArchivedMessageSearchController : ControllerBase
             messageCreationPeriod,
             request.SearchCriteria.MessageId,
             request.SearchCriteria.SenderNumber,
+            request.SearchCriteria.SenderRoleCode,
             request.SearchCriteria.ReceiverNumber,
+            request.SearchCriteria.ReceiverRoleCode,
             DocumentTypeMapper.FromDocumentTypes(request.SearchCriteria.DocumentTypes),
             request.SearchCriteria.BusinessReasons,
             request.SearchCriteria.IncludeRelatedMessages);

--- a/source/B2CWebApi/Models/SearchArchivedMessagesCriteria.cs
+++ b/source/B2CWebApi/Models/SearchArchivedMessagesCriteria.cs
@@ -29,7 +29,9 @@ public record SearchArchivedMessagesCriteriaV3(
     MessageCreationPeriod? CreatedDuringPeriod,
     string? MessageId,
     string? SenderNumber,
+    string? SenderRoleCode,
     string? ReceiverNumber,
+    string? ReceiverRoleCode,
     IReadOnlyCollection<DocumentType>? DocumentTypes,
     IReadOnlyCollection<string>? BusinessReasons,
     bool IncludeRelatedMessages = false);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Add ReceiverRole and SenderRole filter options which can be used by the FAS user when searching archived message

The related PRs will contain the following:
- [x] V3 archived message search API with DocumentType to be an enum type instead of a string => https://github.com/Energinet-DataHub/opengeh-edi/pull/1282
- [x] Return the ReceiverRole and SenderRole to the BFF of an archived message for displaying in this V3 endpoint
- [ ] Remove V1 endpoint if its no longer used

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/11237206643
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/317