### PR TITLE
feat: introduce new MeteredDataForMeasurementPoint IncomingDocumentType

### DIFF
--- a/source/BuildingBlocks.Domain/Models/IncomingDocumentType.cs
+++ b/source/BuildingBlocks.Domain/Models/IncomingDocumentType.cs
@@ -20,6 +20,7 @@ public class IncomingDocumentType : EnumerationType
     public static readonly IncomingDocumentType B2CRequestAggregatedMeasureData = new(nameof(B2CRequestAggregatedMeasureData));
     public static readonly IncomingDocumentType RequestWholesaleSettlement = new(nameof(RequestWholesaleSettlement));
     public static readonly IncomingDocumentType B2CRequestWholesaleSettlement = new(nameof(B2CRequestWholesaleSettlement));
+    public static readonly IncomingDocumentType MeteredDataForMeasurementPoint = new(nameof(MeteredDataForMeasurementPoint));
 
     private IncomingDocumentType(string name)
         : base(name)

--- a/source/IncomingMessages.Application/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
+++ b/source/IncomingMessages.Application/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
@@ -27,6 +27,7 @@ using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Configuration.DataAc
 using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Configuration.Options;
 using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.MessageParsers;
 using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.MessageParsers.AggregatedMeasureDataRequestMessageParsers;
+using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.MessageParsers.MeteredDateForMeasurementPointParsers;
 using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.MessageParsers.WholesaleSettlementMessageParsers;
 using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Repositories.MessageId;
 using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Repositories.TransactionId;
@@ -63,6 +64,7 @@ public static class IncomingMessagesExtensions
             .AddScoped<IMarketMessageParser, WholesaleSettlementJsonMessageParser>()
             .AddScoped<IMarketMessageParser, WholesaleSettlementXmlMessageParser>()
             .AddScoped<IMarketMessageParser, WholesaleSettlementB2CJsonMessageParser>()
+            .AddScoped<IMarketMessageParser, MeteredDateForMeasurementPointEbixMessageParser>()
             .AddScoped<MarketMessageParser>()
             .AddScoped<ISenderAuthorizer, SenderAuthorizer>()
             .AddScoped<ValidateIncomingMessage>()

--- a/source/IncomingMessages.Infrastructure/MessageParsers/MarketMessageParser.cs
+++ b/source/IncomingMessages.Infrastructure/MessageParsers/MarketMessageParser.cs
@@ -34,7 +34,7 @@ public class MarketMessageParser
         var parser = _parsers.FirstOrDefault(parser =>
             parser.HandledFormat.Equals(documentFormat) && parser.DocumentType.Equals(documentType));
         if (parser is null)
-            throw new InvalidOperationException($"No message parser found for message format '{documentFormat}'");
+            throw new InvalidOperationException($"No message parser found for message format '{documentFormat}' and document type '{documentType}'");
         return parser.ParseAsync(marketMessage, cancellationToken);
     }
 }

