### PR TITLE
test: Align and extend XyzResponseFactoryTests with verbatim comparison

### DIFF
--- a/source/IncomingMessages.Infrastructure/Response/EbixResponseFactory.cs
+++ b/source/IncomingMessages.Infrastructure/Response/EbixResponseFactory.cs
@@ -36,18 +36,26 @@ public class EbixResponseFactory : IResponseFactory
     {
         ArgumentNullException.ThrowIfNull(result);
         var messageBody = new StringBuilder();
-        var settings = new XmlWriterSettings() { OmitXmlDeclaration = true, };
+        var settings = new XmlWriterSettings { OmitXmlDeclaration = true, Indent = true };
 
         using var writer = XmlWriter.Create(messageBody, settings);
         writer.WriteStartElement("Error");
-        writer.WriteElementString("faultcode", "SOAP-ENV:Client");
-        writer.WriteElementString("faultstring", $"{result.Errors.First().Code}:{result.Errors.First().Message}");
-        writer.WriteStartElement("detail");
-        writer.WriteStartElement("fault");
-        writer.WriteElementString("ErrorCode", result.Errors.First().Code);
-        writer.WriteElementString("ErrorText", result.Errors.First().Message);
-        writer.WriteEndElement();
-        writer.WriteEndElement();
+        {
+            writer.WriteElementString("faultcode", "SOAP-ENV:Client");
+            writer.WriteElementString("faultstring", $"{result.Errors.First().Code}:{result.Errors.First().Message}");
+            writer.WriteStartElement("detail");
+            {
+                writer.WriteStartElement("fault");
+                {
+                    writer.WriteElementString("ErrorCode", result.Errors.First().Code);
+                    writer.WriteElementString("ErrorText", result.Errors.First().Message);
+                }
+
+                writer.WriteEndElement();
+            }
+
+            writer.WriteEndElement();
+        }
 
         writer.WriteEndElement();
         writer.Close();

--- a/source/IncomingMessages.Infrastructure/Response/JsonResponseFactory.cs
+++ b/source/IncomingMessages.Infrastructure/Response/JsonResponseFactory.cs
@@ -41,38 +41,50 @@ public sealed class JsonResponseFactory(JavaScriptEncoder javaScriptEncoder) : I
         using var writer = new Utf8JsonWriter(messageBody, _writerOptions);
 
         writer.WriteStartObject();
-        writer.WritePropertyName("Error");
-        writer.WriteStartObject();
-        writer.WritePropertyName("Code");
-        writer.WriteStringValue(result.Errors.Count == 1 ? result.Errors.First().Code : "BadRequest");
-        writer.WritePropertyName("Message");
-        writer.WriteStringValue(result.Errors.Count == 1 ? result.Errors.First().Message : "Multiple errors in message");
-        writer.WritePropertyName("Target");
-        writer.WriteStringValue(result.Errors.Count == 1 ? result.Errors.First().Target : string.Empty);
-
-        if (result.Errors.Count > 1)
         {
-            writer.WritePropertyName("Details");
+            writer.WritePropertyName("Error");
             writer.WriteStartObject();
-            writer.WritePropertyName("Errors");
-            writer.WriteStartArray();
-            foreach (var validationError in result.Errors)
             {
-                writer.WriteStartObject();
                 writer.WritePropertyName("Code");
-                writer.WriteStringValue(validationError.Code);
+                writer.WriteStringValue(result.Errors.Count == 1 ? result.Errors.First().Code : "BadRequest");
                 writer.WritePropertyName("Message");
-                writer.WriteStringValue(validationError.Message);
+                writer.WriteStringValue(
+                    result.Errors.Count == 1 ? result.Errors.First().Message : "Multiple errors in message");
                 writer.WritePropertyName("Target");
-                writer.WriteStringValue(validationError.Target);
-                writer.WriteEndObject();
+                writer.WriteStringValue(result.Errors.Count == 1 ? result.Errors.First().Target : string.Empty);
+
+                if (result.Errors.Count > 1)
+                {
+                    writer.WritePropertyName("Details");
+                    writer.WriteStartObject();
+                    {
+                        writer.WritePropertyName("Errors");
+                        writer.WriteStartArray();
+                        foreach (var validationError in result.Errors)
+                        {
+                            writer.WriteStartObject();
+                            {
+                                writer.WritePropertyName("Code");
+                                writer.WriteStringValue(validationError.Code);
+                                writer.WritePropertyName("Message");
+                                writer.WriteStringValue(validationError.Message);
+                                writer.WritePropertyName("Target");
+                                writer.WriteStringValue(validationError.Target);
+                            }
+
+                            writer.WriteEndObject();
+                        }
+
+                        writer.WriteEndArray();
+                    }
+
+                    writer.WriteEndObject();
+                }
             }
 
-            writer.WriteEndArray();
             writer.WriteEndObject();
         }
 
-        writer.WriteEndObject();
         writer.WriteEndObject();
         writer.Flush();
 

--- a/source/IncomingMessages.Infrastructure/Response/ResponseFactory.cs
+++ b/source/IncomingMessages.Infrastructure/Response/ResponseFactory.cs
@@ -18,26 +18,18 @@ using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
 
 namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Response;
 
-public class ResponseFactory
+public class ResponseFactory(IEnumerable<IResponseFactory> factories)
 {
-    private readonly IEnumerable<IResponseFactory> _factories;
-
-    public ResponseFactory(IEnumerable<IResponseFactory> factories)
-    {
-        _factories = factories;
-    }
+    private readonly IEnumerable<IResponseFactory> _factories = factories;
 
     public ResponseMessage From(Result result, DocumentFormat format)
     {
         ArgumentNullException.ThrowIfNull(result);
         ArgumentNullException.ThrowIfNull(format);
 
-        var factory = _factories.FirstOrDefault(factory => factory.HandledFormat.Equals(format));
-
-        if (factory is null)
-        {
-            throw new InvalidOperationException($"Could not generate response message in format {format.Name}");
-        }
+        var factory = _factories.FirstOrDefault(factory => factory.HandledFormat.Equals(format))
+                      ?? throw new InvalidOperationException(
+                          $"Could not generate response message in format {format.Name}");
 
         return factory.From(result);
     }

--- a/source/IncomingMessages.Infrastructure/Response/XmlResponseFactory.cs
+++ b/source/IncomingMessages.Infrastructure/Response/XmlResponseFactory.cs
@@ -20,7 +20,7 @@ using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
 
 namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Response;
 
-public class XmlResponseFactory : IResponseFactory
+public sealed class XmlResponseFactory : IResponseFactory
 {
 #pragma warning disable CA1822
     public DocumentFormat HandledFormat => DocumentFormat.Xml;
@@ -36,26 +36,35 @@ public class XmlResponseFactory : IResponseFactory
     {
         ArgumentNullException.ThrowIfNull(result);
         var messageBody = new StringBuilder();
-        var settings = new XmlWriterSettings() { OmitXmlDeclaration = true, };
+        var settings = new XmlWriterSettings { OmitXmlDeclaration = true, Indent = true };
 
         using var writer = XmlWriter.Create(messageBody, settings);
         writer.WriteStartElement("Error");
-        writer.WriteElementString("Code", result.Errors.Count == 1 ? result.Errors.First().Code : "BadRequest");
-        writer.WriteElementString("Message", result.Errors.Count == 1 ? result.Errors.First().Message : "Multiple errors in message");
-        writer.WriteElementString("Target", result.Errors.Count == 1 ? result.Errors.First().Target : string.Empty);
-        if (result.Errors.Count > 1)
         {
-            writer.WriteStartElement("Details");
-            foreach (var validationError in result.Errors)
+            writer.WriteElementString("Code", result.Errors.Count == 1 ? result.Errors.First().Code : "BadRequest");
+            writer.WriteElementString(
+                "Message",
+                result.Errors.Count == 1 ? result.Errors.First().Message : "Multiple errors in message");
+            writer.WriteElementString("Target", result.Errors.Count == 1 ? result.Errors.First().Target : string.Empty);
+            if (result.Errors.Count > 1)
             {
-                writer.WriteStartElement("Error");
-                writer.WriteElementString("Code", validationError.Code);
-                writer.WriteElementString("Message", validationError.Message);
-                writer.WriteElementString("Target", validationError.Target);
+                writer.WriteStartElement("Details");
+                {
+                    foreach (var validationError in result.Errors)
+                    {
+                        writer.WriteStartElement("Error");
+                        {
+                            writer.WriteElementString("Code", validationError.Code);
+                            writer.WriteElementString("Message", validationError.Message);
+                            writer.WriteElementString("Target", validationError.Target);
+                        }
+
+                        writer.WriteEndElement();
+                    }
+                }
+
                 writer.WriteEndElement();
             }
-
-            writer.WriteEndElement();
         }
 
         writer.WriteEndElement();

--- a/source/IncomingMessages.Infrastructure/Response/XmlResponseFactory.cs
+++ b/source/IncomingMessages.Infrastructure/Response/XmlResponseFactory.cs
@@ -20,7 +20,7 @@ using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
 
 namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Response;
 
-public sealed class XmlResponseFactory : IResponseFactory
+public class XmlResponseFactory : IResponseFactory
 {
 #pragma warning disable CA1822
     public DocumentFormat HandledFormat => DocumentFormat.Xml;

--- a/source/Tests/CimMessageAdapter/Response/EbixResponseFactoryTests.cs
+++ b/source/Tests/CimMessageAdapter/Response/EbixResponseFactoryTests.cs
@@ -17,36 +17,57 @@ using Energinet.DataHub.EDI.IncomingMessages.Domain.Validation;
 using Energinet.DataHub.EDI.IncomingMessages.Domain.Validation.ValidationErrors;
 using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Response;
 using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
+using FluentAssertions;
 using Xunit;
 using Xunit.Categories;
 
 namespace Energinet.DataHub.EDI.Tests.CimMessageAdapter.Response;
 
 [UnitTest]
-public class EbixResponseFactoryTests
+public sealed class EbixResponseFactoryTests
 {
-    private readonly EbixResponseFactory _responseFactory;
-
-    public EbixResponseFactoryTests()
-    {
-        _responseFactory = new EbixResponseFactory();
-    }
+    private readonly EbixResponseFactory _responseFactory = new();
 
     [Fact]
-    public void Generates_single_error_response()
+    public void Given_FailureResultWithOneError_When_ResponseCreated_Then_ResponseContainsError()
     {
         var duplicateMessageIdError = new DuplicateMessageIdDetected("Duplicate message id");
         var result = Result.Failure(duplicateMessageIdError);
 
         var response = CreateResponse(result);
 
-        Assert.True(response.IsErrorResponse);
+        response.IsErrorResponse.Should().BeTrue();
         AssertHasValue(response, "faultcode", "SOAP-ENV:Client");
         AssertHasValue(response, "faultstring", $"{duplicateMessageIdError.Code}:{duplicateMessageIdError.Message}");
     }
 
     [Fact]
-    public void Generates_multiple_errors_response()
+    public void Given_FailureResult_When_ResponseCreated_Then_ResponseLooksLikeAnEbixResponse()
+    {
+        var duplicateMessageIdError = new DuplicateMessageIdDetected("Duplicate message id");
+        var result = Result.Failure(duplicateMessageIdError);
+
+        var response = CreateResponse(result);
+
+        response.IsErrorResponse.Should().BeTrue();
+        response.MessageBody.Should()
+            .BeEquivalentTo(
+                """
+                <Error>
+                  <faultcode>SOAP-ENV:Client</faultcode>
+                  <faultstring>00101:Message id 'Duplicate message id' is not unique</faultstring>
+                  <detail>
+                    <fault>
+                      <ErrorCode>00101</ErrorCode>
+                      <ErrorText>Message id 'Duplicate message id' is not unique</ErrorText>
+                    </fault>
+                  </detail>
+                </Error>
+                """);
+    }
+
+    [Fact]
+    public void Given_FailureResultWithMultipleErrors_When_ResponseCreated_Then_ResponseContainsOnlyTheFirstError()
     {
         var duplicateMessageIdError = new DuplicateMessageIdDetected("Duplicate message id");
         var duplicateTransactionIdError = new DuplicateTransactionIdDetected("Fake transaction id");
@@ -54,7 +75,7 @@ public class EbixResponseFactoryTests
 
         var response = CreateResponse(result);
 
-        Assert.True(response.IsErrorResponse);
+        response.IsErrorResponse.Should().BeTrue();
         AssertHasValue(response, "faultcode", "SOAP-ENV:Client");
         AssertHasValue(response, "faultstring", $"{duplicateMessageIdError.Code}:{duplicateMessageIdError.Message}");
         AssertHasNotValue(response, "faultstring", $"{duplicateTransactionIdError.Code}:{duplicateTransactionIdError.Message}");
@@ -63,13 +84,13 @@ public class EbixResponseFactoryTests
     private static void AssertHasValue(ResponseMessage responseMessage, string elementName, string expectedValue)
     {
         var document = XDocument.Parse(responseMessage.MessageBody);
-        Assert.Equal(expectedValue, document?.Element("Error")?.Element(elementName)?.Value);
+        (document.Element("Error")?.Element(elementName)?.Value).Should().Be(expectedValue);
     }
 
     private static void AssertHasNotValue(ResponseMessage responseMessage, string elementName, string expectedValue)
     {
         var document = XDocument.Parse(responseMessage.MessageBody);
-        Assert.NotEqual(expectedValue, document?.Element("Error")?.Element(elementName)?.Value);
+        (document.Element("Error")?.Element(elementName)?.Value).Should().NotBe(expectedValue);
     }
 
     private ResponseMessage CreateResponse(Result result)

--- a/source/Tests/CimMessageAdapter/Response/EbixResponseFactoryTests.cs
+++ b/source/Tests/CimMessageAdapter/Response/EbixResponseFactoryTests.cs
@@ -63,7 +63,7 @@ public sealed class EbixResponseFactoryTests
                     </fault>
                   </detail>
                 </Error>
-                """);
+                """.ReplaceLineEndings());
     }
 
     [Fact]

--- a/source/Tests/CimMessageAdapter/Response/JsonResponseFactoryTests.cs
+++ b/source/Tests/CimMessageAdapter/Response/JsonResponseFactoryTests.cs
@@ -104,7 +104,7 @@ public sealed class JsonResponseFactoryTests
                     }
                   }
                 }
-                """);
+                """.ReplaceLineEndings());
     }
 
     private static void AssertHasValue(ResponseMessage response, string path, string expectedValue)

