### PR TITLE
feat: added delegation handling for metered data messages

### DIFF
--- a/source/IncomingMessages.Application/DelegateIncomingMessage.cs
+++ b/source/IncomingMessages.Application/DelegateIncomingMessage.cs
@@ -74,10 +74,12 @@ public class DelegateIncomingMessage
         }
 
         // Delegation is setup for grid areas, so we need to set delegated for each series since they contain the grid area
+        // Except for incoming metered data for measurement point, since this doesn't have a grid area
         foreach (var series in message.Series)
         {
             if ((originalActorRole == ActorRole.GridAccessProvider || originalActorRole == ActorRole.MeteredDataResponsible)
-                && series.GridArea == null)
+                && series.GridArea == null
+                && processType != ProcessType.IncomingMeteredDataForMeasurementPoint)
             {
                 continue;
             }
@@ -90,6 +92,7 @@ public class DelegateIncomingMessage
                     cancellationToken)
                 .ConfigureAwait(false);
 
+            // TODO: Metered mes type should find delegation when role is del only and ignore gridarea.
             if (delegations.Count != 0)
             {
                 GridAreaOwnerDto? gridAreaOwner = null;
@@ -101,6 +104,13 @@ public class DelegateIncomingMessage
                             series.GridArea,
                             cancellationToken)
                         .ConfigureAwait(false);
+                }
+
+                if (processType == ProcessType.IncomingMeteredDataForMeasurementPoint)
+                {
+                    // For incoming metered data for measurement point, we do not know the owner of the metering point yet (original actor). Therefore, all delegated grid ares are parsed on.
+                    // Then in the async validation we will check that the metering point belongs to any of the grid areas.
+                    series.DelegateSeries(null, requestedByActorRole, delegations.Select(d => d.GridAreaCode).ToArray());
                 }
 
                 var originalActorNumber = series.GetActorNumberForRole(originalActorRole, gridAreaOwner?.ActorNumber);
@@ -151,6 +161,11 @@ public class DelegateIncomingMessage
             || incomingDocumentType == IncomingDocumentType.B2CRequestWholesaleSettlement)
         {
             return ProcessType.RequestWholesaleResults;
+        }
+
+        if (incomingDocumentType == IncomingDocumentType.MeteredDataForMeasurementPoint)
+        {
+            return ProcessType.IncomingMeteredDataForMeasurementPoint;
         }
 
         throw new ArgumentOutOfRangeException(nameof(incomingDocumentType), incomingDocumentType, $"Cannot map {nameof(IncomingDocumentType)} to {nameof(ProcessType)}");

--- a/source/IncomingMessages.Application/DelegateIncomingMessage.cs
+++ b/source/IncomingMessages.Application/DelegateIncomingMessage.cs
@@ -150,21 +150,18 @@ public class DelegateIncomingMessage
 
     private ProcessType MapToProcessType(IncomingDocumentType incomingDocumentType)
     {
-        if (incomingDocumentType == IncomingDocumentType.RequestAggregatedMeasureData
-            || incomingDocumentType == IncomingDocumentType.B2CRequestAggregatedMeasureData)
+        var documentTypeToProcessTypeMap = new Dictionary<IncomingDocumentType, ProcessType>
         {
-            return ProcessType.RequestEnergyResults;
-        }
+            { IncomingDocumentType.RequestAggregatedMeasureData, ProcessType.RequestEnergyResults },
+            { IncomingDocumentType.B2CRequestAggregatedMeasureData, ProcessType.RequestEnergyResults },
+            { IncomingDocumentType.RequestWholesaleSettlement, ProcessType.RequestWholesaleResults },
+            { IncomingDocumentType.B2CRequestWholesaleSettlement, ProcessType.RequestWholesaleResults },
+            { IncomingDocumentType.MeteredDataForMeasurementPoint, ProcessType.IncomingMeteredDataForMeasurementPoint },
+        };
 