--- a/source/IncomingMessages.Infrastructure/MessageParsers/MeteredDateForMeasurementPointParsers/MeteredDateForMeasurementPointEbixMessageParser.cs
+++ b/source/IncomingMessages.Infrastructure/MessageParsers/MeteredDateForMeasurementPointParsers/MeteredDateForMeasurementPointEbixMessageParser.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+
+namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.MessageParsers.MeteredDateForMeasurementPointParsers;
+
+public class MeteredDateForMeasurementPointEbixMessageParser : IMarketMessageParser
+{
+    public DocumentFormat HandledFormat => DocumentFormat.Ebix;
+
+    public IncomingDocumentType DocumentType => IncomingDocumentType.MeteredDataForMeasurementPoint;
+
+    public Task<IncomingMarketMessageParserResult> ParseAsync(IIncomingMarketMessageStream incomingMarketMessageStream, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/source/IncomingMessages.IntegrationTests/MessageParsers/GivenNewDocumentTypeTests.cs
+++ b/source/IncomingMessages.IntegrationTests/MessageParsers/GivenNewDocumentTypeTests.cs
@@ -42,25 +42,34 @@ public class GivenNewIncomingDocumentTypeTests : IncomingMessagesTestBase
     {
     }
 
-    public static IEnumerable<object[]> GetAllIncomingDocumentTypeAndDocumentFormats()
+    public static TheoryData<IncomingDocumentType, DocumentFormat> GetAllIncomingDocumentTypeAndDocumentFormats
     {
-        var incomingDocumentTypes =
-            typeof(IncomingDocumentType).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
-        var documentFormats =
-            typeof(DocumentFormat).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
-
-        foreach (var documentType in incomingDocumentTypes)
+        get
         {
-            foreach (var documentFormat in documentFormats)
+            var data = new TheoryData<IncomingDocumentType, DocumentFormat>();
+
+            var incomingDocumentTypes =
+                typeof(IncomingDocumentType).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+            var documentFormats =
+                typeof(DocumentFormat).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+            foreach (var documentType in incomingDocumentTypes)
             {
-                yield return [documentType.GetValue(null)!, documentFormat.GetValue(null)!];
+                foreach (var documentFormat in documentFormats)
+                {
+                    data.Add((IncomingDocumentType)documentType.GetValue(null)!, (DocumentFormat)documentFormat.GetValue(null)!);
+                }
             }
+
+            return data;
         }
     }
 
     [Theory]
     [MemberData(nameof(GetAllIncomingDocumentTypeAndDocumentFormats))]
-    public async Task When_ParsingMessageOfDocumentTypeAndFormat_Then_ExpectedMessageParserFound(IncomingDocumentType incomingDocumentType, DocumentFormat documentFormat)
+    public async Task When_ParsingMessageOfDocumentTypeAndFormat_Then_ExpectedMessageParserFound(
+        IncomingDocumentType incomingDocumentType,
+        DocumentFormat documentFormat)
     {
         // Arrange
         var marketMessageParser = GetService<MarketMessageParser>();

--- a/source/IncomingMessages.IntegrationTests/MessageParsers/GivenNewDocumentTypeTests.cs
+++ b/source/IncomingMessages.IntegrationTests/MessageParsers/GivenNewDocumentTypeTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Reflection;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.MessageParsers;
+using Energinet.DataHub.EDI.IncomingMessages.IntegrationTests.Fixtures;
+using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
+using FluentAssertions;
+using Xunit.Abstractions;
+
+namespace Energinet.DataHub.EDI.IncomingMessages.IntegrationTests.MessageParsers;
+
+public class GivenNewIncomingDocumentTypeTests : IncomingMessagesTestBase
+{
+    private static readonly List<(IncomingDocumentType, DocumentFormat)> _unsupportedCombinationsOfIncomingDocumentTypeAndDocumentFormat = new()
+    {
+        (IncomingDocumentType.B2CRequestWholesaleSettlement, DocumentFormat.Xml),
+        (IncomingDocumentType.B2CRequestAggregatedMeasureData, DocumentFormat.Xml),
+        (IncomingDocumentType.RequestWholesaleSettlement, DocumentFormat.Ebix),
+        (IncomingDocumentType.RequestAggregatedMeasureData, DocumentFormat.Ebix),
+        (IncomingDocumentType.B2CRequestWholesaleSettlement, DocumentFormat.Ebix),
+        (IncomingDocumentType.B2CRequestAggregatedMeasureData, DocumentFormat.Ebix),
+        // TODO: Remove when implementing parsers for CIM
+        (IncomingDocumentType.MeteredDataForMeasurementPoint, DocumentFormat.Xml),
+        (IncomingDocumentType.MeteredDataForMeasurementPoint, DocumentFormat.Json),
+    };
+
+    public GivenNewIncomingDocumentTypeTests(IncomingMessagesTestFixture incomingMessagesTestFixture, ITestOutputHelper testOutputHelper)
+        : base(incomingMessagesTestFixture, testOutputHelper)
+    {
+    }
+
+    public static IEnumerable<object[]> GetAllIncomingDocumentTypeAndDocumentFormats()
+    {
+        var incomingDocumentTypes =
+            typeof(IncomingDocumentType).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+        var documentFormats =
+            typeof(DocumentFormat).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+        foreach (var documentType in incomingDocumentTypes)
+        {
+            foreach (var documentFormat in documentFormats)
+            {
+                yield return [documentType.GetValue(null)!, documentFormat.GetValue(null)!];
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(GetAllIncomingDocumentTypeAndDocumentFormats))]
+    public async Task When_ParsingMessageOfDocumentTypeAndFormat_Then_ExpectedMessageParserFound(IncomingDocumentType incomingDocumentType, DocumentFormat documentFormat)
+    {
+        // Arrange
+        var marketMessageParser = GetService<MarketMessageParser>();
+
+        // Act
+        var act = () => marketMessageParser.ParseAsync(
+            new IncomingMarketMessageStream(new MemoryStream()),
+            documentFormat,
+            incomingDocumentType,
+            CancellationToken.None);
+
+        // Assert
+        if (_unsupportedCombinationsOfIncomingDocumentTypeAndDocumentFormat.Contains((incomingDocumentType, documentFormat)))
+        {
+            await act.Should().ThrowAsync<InvalidOperationException>("because this combination is not supported");
+        }
+        else
+        {
+            await act.Should().NotThrowAsync<InvalidOperationException>("because this combination is valid, but no parser was found");
+        }
+    }
+}

--- a/source/Tests/B2CWebApi/Mappers/DocumentTypeMapperTests.cs
+++ b/source/Tests/B2CWebApi/Mappers/DocumentTypeMapperTests.cs
@@ -63,10 +63,13 @@ public class DocumentTypeMapperTests
                     typeof(IncomingDocumentType).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
                         .Select(f => f.GetValue(null) as IncomingDocumentType)
                         .Where(dt => dt != null)
-                        .Select(dt => dt!.Name))
-                .ToList();
+                        .Select(dt => dt!.Name));
+
+        // TODO - Remove this line when all DocumentTypes are supported in B2C
+        supportedDocumentTypes = supportedDocumentTypes
+            .Where(x => x != IncomingDocumentType.MeteredDataForMeasurementPoint.Name);
 
         // Act & Assert
-        documentTypes.Should().BeEquivalentTo(supportedDocumentTypes);
+        documentTypes.Should().BeEquivalentTo(supportedDocumentTypes.ToList());
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Grid operators (MDR), should be able to send metered data for a measurement point to EDI in the Ebix format, as described in the referenced task. Below is a list of the excepted PRs needed to prepare IncomingMessageClient to handle this new message

Previous PRs:
- (none)

This PR contains:
- [ ] (IncomingMessageClient) Introduce a new incoming message type to represent the "metered data for a measurement point" message

Following PRs: 
- [ ] (IncomingMessageClient) Implement MeteredDateForMeasurementPointEbixMessageParser
- [ ] (IncomingMessageClient) Implement an IResponseFactory to deliver an Ebix parsing error response.
- [ ] (IncomingMessageClient) Skip archiving message with inc doc type MeteredDataForMeasurementPoint
- [ ] (IncomingMessageClient) Extend AuthorizeSender validator to ensure the sender role is MDR for this message type

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/11479079179
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/351