--- a/source/Tests/CimMessageAdapter/Response/JsonResponseFactoryTests.cs
+++ b/source/Tests/CimMessageAdapter/Response/JsonResponseFactoryTests.cs
@@ -18,6 +18,7 @@ using Energinet.DataHub.EDI.IncomingMessages.Domain.Validation;
 using Energinet.DataHub.EDI.IncomingMessages.Domain.Validation.ValidationErrors;
 using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Response;
 using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
+using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -26,7 +27,7 @@ using Xunit.Categories;
 namespace Energinet.DataHub.EDI.Tests.CimMessageAdapter.Response;
 
 [UnitTest]
-public class JsonResponseFactoryTests
+public sealed class JsonResponseFactoryTests
 {
     private readonly JsonResponseFactory _responseFactory;
 
@@ -41,20 +42,20 @@ public class JsonResponseFactoryTests
     }
 
     [Fact]
-    public void Generates_single_error_response()
+    public void Given_FailureResultWithSingleError_When_ResponseCreated_Then_ResponseContainsError()
     {
         var duplicateMessageIdError = new DuplicateMessageIdDetected("Duplicate message id");
         var result = Result.Failure(duplicateMessageIdError);
 
         var response = CreateResponse(result);
 
-        Assert.True(response.IsErrorResponse);
+        response.IsErrorResponse.Should().BeTrue();
         AssertHasValue(response, "Error.Code", duplicateMessageIdError.Code);
         AssertHasValue(response, "Error.Message", duplicateMessageIdError.Message);
     }
 
     [Fact]
