### PR TITLE
fix: wrong value for business reason when archiving outgoing messages

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -38,6 +38,7 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
     with:
       download_attempt_limit: 30
+      azure_functions_core_tools_version: 4.0.5413
       # Matrix parameters
       job_name: ${{ matrix.tests_filter_expression.name }}
       tests_dll_file_path: ${{ matrix.tests_filter_expression.paths }}
@@ -160,6 +161,7 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v14
     with:
       download_attempt_limit: 20
+      azure_functions_core_tools_version: 4.0.5413
       azure_integrationtest_tenant_id: ${{ vars.integration_test_azure_tenant_id }}
       azure_integrationtest_subscription_id: ${{ vars.integration_test_azure_subscription_id }}
       azure_integrationtest_spn_id: ${{ vars.integration_test_azure_spn_id_oidc }}

--- a/source/OutgoingMessages.Application/UseCases/PeekMessage.cs
+++ b/source/OutgoingMessages.Application/UseCases/PeekMessage.cs
@@ -16,6 +16,7 @@ using Energinet.DataHub.EDI.ArchivedMessages.Interfaces;
 using Energinet.DataHub.EDI.ArchivedMessages.Interfaces.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Authentication;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.OutgoingMessages.Application.Mapping;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.DocumentWriters;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models;

--- a/source/OutgoingMessages.Application/UseCases/PeekMessage.cs
+++ b/source/OutgoingMessages.Application/UseCases/PeekMessage.cs
@@ -129,7 +129,7 @@ public class PeekMessage
             authenticatedActor.ActorNumber,
             authenticatedActor.ActorRole,
             timestamp,
-            outgoingMessageBundle.BusinessReason,
+            BusinessReason.FromName(outgoingMessageBundle.BusinessReason).Code,
             ArchivedMessageTypeDto.OutgoingMessage,
             marketDocumentStream,
             outgoingMessageBundle.RelatedToMessageId);

--- a/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenAPeekIsRequestedTests.cs
+++ b/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenAPeekIsRequestedTests.cs
@@ -300,7 +300,7 @@ public class WhenAPeekIsRequestedTests : OutgoingMessagesTestBase
         var expectedFileStorageReference = $"{receiver.ReceiverNumber.Value}/{year:0000}/{month:00}/{day:00}/{archivedMessage!.Id:N}";
         var assertProperties = new Dictionary<string, Action<object?>>
         {
-            { "BusinessReason", businessReason => businessReason.Should().Be(outgoingMessage.BusinessReason) },
+            { "BusinessReason", businessReason => businessReason.Should().Be(BusinessReason.FromName(outgoingMessage.BusinessReason).Code) },
             { "CreatedAt", createdAt => createdAt.Should().Be(expectedTimestamp) },
             { "DocumentType", documentType => documentType.Should().Be(outgoingMessage.DocumentType.Name) },
             { "EventIds", eventIds => eventIds.Should().Be(expectedEventId.Value) },


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

When archiving outgoing messages, We store the business reason name instead of the code. 

Therefore, when searching for archived messages the business reason filter can't find any outgoing messages. 

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/12083191208
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/360