### PR TITLE
test: Increase outgoing message deletion timeout for load tests

### DIFF
--- a/source/SubsystemTests/Drivers/EdiDatabaseDriver.cs
+++ b/source/SubsystemTests/Drivers/EdiDatabaseDriver.cs
@@ -198,6 +198,8 @@ internal sealed class EdiDatabaseDriver
             deleteOutgoingMessagesCommand.Parameters.AddWithValue("@CalculationId", calculationId);
 
             deleteOutgoingMessagesCommand.Connection = connection;
+            deleteOutgoingMessagesCommand.CommandTimeout = (int)TimeSpan.FromMinutes(2).TotalSeconds;
+
             await deleteOutgoingMessagesCommand.ExecuteNonQueryAsync().ConfigureAwait(false);
         }
     }

--- a/source/SubsystemTests/Drivers/EdiDriver.cs
+++ b/source/SubsystemTests/Drivers/EdiDriver.cs
@@ -196,10 +196,12 @@ internal sealed class EdiDriver
             return;
         }
 
-        _logger.WriteLine($"Stopping {orchestrationsForCalculation.Count} orchestrations for calculation (CalculationId={calculationId})");
 
         foreach (var orchestration in orchestrationsForCalculation)
-            await _durableClient.TerminateAsync(orchestration.InstanceId, "Stopped by subsystem test");
+        {
+            _logger.WriteLine($"Stopping orchestration for calculation (CalculationId={calculationId}, OrchestrationInstanceId={orchestration.InstanceId})");
+            await _durableClient.TerminateAsync(orchestration.InstanceId, "Stopped after load test");
+        }
     }
 
     private static async Task<(Guid MessageId, string Content)> GetRequestWholesaleSettlementContentAsync(

--- a/source/SubsystemTests/Drivers/EdiDriver.cs
+++ b/source/SubsystemTests/Drivers/EdiDriver.cs
@@ -190,8 +190,11 @@ internal sealed class EdiDriver
             .Where(o => o.Input.ToString().Contains(calculationId.ToString()))
             .ToList();
 
-        if (orchestrationsForCalculation.Any())
+        if (!orchestrationsForCalculation.Any())
+        {
+            _logger.WriteLine($"Found no orchestrations to stop for calculation (CalculationId={calculationId}, CreatedAfter={createdAfter.ToDateTimeUtc()})");
             return;
+        }
 
         _logger.WriteLine($"Stopping {orchestrationsForCalculation.Count} orchestrations for calculation (CalculationId={calculationId})");
 

--- a/source/SubsystemTests/Drivers/EdiDriver.cs
+++ b/source/SubsystemTests/Drivers/EdiDriver.cs
@@ -196,7 +196,6 @@ internal sealed class EdiDriver
             return;
         }
 
-
         foreach (var orchestration in orchestrationsForCalculation)
         {
             _logger.WriteLine($"Stopping orchestration for calculation (CalculationId={calculationId}, OrchestrationInstanceId={orchestration.InstanceId})");


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

- Cleanup before load test threw a sql timeout exception, since deleting messages could take more than the default 30 seconds timeout. This PR increased the timeout to 2 minutes.
- Cleanup after load test didn't correctly stop the orchestration, which is now fixed

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task