-    public void Generates_multiple_errors_response()
+    public void Given_FailureResultWithMultipleErrors_When_ResponseCreated_Then_ResponseContainsAllErrors()
     {
         var duplicateMessageIdError = new DuplicateMessageIdDetected("Duplicate message id");
         var duplicateTransactionIdError = new DuplicateTransactionIdDetected("Fake transaction id");
@@ -62,18 +63,55 @@ public class JsonResponseFactoryTests
 
         var response = CreateResponse(result);
 
-        Assert.True(response.IsErrorResponse);
+        response.IsErrorResponse.Should().BeTrue();
         AssertHasValue(response, "Error.Code", "BadRequest");
         AssertHasValue(response, "Error.Message", "Multiple errors in message");
         AssertContainsError(response, duplicateMessageIdError, "Error.Details.Errors[0].");
         AssertContainsError(response, duplicateTransactionIdError, "Error.Details.Errors[1].");
     }
 
+    [Fact]
+    public void Given_FailureResultWithMultipleErrors_When_ResponseCreated_Then_ResponseLooksLikeAJsonResponse()
+    {
+        var duplicateMessageIdError = new DuplicateMessageIdDetected("Duplicate message id");
+        var duplicateTransactionIdError = new DuplicateTransactionIdDetected("Fake transaction id");
+        var result = Result.Failure(duplicateMessageIdError, duplicateTransactionIdError);
+
+        var response = CreateResponse(result);
+
+        response.IsErrorResponse.Should().BeTrue();
+        response.MessageBody.Should()
+            .BeEquivalentTo(
+                """
+                {
+                  "Error": {
+                    "Code": "BadRequest",
+                    "Message": "Multiple errors in message",
+                    "Target": "",
+                    "Details": {
+                      "Errors": [
+                        {
+                          "Code": "00101",
+                          "Message": "Message id \u0027Duplicate message id\u0027 is not unique",
+                          "Target": "MessageId"
+                        },
+                        {
+                          "Code": "00102",
+                          "Message": "Transaction id \u0027Fake transaction id\u0027 is not unique and will not be processed.",
+                          "Target": "TransactionId"
+                        }
+                      ]
+                    }
+                  }
+                }
+                """);
+    }
+
     private static void AssertHasValue(ResponseMessage response, string path, string expectedValue)
     {
         var jsonObject = JObject.Parse(response.MessageBody);
         var value = (string)jsonObject.SelectToken(path)!;
-        Assert.Equal(expectedValue, value);
+        value.Should().Be(expectedValue);
     }
 
     private static void AssertContainsError(ResponseMessage response, ValidationError validationError, string path)