-        if (incomingDocumentType == IncomingDocumentType.RequestWholesaleSettlement
-            || incomingDocumentType == IncomingDocumentType.B2CRequestWholesaleSettlement)
+        if (documentTypeToProcessTypeMap.TryGetValue(incomingDocumentType, out var processType))
         {
-            return ProcessType.RequestWholesaleResults;
-        }
-
-        if (incomingDocumentType == IncomingDocumentType.MeteredDataForMeasurementPoint)
-        {
-            return ProcessType.IncomingMeteredDataForMeasurementPoint;
+            return processType;
         }
 
         throw new ArgumentOutOfRangeException(nameof(incomingDocumentType), incomingDocumentType, $"Cannot map {nameof(IncomingDocumentType)} to {nameof(ProcessType)}");

--- a/source/IncomingMessages.Application/DelegateIncomingMessage.cs
+++ b/source/IncomingMessages.Application/DelegateIncomingMessage.cs
@@ -74,7 +74,7 @@ public class DelegateIncomingMessage
         }
 
         // Delegation is setup for grid areas, so we need to set delegated for each series since they contain the grid area
-        // Except for incoming metered data for measurement point, since this doesn't have a grid area
+        // Except for incoming metered data for measurement point, which this doesn't have a grid area
         foreach (var series in message.Series)
         {
             if ((originalActorRole == ActorRole.GridAccessProvider || originalActorRole == ActorRole.MeteredDataResponsible)
@@ -92,7 +92,6 @@ public class DelegateIncomingMessage
                     cancellationToken)
                 .ConfigureAwait(false);
 
-            // TODO: Metered mes type should find delegation when role is del only and ignore gridarea.
             if (delegations.Count != 0)
             {
                 GridAreaOwnerDto? gridAreaOwner = null;

--- a/source/IncomingMessages.Domain/Abstractions/BaseDelegatedSeries.cs
+++ b/source/IncomingMessages.Domain/Abstractions/BaseDelegatedSeries.cs
@@ -26,7 +26,7 @@ public abstract record BaseDelegatedSeries : IDelegatedIncomingMessageSeries
 
     public IReadOnlyCollection<string> DelegatedGridAreas { get; private set; } = Array.Empty<string>();
 
-    public void DelegateSeries(ActorNumber originalActorNumber, ActorRole requestedByActorRole, IReadOnlyCollection<string> delegatedGridAreas)
+    public void DelegateSeries(ActorNumber? originalActorNumber, ActorRole requestedByActorRole, IReadOnlyCollection<string> delegatedGridAreas)
     {
         IsDelegated = true;
         OriginalActorNumber = originalActorNumber;

--- a/source/IncomingMessages.Domain/Abstractions/IDelegatedIncomingMessageSeries.cs
+++ b/source/IncomingMessages.Domain/Abstractions/IDelegatedIncomingMessageSeries.cs
@@ -47,5 +47,5 @@ public interface IDelegatedIncomingMessageSeries
     /// <summary>
     /// Sets the incoming message series as delegated
     /// </summary>
-    public void DelegateSeries(ActorNumber originalActorNumber, ActorRole requestedByActorRole, IReadOnlyCollection<string> delegatedGridAreas);
+    public void DelegateSeries(ActorNumber? originalActorNumber, ActorRole requestedByActorRole, IReadOnlyCollection<string> delegatedGridAreas);
 }

--- a/source/IncomingMessages.Domain/MeteredDataForMeasurementPointMessage.cs
+++ b/source/IncomingMessages.Domain/MeteredDataForMeasurementPointMessage.cs
@@ -52,8 +52,8 @@ public record MeteredDataForMeasurementPointSeries(
     {
         return actorRole.Name switch
         {
-            // MeteredDataResponsible is the only role that can make this incoming message.
-            DataHubNames.ActorRole.MeteredDataResponsible => ActorNumber.TryCreate(SenderNumber),
+            DataHubNames.ActorRole.GridAccessProvider => ActorNumber.TryCreate(SenderNumber),
+            DataHubNames.ActorRole.Delegated => ActorNumber.TryCreate(SenderNumber),
             _ => null,
         };
     }

--- a/source/IncomingMessages.Infrastructure/Factories/InitializeMeteredDataForMeasurementPointProcessDtoFactory.cs
+++ b/source/IncomingMessages.Infrastructure/Factories/InitializeMeteredDataForMeasurementPointProcessDtoFactory.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Authentication;
 using Energinet.DataHub.EDI.IncomingMessages.Domain;
 using Energinet.DataHub.EDI.Process.Interfaces;
 
@@ -20,12 +20,9 @@ namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Factories;
 
 public static class InitializeMeteredDataForMeasurementPointProcessDtoFactory
 {
-    public static InitializeMeteredDataForMeasurementPointMessageProcessDto Create(MeteredDataForMeasurementPointMessage meteredDataForMeasurementPointMessage)
+    public static InitializeMeteredDataForMeasurementPointMessageProcessDto Create(MeteredDataForMeasurementPointMessage meteredDataForMeasurementPointMessage, AuthenticatedActor authenticatedActor)
     {
         ArgumentNullException.ThrowIfNull(meteredDataForMeasurementPointMessage);
-
-        var senderActorNumber = ActorNumber.Create(meteredDataForMeasurementPointMessage.SenderNumber);
-        var senderRoleCode = ActorRole.FromCode(meteredDataForMeasurementPointMessage.SenderRoleCode);
 
         var series = meteredDataForMeasurementPointMessage.Series
             .Cast<MeteredDataForMeasurementPointSeries>()
@@ -43,8 +40,8 @@ public static class InitializeMeteredDataForMeasurementPointProcessDtoFactory
                         MeteringPointLocationId: series.MeteringPointLocationId,
                         DelegatedGridAreaCodes: series.DelegatedGridAreas,
                         RequestedByActor: RequestedByActor.From(
-                            senderActorNumber,
-                            series.RequestedByActorRole ?? senderRoleCode),
+                            authenticatedActor.CurrentActorIdentity.ActorNumber,
+                            series.RequestedByActorRole ?? authenticatedActor.CurrentActorIdentity.ActorRole),
                         EnergyObservations: series.EnergyObservations
                             .Select(
                                 energyObservation => new InitializeEnergyObservation(

--- a/source/IncomingMessages.Infrastructure/Factories/InitializeMeteredDataForMeasurementPointProcessDtoFactory.cs
+++ b/source/IncomingMessages.Infrastructure/Factories/InitializeMeteredDataForMeasurementPointProcessDtoFactory.cs
@@ -25,7 +25,7 @@ public static class InitializeMeteredDataForMeasurementPointProcessDtoFactory
         ArgumentNullException.ThrowIfNull(meteredDataForMeasurementPointMessage);
 
         var senderActorNumber = ActorNumber.Create(meteredDataForMeasurementPointMessage.SenderNumber);
-        var senderActorRole = ActorRole.FromCode(meteredDataForMeasurementPointMessage.SenderRoleCode);
+        var senderRoleCode = ActorRole.FromCode(meteredDataForMeasurementPointMessage.SenderRoleCode);
 
         var series = meteredDataForMeasurementPointMessage.Series
             .Cast<MeteredDataForMeasurementPointSeries>()
@@ -41,12 +41,10 @@ public static class InitializeMeteredDataForMeasurementPointProcessDtoFactory
                         ProductUnitType: series.ProductUnitType,
                         MeteringPointType: series.MeteringPointType,
                         MeteringPointLocationId: series.MeteringPointLocationId,
+                        DelegatedGridAreaCodes: series.DelegatedGridAreas,
                         RequestedByActor: RequestedByActor.From(
                             senderActorNumber,
-                            series.RequestedByActorRole ?? senderActorRole),
-                        OriginalActor: OriginalActor.From(
-                            series.OriginalActorNumber ?? senderActorNumber,
-                            senderActorRole),
+                            series.RequestedByActorRole ?? senderRoleCode),
                         EnergyObservations: series.EnergyObservations
                             .Select(
                                 energyObservation => new InitializeEnergyObservation(

--- a/source/IncomingMessages.Infrastructure/IncomingMessagePublisher.cs
+++ b/source/IncomingMessages.Infrastructure/IncomingMessagePublisher.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Azure.Messaging.ServiceBus;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Authentication;
 using Energinet.DataHub.EDI.BuildingBlocks.Interfaces;
 using Energinet.DataHub.EDI.IncomingMessages.Domain;
 using Energinet.DataHub.EDI.IncomingMessages.Domain.Abstractions;
@@ -26,16 +27,19 @@ namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure;
 
 public class IncomingMessagePublisher
 {
+    private readonly AuthenticatedActor _authenticatedActor;
     private readonly ISerializer _serializer;
     private readonly ServiceBusSender _sender;
 
     public IncomingMessagePublisher(
+        AuthenticatedActor authenticatedActor,
         IOptions<IncomingMessagesQueueOptions> options,
         IAzureClientFactory<ServiceBusSender> senderFactory,
         ISerializer serializer)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(senderFactory);
+        _authenticatedActor = authenticatedActor;
         _serializer = serializer;
 
         _sender = senderFactory.CreateClient(options.Value.QueueName);
@@ -55,7 +59,7 @@ public class IncomingMessagePublisher
                 await SendInitializeWholesaleServicesProcessAsync(InitializeWholesaleServicesProcessDtoFactory.Create(wholesaleSettlementMessage), cancellationToken).ConfigureAwait(false);
                 break;
             case MeteredDataForMeasurementPointMessage meteredDataForMeasurementPointMessage:
-                await SendInitializeMeteredDataForMeasurementPointMessageProcessAsync(InitializeMeteredDataForMeasurementPointProcessDtoFactory.Create(meteredDataForMeasurementPointMessage), cancellationToken).ConfigureAwait(false);
+                await SendInitializeMeteredDataForMeasurementPointMessageProcessAsync(InitializeMeteredDataForMeasurementPointProcessDtoFactory.Create(meteredDataForMeasurementPointMessage, _authenticatedActor), cancellationToken).ConfigureAwait(false);
                 break;
             default:
                 throw new InvalidOperationException($"Unknown message type {incomingMessage.GetType().Name}");

--- a/source/IncomingMessages.IntegrationTests/IncomingMessages/GivenIncomingMessagesTests.cs
+++ b/source/IncomingMessages.IntegrationTests/IncomingMessages/GivenIncomingMessagesTests.cs
@@ -68,8 +68,7 @@ public sealed class GivenIncomingMessagesTests : IncomingMessagesTestBase
         {
             { DocumentFormat.Json, IncomingDocumentType.RequestAggregatedMeasureData, ActorRole.BalanceResponsibleParty, ReadJsonFile(@"IncomingMessages\RequestAggregatedMeasureDataAsDdk.json") },
             { DocumentFormat.Json, IncomingDocumentType.RequestWholesaleSettlement, ActorRole.EnergySupplier, ReadJsonFile(@"IncomingMessages\RequestWholesaleSettlement.json") },
-            // TODO: enable when delegation has been impl.
-            //{ DocumentFormat.Ebix, IncomingDocumentType.MeteredDataForMeasurementPoint, ActorRole.MeteredDataResponsible, ReadJsonFile(@"IncomingMessages\EbixMeteredDataForMeasurementPoint.xml") },
+            { DocumentFormat.Ebix, IncomingDocumentType.MeteredDataForMeasurementPoint, ActorRole.MeteredDataResponsible, ReadJsonFile(@"IncomingMessages\EbixMeteredDataForMeasurementPoint.xml") },
         };
 
         return data;

--- a/source/IncomingMessages.IntegrationTests/IncomingMessages/GivenIncomingMessagesWithDelegationTests.cs
+++ b/source/IncomingMessages.IntegrationTests/IncomingMessages/GivenIncomingMessagesWithDelegationTests.cs
@@ -540,8 +540,7 @@ public sealed class GivenIncomingMessagesWithDelegationTests : IncomingMessagesT
         {
             var message = _senderSpy.LatestMessage!.Body.ToObjectFromJson<InitializeMeteredDataForMeasurementPointMessageProcessDto>();
             var series = message.Series.Should().ContainSingle().Subject;
-            // Should this be the authenticated actor role or the one in message
-            series.RequestedByActor.ActorRole.Should().Be(ActorRole.MeteredDataResponsible);
+            series.RequestedByActor.ActorRole.Should().Be(_authenticatedActor.CurrentActorIdentity.ActorRole);
             series.RequestedByActor.ActorNumber.Should().Be(_authenticatedActor.CurrentActorIdentity.ActorNumber);
             series.DelegatedGridAreaCodes.Should().BeEmpty();
         }

--- a/source/IncomingMessages.IntegrationTests/IncomingMessages/GivenIncomingMessagesWithDelegationTests.cs
+++ b/source/IncomingMessages.IntegrationTests/IncomingMessages/GivenIncomingMessagesWithDelegationTests.cs
@@ -349,6 +349,204 @@ public sealed class GivenIncomingMessagesWithDelegationTests : IncomingMessagesT
         }
     }
 
+    [Fact]
+    public async Task AndGiven_MessageIsMeteredDataForMeasurementPoint_When_SenderIsDelegatedAndDelegationExists_Then_ActorPropertiesOnInternalRepresentationAreCorrect()
+    {
+        // Arrange
+        const string expectedGridAreaCode = "512";
+        var delegatedToAsDelegated = new Actor(ActorNumber.Create("2222222222222"), ActorRole.Delegated);
+        var now = Instant.FromUtc(2024, 05, 07, 13, 37);
+        _clockStub.SetCurrentInstant(now);
+
+        var documentFormat = DocumentFormat.Ebix;
+
+        _authenticatedActor.SetAuthenticatedActor(
+            new ActorIdentity(delegatedToAsDelegated.ActorNumber, Restriction.Owned, delegatedToAsDelegated.ActorRole));
+
+        var messageStream = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
+            documentFormat,
+            delegatedToAsDelegated.ActorNumber,
+            [
+                ("555555555", Instant.FromUtc(2024, 01, 01, 0, 0), Instant.FromUtc(2024, 01, 31, 0, 0), Resolution.QuarterHourly),
+            ]);
+
+        await AddDelegationAsync(
+            _originalActor,
+            delegatedToAsDelegated,
+            expectedGridAreaCode,
+            ProcessType.IncomingMeteredDataForMeasurementPoint,
+            now,
+            now.Plus(Duration.FromSeconds(1)));
+
+        // Act
+        var response = await _incomingMessagesRequest.ReceiveIncomingMarketMessageAsync(
+            messageStream,
+            documentFormat,
+            IncomingDocumentType.MeteredDataForMeasurementPoint,
+            documentFormat,
+            CancellationToken.None);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            response.IsErrorResponse.Should().BeFalse();
+            response.MessageBody.Should().BeNullOrEmpty();
+
+            _senderSpy.LatestMessage.Should().NotBeNull();
+        }
+
+        using (new AssertionScope())
+        {
+            var message = _senderSpy.LatestMessage!.Body.ToObjectFromJson<InitializeMeteredDataForMeasurementPointMessageProcessDto>();
+            var series = message.Series.Should().ContainSingle().Subject;
+            series.RequestedByActor.ActorRole.Should().Be(delegatedToAsDelegated.ActorRole);
+            series.RequestedByActor.ActorNumber.Should().Be(delegatedToAsDelegated.ActorNumber);
+            series.DelegatedGridAreaCodes.Should().Contain(expectedGridAreaCode);
+        }
+    }
+
+    [Fact]
+    public async Task AndGiven_MessageIsMeteredDataForMeasurementPoint_When_SenderIsDelegatedAndDelegationDoesNotExists_Then_ReturnsErrorMessage()
+    {
+        // Arrange
+        var delegatedToAsDelegated = new Actor(ActorNumber.Create("2222222222222"), ActorRole.Delegated);
+        var now = Instant.FromUtc(2024, 05, 07, 13, 37);
+        _clockStub.SetCurrentInstant(now);
+
+        var documentFormat = DocumentFormat.Ebix;
+
+        _authenticatedActor.SetAuthenticatedActor(
+            new ActorIdentity(delegatedToAsDelegated.ActorNumber, Restriction.Owned, delegatedToAsDelegated.ActorRole));
+
+        var messageStream = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
+            documentFormat,
+            delegatedToAsDelegated.ActorNumber,
+            [
+                ("555555555", Instant.FromUtc(2024, 01, 01, 0, 0), Instant.FromUtc(2024, 01, 31, 0, 0), Resolution.QuarterHourly),
+            ]);
+
+        // Act
+        var response = await _incomingMessagesRequest.ReceiveIncomingMarketMessageAsync(
+            messageStream,
+            documentFormat,
+            IncomingDocumentType.MeteredDataForMeasurementPoint,
+            documentFormat,
+            CancellationToken.None);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            response.IsErrorResponse.Should().BeTrue();
+            response.MessageBody.Should().Contain("The authenticated user does not hold the required role");
+
+            _senderSpy.LatestMessage.Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public async Task AndGiven_MessageIsMeteredDataForMeasurementPoint_When_SenderIsGridAccessProviderAndDelegationExists_Then_ActorPropertiesOnInternalRepresentationAreCorrect()
+    {
+        // Arrange
+        const string expectedGridAreaCode = "512";
+        var delegatedToAsGridAccessProvider = new Actor(ActorNumber.Create("2222222222222"), ActorRole.GridAccessProvider);
+        var now = Instant.FromUtc(2024, 05, 07, 13, 37);
+        _clockStub.SetCurrentInstant(now);
+
+        var documentFormat = DocumentFormat.Ebix;
+
+        _authenticatedActor.SetAuthenticatedActor(
+            new ActorIdentity(delegatedToAsGridAccessProvider.ActorNumber, Restriction.Owned, delegatedToAsGridAccessProvider.ActorRole));
+
+        var messageStream = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
+            documentFormat,
+            delegatedToAsGridAccessProvider.ActorNumber,
+            [
+                ("555555555", Instant.FromUtc(2024, 01, 01, 0, 0), Instant.FromUtc(2024, 01, 31, 0, 0), Resolution.QuarterHourly),
+            ]);
+
+        await AddDelegationAsync(
+            _originalActor,
+            delegatedToAsGridAccessProvider,
+            expectedGridAreaCode,
+            ProcessType.IncomingMeteredDataForMeasurementPoint,
+            now,
+            now.Plus(Duration.FromSeconds(1)));
+
+        // Act
+        var response = await _incomingMessagesRequest.ReceiveIncomingMarketMessageAsync(
+            messageStream,
+            documentFormat,
+            IncomingDocumentType.MeteredDataForMeasurementPoint,
+            documentFormat,
+            CancellationToken.None);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            response.IsErrorResponse.Should().BeFalse();
+            response.MessageBody.Should().BeNullOrEmpty();
+
+            _senderSpy.LatestMessage.Should().NotBeNull();
+        }
+
+        using (new AssertionScope())
+        {
+            var message = _senderSpy.LatestMessage!.Body.ToObjectFromJson<InitializeMeteredDataForMeasurementPointMessageProcessDto>();
+            var series = message.Series.Should().ContainSingle().Subject;
+            series.RequestedByActor.ActorRole.Should().Be(delegatedToAsGridAccessProvider.ActorRole);
+            series.RequestedByActor.ActorNumber.Should().Be(delegatedToAsGridAccessProvider.ActorNumber);
+            series.DelegatedGridAreaCodes.Should().Contain(expectedGridAreaCode);
+        }
+    }
+
+    [Fact]
+    public async Task AndGiven_MessageIsMeteredDataForMeasurementPoint_When_SenderIsGridAccessProviderAndDelegationDoesNotExists_Then_ActorPropertiesOnInternalRepresentationAreCorrect()
+    {
+        // Arrange
+        var delegatedToAsGridAccessProvider = new Actor(ActorNumber.Create("2222222222222"), ActorRole.GridAccessProvider);
+
+        var now = Instant.FromUtc(2024, 05, 07, 13, 37);
+        _clockStub.SetCurrentInstant(now);
+
+        _authenticatedActor.SetAuthenticatedActor(
+            new ActorIdentity(delegatedToAsGridAccessProvider.ActorNumber, Restriction.Owned, delegatedToAsGridAccessProvider.ActorRole));
+        var documentFormat = DocumentFormat.Ebix;
+
+        var messageStream = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
+            documentFormat,
+            _authenticatedActor.CurrentActorIdentity.ActorNumber,
+            [
+                ("555555555", Instant.FromUtc(2024, 01, 01, 0, 0), Instant.FromUtc(2024, 01, 31, 0, 0), Resolution.QuarterHourly),
+            ]);
+
+        // Act
+        var response = await _incomingMessagesRequest.ReceiveIncomingMarketMessageAsync(
+            messageStream,
+            documentFormat,
+            IncomingDocumentType.MeteredDataForMeasurementPoint,
+            documentFormat,
+            CancellationToken.None);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            response.IsErrorResponse.Should().BeFalse();
+            response.MessageBody.Should().BeNullOrEmpty();
+
+            _senderSpy.LatestMessage.Should().NotBeNull();
+        }
+
+        using (new AssertionScope())
+        {
+            var message = _senderSpy.LatestMessage!.Body.ToObjectFromJson<InitializeMeteredDataForMeasurementPointMessageProcessDto>();
+            var series = message.Series.Should().ContainSingle().Subject;
+            // Should this be the authenticated actor role or the one in message
+            series.RequestedByActor.ActorRole.Should().Be(ActorRole.MeteredDataResponsible);
+            series.RequestedByActor.ActorNumber.Should().Be(_authenticatedActor.CurrentActorIdentity.ActorNumber);
+            series.DelegatedGridAreaCodes.Should().BeEmpty();
+        }
+    }
+
     private async Task AddDelegationAsync(
         Actor delegatedBy,
         Actor delegatedTo,

--- a/source/IntegrationEvents.Infrastructure/EventProcessors/ProcessDelegationConfiguredEventProcessor.cs
+++ b/source/IntegrationEvents.Infrastructure/EventProcessors/ProcessDelegationConfiguredEventProcessor.cs
@@ -58,6 +58,7 @@ public class ProcessDelegationConfiguredEventProcessor : IIntegrationEventProces
             DelegatedProcess.ProcessRequestEnergyResults => ProcessType.RequestEnergyResults,
             DelegatedProcess.ProcessRequestWholesaleResults => ProcessType.RequestWholesaleResults,
             DelegatedProcess.ProcessReceiveWholesaleResults => ProcessType.ReceiveWholesaleResults,
+            // TODO: DelegatedProcess.IncomingMeteredDataForMeasurementPoint => ProcessType.IncomingMeteredDataForMeasurementPoint,
             _ => throw new ArgumentOutOfRangeException(nameof(delegatedProcess), delegatedProcess, null),
         };
     }

