### PR TITLE
feat: stub impl of InitializeMeteredDataForMeasurementPointHandler to avoid errors

### DIFF
--- a/source/Process.Application/Extensions/DependencyInjection/ProcessExtensions.cs
+++ b/source/Process.Application/Extensions/DependencyInjection/ProcessExtensions.cs
@@ -82,6 +82,7 @@ public static class ProcessExtensions
         // ProcessInitialization handlers Configuration
         services.AddTransient<IProcessInitializationHandler, InitializeAggregatedMeasureDataHandler>();
         services.AddTransient<IProcessInitializationHandler, InitializeWholesaleServicesProcessHandler>();
+        services.AddTransient<IProcessInitializationHandler, InitializeMeteredDataForMeasurementPointHandler>();
 
         // ProcessInitializationClient Configuration
         services.AddTransient<IProcessClient, ProcessClient>();

--- a/source/Process.Application/ProcessInitializationHandlers/InitializeMeteredDataForMeasurementPointHandler.cs
+++ b/source/Process.Application/ProcessInitializationHandlers/InitializeMeteredDataForMeasurementPointHandler.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.BuildingBlocks.Interfaces;
+using Energinet.DataHub.EDI.Process.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Energinet.DataHub.EDI.Process.Application.ProcessInitializationHandlers;
+
+public class InitializeMeteredDataForMeasurementPointHandler(
+    IMediator mediator,
+    ISerializer serializer,
+    ILogger<InitializeMeteredDataForMeasurementPointHandler> logger)
+    : IProcessInitializationHandler
+{
+    private readonly IMediator _mediator = mediator;
+    private readonly ISerializer _serializer = serializer;
+    private readonly ILogger<InitializeMeteredDataForMeasurementPointHandler> _logger = logger;
+
+    public bool CanHandle(string processTypeToInitialize)
+    {
+        ArgumentNullException.ThrowIfNull(processTypeToInitialize);
+        return processTypeToInitialize.Equals(nameof(InitializeMeteredDataForMeasurementPointMessageProcessDto), StringComparison.Ordinal);
+    }
+
+    public Task ProcessAsync(byte[] processInitializationData)
+    {
+        var marketMessage = _serializer.Deserialize<InitializeAggregatedMeasureDataProcessDto>(System.Text.Encoding.UTF8.GetString(processInitializationData));
+        _logger.LogInformation("Received InitializeAggregatedMeasureDataProcess for message {MessageId}", marketMessage.MessageId);
+        // Nothing to see here yet.
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Grid operators (DDM), should be able to send metered data for a measurement point to EDI in the Ebix format, as described in the referenced task. Below is a list of the excepted PRs needed to prepare IncomingMessageClient to handle this new message

Previous PRs:
- [x] (IncomingMessageClient) Introduce a new incoming message type to represent the "metered data for a measurement point" message
- [x] (IncomingMessageClient) Implement MeteredDateForMeasurementPointEbixMessageParser
- [x] (IncomingMessageClient) Extend AuthorizeSender validator to ensure the sender role is MDR for this message type
- [x] (IncomingMessagePublisher) handle MeteredDataForMeasurementPoint 
- [x] (IncomingMessageClient) Implement an IResponseFactory to deliver an Ebix parsing error response.
- [x] Updating sync validation rules to validate this message type.

This PR contains:
- [ ] Avoid process module to throw errors when receiving an InitializeMeteredDataForMeasurementPointMessageProcessDto 

Following PRs: 
- [ ] handling delegation for message type 
- [ ] (IncomingMessageClient) Skip archiving message with inc doc type MeteredDataForMeasurementPoint

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/11590455378
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/351