@@ -82,8 +120,8 @@ public class JsonResponseFactoryTests
         var code = (string)jsonObject.SelectToken(path + "Code")!;
         var message = (string)jsonObject.SelectToken(path + "Message")!;
 
-        Assert.Equal(validationError.Code, code);
-        Assert.Equal(validationError.Message, message);
+        code.Should().Be(validationError.Code);
+        message.Should().Be(validationError.Message);
     }
 
     private ResponseMessage CreateResponse(Result result)

--- a/source/Tests/CimMessageAdapter/Response/ResponseFactoryTests.cs
+++ b/source/Tests/CimMessageAdapter/Response/ResponseFactoryTests.cs
@@ -15,32 +15,34 @@
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.IncomingMessages.Domain.Validation;
 using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Response;
+using FluentAssertions;
 using Xunit;
 using Xunit.Categories;
 
 namespace Energinet.DataHub.EDI.Tests.CimMessageAdapter.Response;
 
 [UnitTest]
-public class ResponseFactoryTests
+public sealed class ResponseFactoryTests
 {
     [Fact]
-    public void Generate_empty_response_when_no_validation_errors_has_occurred()
+    public void Given_SucceededResult_When_ResponseCreated_Then_ResponseIsEmpty()
     {
-        var responseFactory = new ResponseFactory(new[] { new XmlResponseFactory() });
+        var responseFactory = new ResponseFactory([new XmlResponseFactory()]);
         var result = Result.Succeeded();
 
         var response = responseFactory.From(result, DocumentFormat.Xml);
 
-        Assert.False(response.IsErrorResponse);
-        Assert.Empty(response.MessageBody);
+        response.IsErrorResponse.Should().BeFalse();
+        response.MessageBody.Should().BeEmpty();
     }
 
     [Fact]
-    public void Throw_if_requested_format_can_not_be_parsed()
+    public void Given_AResponseFactory_When_InvokedWithUnknownDocumentType_Then_ThrowError()
     {
-        var responseFactory = new ResponseFactory(new List<IResponseFactory>());
+        var responseFactory = new ResponseFactory([]);
         var result = Result.Succeeded();
 
-        Assert.Throws<InvalidOperationException>(() => responseFactory.From(result, DocumentFormat.Json));
+        var act = () => responseFactory.From(result, DocumentFormat.Json);
+        act.Should().ThrowExactly<InvalidOperationException>();
     }
 }