--- a/source/Process.Interfaces/InitializeMeteredDataForMeasurementPointMessageProcessDto.cs
+++ b/source/Process.Interfaces/InitializeMeteredDataForMeasurementPointMessageProcessDto.cs
@@ -31,8 +31,9 @@ public record InitializeMeteredDataForMeasurementPointMessageSeries(
     string? ProductUnitType,
     string? MeteringPointType,
     string? MeteringPointLocationId,
+    // DelegatedGridAreaCodes is a list of grid area codes that the requester is allowed to submit measurements for
+    IReadOnlyCollection<string>? DelegatedGridAreaCodes,
     RequestedByActor RequestedByActor,
-    OriginalActor OriginalActor,
     IReadOnlyCollection<InitializeEnergyObservation> EnergyObservations);
 
 public record InitializeEnergyObservation(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Grid operators (DDM), should be able to send metered data for a measurement point to EDI in the Ebix format, as described in the referenced task. Below is a list of the excepted PRs needed to prepare IncomingMessageClient to handle this new message

Previous PRs:
- [x] (IncomingMessageClient) Introduce a new incoming message type to represent the "metered data for a measurement point" message
- [x] (IncomingMessageClient) Implement MeteredDateForMeasurementPointEbixMessageParser
- [x] (IncomingMessageClient) Extend AuthorizeSender validator to ensure the sender role is MDR for this message type
- [x] (IncomingMessagePublisher) handle MeteredDataForMeasurementPoint 
- [x] (IncomingMessageClient) Implement an IResponseFactory to deliver an Ebix parsing error response.
- [x] Updating sync validation rules to validate this message type.
- [x] Extend ProcessClient to skip ProcessTypes of InitializeMeteredDataForMeasurementPointMessageProcessDto type

This PR contains:
- [ ] handling delegation for message type 

Following PRs: 
- [ ] (IncomingMessageClient) Skip archiving message with inc doc type MeteredDataForMeasurementPoint
- [ ] Sync success response should contain message id for ebix

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/11595028032
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/351