### PR TITLE
feat: Introduce receiver for incoming ebix messages

### DIFF
--- a/source/B2BApi/Common/HttpRequestDataExtensions.cs
+++ b/source/B2BApi/Common/HttpRequestDataExtensions.cs
@@ -19,10 +19,10 @@ namespace Energinet.DataHub.EDI.B2BApi.Common;
 
 public static class HttpRequestDataExtensions
 {
-    public static async Task<MemoryStream> CreateSeekingStreamFromBodyAsync(this HttpRequestData request)
+    public static async Task<MemoryStream> CreateSeekingStreamFromBodyAsync(this HttpRequestData request, CancellationToken cancellationToken)
     {
         var memoryStream = new MemoryStream();
-        await request.Body.CopyToAsync(memoryStream).ConfigureAwait(false);
+        await request.Body.CopyToAsync(memoryStream, cancellationToken).ConfigureAwait(false);
         return memoryStream;
     }
 

--- a/source/B2BApi/Common/HttpRequestDataExtensions.cs
+++ b/source/B2BApi/Common/HttpRequestDataExtensions.cs
@@ -19,7 +19,9 @@ namespace Energinet.DataHub.EDI.B2BApi.Common;
 
 public static class HttpRequestDataExtensions
 {
-    public static async Task<MemoryStream> CreateSeekingStreamFromBodyAsync(this HttpRequestData request, CancellationToken cancellationToken)
+    public static async Task<MemoryStream> CreateSeekingStreamFromBodyAsync(
+        this HttpRequestData request,
+        CancellationToken cancellationToken)
     {
         var memoryStream = new MemoryStream();
         await request.Body.CopyToAsync(memoryStream, cancellationToken).ConfigureAwait(false);

--- a/source/B2BApi/IncomingMessages/EbixIncomingMessageReceiver.cs
+++ b/source/B2BApi/IncomingMessages/EbixIncomingMessageReceiver.cs
@@ -41,7 +41,7 @@ public sealed class EbixIncomingMessageReceiver(
         ArgumentNullException.ThrowIfNull(request);
         var cancellationToken = request.GetCancellationToken(hostCancellationToken);
 
-        using var seekingStreamFromBody = await request.CreateSeekingStreamFromBodyAsync().ConfigureAwait(false);
+        using var seekingStreamFromBody = await request.CreateSeekingStreamFromBodyAsync(cancellationToken).ConfigureAwait(false);
         var incomingMarketMessageStream = new IncomingMarketMessageStream(seekingStreamFromBody);
 
         if (!await _featureFlagManager.ReceiveMeteredDataForMeasurementPointsAsync().ConfigureAwait(false))

--- a/source/B2BApi/IncomingMessages/EbixIncomingMessageReceiver.cs
+++ b/source/B2BApi/IncomingMessages/EbixIncomingMessageReceiver.cs
@@ -1,0 +1,88 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Text;
+using BuildingBlocks.Application.FeatureFlag;
+using Energinet.DataHub.EDI.B2BApi.Common;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.IncomingMessages.Interfaces;
+using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace Energinet.DataHub.EDI.B2BApi.IncomingMessages;
+
+public sealed class EbixIncomingMessageReceiver(
+    IIncomingMessageClient incomingMessageClient,
+    IFeatureFlagManager featureFlagManager)
+{
+    private readonly IIncomingMessageClient _incomingMessageClient = incomingMessageClient;
+    private readonly IFeatureFlagManager _featureFlagManager = featureFlagManager;
+
+    [Function(nameof(EbixIncomingMessageReceiver))]
+    public async Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "incomingMessages/ebix")]
+        HttpRequestData request,
+        FunctionContext executionContext,
+        CancellationToken hostCancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var cancellationToken = request.GetCancellationToken(hostCancellationToken);
+
+        using var seekingStreamFromBody = await request.CreateSeekingStreamFromBodyAsync().ConfigureAwait(false);
+        var incomingMarketMessageStream = new IncomingMarketMessageStream(seekingStreamFromBody);
+
+        if (!await _featureFlagManager.ReceiveMeteredDataForMeasurementPointsAsync().ConfigureAwait(false))
+        {
+            /*
+             * The HTTP 403 Forbidden client error response status code indicates that the server understood the request
+             * but refused to process it. This status is similar to 401, except that for 403 Forbidden responses,
+             * authenticating or re-authenticating makes no difference. The request failure is tied to application logic,
+             * such as insufficient permissions to a resource or action.
+             */
+            return request.CreateResponse(HttpStatusCode.Forbidden);
+        }
+
+        var responseMessage = await _incomingMessageClient
+            .ReceiveIncomingMarketMessageAsync(
+                incomingMarketMessageStream,
+                incomingDocumentFormat: DocumentFormat.Ebix,
+                IncomingDocumentType.MeteredDataForMeasurementPoint,
+                responseDocumentFormat: DocumentFormat.Ebix,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        var httpStatusCode = responseMessage.IsErrorResponse
+            ? HttpStatusCode.BadRequest
+            : HttpStatusCode.Accepted;
+
+        var httpResponseData = await CreateResponseAsync(request, httpStatusCode, responseMessage)
+            .ConfigureAwait(false);
+
+        return httpResponseData;
+    }
+
+    private static async Task<HttpResponseData> CreateResponseAsync(
+        HttpRequestData request,
+        HttpStatusCode statusCode,
+        ResponseMessage responseMessage)
+    {
+        var response = request.CreateResponse(statusCode);
+        response.Headers.Add("Content-Type", $"{DocumentFormat.Ebix.GetContentType()}; charset=utf-8");
+        await response.WriteStringAsync(responseMessage.MessageBody, Encoding.UTF8).ConfigureAwait(false);
+
+        return response;
+    }
+}

--- a/source/B2BApi/IncomingMessages/EbixIncomingMessageReceiver.cs
+++ b/source/B2BApi/IncomingMessages/EbixIncomingMessageReceiver.cs
@@ -41,7 +41,10 @@ public sealed class EbixIncomingMessageReceiver(
         ArgumentNullException.ThrowIfNull(request);
         var cancellationToken = request.GetCancellationToken(hostCancellationToken);
 
-        using var seekingStreamFromBody = await request.CreateSeekingStreamFromBodyAsync(cancellationToken).ConfigureAwait(false);
+        using var seekingStreamFromBody = await request
+            .CreateSeekingStreamFromBodyAsync(cancellationToken)
+            .ConfigureAwait(false);
+
         var incomingMarketMessageStream = new IncomingMarketMessageStream(seekingStreamFromBody);
 
         if (!await _featureFlagManager.ReceiveMeteredDataForMeasurementPointsAsync().ConfigureAwait(false))

--- a/source/B2BApi/IncomingMessages/IncomingMessageReceiver.cs
+++ b/source/B2BApi/IncomingMessages/IncomingMessageReceiver.cs
@@ -53,7 +53,7 @@ public class IncomingMessageReceiver
         ArgumentNullException.ThrowIfNull(request);
         var cancellationToken = request.GetCancellationToken(hostCancellationToken);
 
-        using var seekingStreamFromBody = await request.CreateSeekingStreamFromBodyAsync().ConfigureAwait(false);
+        using var seekingStreamFromBody = await request.CreateSeekingStreamFromBodyAsync(cancellationToken).ConfigureAwait(false);
         var incomingMarketMessageStream = new IncomingMarketMessageStream(seekingStreamFromBody);
         await AuditLogAsync(request, incomingDocumentTypeName, incomingMarketMessageStream, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Introduces a new receiver for incoming messages. The route contains no document type or format. The route is assumed to only be used with metered data for measurement points in the ebix format. We allow this strong assumption, as to the best of our knowledge, no other type of incoming ebix messages exists.

## References

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/351

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task