--- a/source/Tests/CimMessageAdapter/Response/XmlResponseFactoryTests.cs
+++ b/source/Tests/CimMessageAdapter/Response/XmlResponseFactoryTests.cs
@@ -17,36 +17,32 @@ using Energinet.DataHub.EDI.IncomingMessages.Domain.Validation;
 using Energinet.DataHub.EDI.IncomingMessages.Domain.Validation.ValidationErrors;
 using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Response;
 using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
+using FluentAssertions;
 using Xunit;
 using Xunit.Categories;
 
 namespace Energinet.DataHub.EDI.Tests.CimMessageAdapter.Response;
 
 [UnitTest]
-public class XmlResponseFactoryTests
+public sealed class XmlResponseFactoryTests
 {
-    private readonly XmlResponseFactory _responseFactory;
-
-    public XmlResponseFactoryTests()
-    {
-        _responseFactory = new XmlResponseFactory();
-    }
+    private readonly XmlResponseFactory _responseFactory = new();
 
     [Fact]
-    public void Generates_single_error_response()
+    public void Given_FailureResultWithSingleError_When_ResponseCreated_Then_ResponseContainsError()
     {
         var duplicateMessageIdError = new DuplicateMessageIdDetected("Duplicate message id");
         var result = Result.Failure(duplicateMessageIdError);
 
         var response = CreateResponse(result);
 
-        Assert.True(response.IsErrorResponse);
+        response.IsErrorResponse.Should().BeTrue();
         AssertHasValue(response, "Code", duplicateMessageIdError.Code);
         AssertHasValue(response, "Message", duplicateMessageIdError.Message);
     }
 
     [Fact]
-    public void Generates_multiple_errors_response()
+    public void Given_FailureResultWithMultipleErrors_When_ResponseCreated_Then_ResponseContainsAllErrors()
     {
         var duplicateMessageIdError = new DuplicateMessageIdDetected("Duplicate message id");
         var duplicateTransactionIdError = new DuplicateTransactionIdDetected("Fake transaction id");
@@ -54,17 +50,50 @@ public class XmlResponseFactoryTests
 
         var response = CreateResponse(result);
 
-        Assert.True(response.IsErrorResponse);
+        response.IsErrorResponse.Should().BeTrue();
         AssertHasValue(response, "Code", "BadRequest");
         AssertHasValue(response, "Message", "Multiple errors in message");
         AssertContainsError(response, duplicateMessageIdError);
         AssertContainsError(response, duplicateTransactionIdError);
     }
 
+    [Fact]
+    public void Given_FailureResultWithMultipleErrors_When_ResponseCreated_Then_ResponseLooksLikeAXmlResponse()
+    {
+        var duplicateMessageIdError = new DuplicateMessageIdDetected("Duplicate message id");
+        var duplicateTransactionIdError = new DuplicateTransactionIdDetected("Fake transaction id");
+        var result = Result.Failure(duplicateMessageIdError, duplicateTransactionIdError);
+
+        var response = CreateResponse(result);
+
+        response.IsErrorResponse.Should().BeTrue();
+        response.MessageBody.Should()
+            .BeEquivalentTo(
+                """
+                <Error>
+                  <Code>BadRequest</Code>
+                  <Message>Multiple errors in message</Message>
+                  <Target />
+                  <Details>
+                    <Error>
+                      <Code>00101</Code>
+                      <Message>Message id 'Duplicate message id' is not unique</Message>
+                      <Target>MessageId</Target>
+                    </Error>
+                    <Error>
+                      <Code>00102</Code>
+                      <Message>Transaction id 'Fake transaction id' is not unique and will not be processed.</Message>
+                      <Target>TransactionId</Target>
+                    </Error>
+                  </Details>
+                </Error>
+                """);
+    }
+
     private static void AssertHasValue(ResponseMessage responseMessage, string elementName, string expectedValue)
     {
         var document = XDocument.Parse(responseMessage.MessageBody);
-        Assert.Equal(expectedValue, document?.Element("Error")?.Element(elementName)?.Value);
+        (document.Element("Error")?.Element(elementName)?.Value).Should().Be(expectedValue);
     }
 
     private static void AssertContainsError(ResponseMessage responseMessage, ValidationError validationError)

--- a/source/Tests/CimMessageAdapter/Response/XmlResponseFactoryTests.cs
+++ b/source/Tests/CimMessageAdapter/Response/XmlResponseFactoryTests.cs
@@ -101,8 +101,16 @@ public sealed class XmlResponseFactoryTests
         var document = XDocument.Parse(responseMessage.MessageBody);
         var errors = document.Element("Error")?.Element("Details")?.Elements().ToList();
 
-        Assert.Contains(errors!, error => error.Element("Code")?.Value == validationError.Code);
-        Assert.Contains(errors!, error => error.Element("Message")?.Value == validationError.Message);
+        errors.Should().NotBeNull();
+        errors!
+            .Select(e => e.Element("Code")!.Value)
+            .Should()
+            .Contain(validationError.Code);
+
+        errors!
+            .Select(e => e.Element("Message")!.Value)
+            .Should()
+            .Contain(validationError.Message);
     }
 
     private ResponseMessage CreateResponse(Result result)

--- a/source/Tests/CimMessageAdapter/Response/XmlResponseFactoryTests.cs
+++ b/source/Tests/CimMessageAdapter/Response/XmlResponseFactoryTests.cs
@@ -87,7 +87,7 @@ public sealed class XmlResponseFactoryTests
                     </Error>
                   </Details>
                 </Error>
-                """);
+                """.ReplaceLineEndings());
     }
 
     private static void AssertHasValue(ResponseMessage responseMessage, string elementName, string expectedValue)

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -23,7 +23,7 @@ limitations under the License.
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.12.1" />
-        <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
+        <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

## References

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/351

## Checklist
- [x] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task