### PR TITLE
refac: move incoming message validation requirement into domain models

### DIFF
--- a/source/BuildingBlocks.Domain/Models/MessageType.cs
+++ b/source/BuildingBlocks.Domain/Models/MessageType.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text.Json.Serialization;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+
+namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+
+/// <summary>
+/// Represent the Message Type
+/// Mapping of the Message Type code to the Message Type name is comming from this section "Datadefinitioner for DocumentNameCodeType" document:
+/// https://energinet.dk/media/4v0nfpec/edi-transaktioner-for-det-danske-elmarked.pdf
+/// </summary>
+public sealed class MessageType : DataHubType<MessageType>
+{
+    public static readonly MessageType ValidatedMeteredData = new(nameof(ValidatedMeteredData), "E66");
+    public static readonly MessageType RequestAggregatedMeteredData = new(nameof(RequestAggregatedMeteredData), "E74");
+    public static readonly MessageType RequestForAggregatedBillingInformation = new(nameof(RequestForAggregatedBillingInformation), "D21");
+
+    [JsonConstructor]
+    private MessageType(string name, string code)
+        : base(name, code) { }
+}

--- a/source/IncomingMessages.Domain/Abstractions/IIncomingMessage.cs
+++ b/source/IncomingMessages.Domain/Abstractions/IIncomingMessage.cs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+
 namespace Energinet.DataHub.EDI.IncomingMessages.Domain.Abstractions;
 
 /// <summary>
@@ -68,4 +71,10 @@ public interface IIncomingMessage
     /// Series of the incoming message
     /// </summary>
     IReadOnlyCollection<IIncomingMessageSeries> Series { get; }
+
+    public IReadOnlyCollection<string> AllowedMessageTypes { get; }
+
+    public IReadOnlyCollection<BusinessReason> AllowedBusinessReasons { get; }
+
+    public IReadOnlyCollection<ActorRole> AllowedSenderRoles { get; }
 }

--- a/source/IncomingMessages.Domain/Abstractions/IIncomingMessage.cs
+++ b/source/IncomingMessages.Domain/Abstractions/IIncomingMessage.cs
@@ -72,7 +72,7 @@ public interface IIncomingMessage
     /// </summary>
     IReadOnlyCollection<IIncomingMessageSeries> Series { get; }
 
-    public IReadOnlyCollection<string> AllowedMessageTypes { get; }
+    public IReadOnlyCollection<MessageType> AllowedMessageTypes { get; }
 
     public IReadOnlyCollection<BusinessReason> AllowedBusinessReasons { get; }
 

--- a/source/IncomingMessages.Domain/MessageParsers/RSM012/MeteredDateForMeasurementPointEbixMessageParser.cs
+++ b/source/IncomingMessages.Domain/MessageParsers/RSM012/MeteredDateForMeasurementPointEbixMessageParser.cs
@@ -87,7 +87,7 @@ public class MeteredDateForMeasurementPointEbixMessageParser(EbixSchemaProvider 
 
     protected override IncomingMarketMessageParserResult CreateResult(MessageHeader header, IReadOnlyCollection<IIncomingMessageSeries> transactions)
     {
-        return new IncomingMarketMessageParserResult(new MeteredDataForMeasurementPointMessage(
+        return new IncomingMarketMessageParserResult(new MeteredDataForMeasurementPointMessageBase(
             header.MessageId,
             header.MessageType,
             header.CreatedAt,

--- a/source/IncomingMessages.Domain/MessageParsers/RSM012/MeteredDateForMeasurementPointJsonMessageParser.cs
+++ b/source/IncomingMessages.Domain/MessageParsers/RSM012/MeteredDateForMeasurementPointJsonMessageParser.cs
@@ -96,7 +96,7 @@ public class MeteredDateForMeasurementPointJsonMessageParser(JsonSchemaProvider 
 
     protected override IncomingMarketMessageParserResult CreateResult(MessageHeader header, IReadOnlyCollection<IIncomingMessageSeries> transactions)
     {
-        return new IncomingMarketMessageParserResult(new MeteredDataForMeasurementPointMessage(
+        return new IncomingMarketMessageParserResult(new MeteredDataForMeasurementPointMessageBase(
             header.MessageId,
             header.MessageType,
             header.CreatedAt,

--- a/source/IncomingMessages.Domain/MessageParsers/RSM012/MeteredDateForMeasurementPointXmlMessageParser.cs
+++ b/source/IncomingMessages.Domain/MessageParsers/RSM012/MeteredDateForMeasurementPointXmlMessageParser.cs
@@ -95,7 +95,7 @@ public class MeteredDateForMeasurementPointXmlMessageParser(CimXmlSchemaProvider
         IReadOnlyCollection<IIncomingMessageSeries> transactions)
     {
         return new IncomingMarketMessageParserResult(
-            new MeteredDataForMeasurementPointMessage(
+            new MeteredDataForMeasurementPointMessageBase(
                 header.MessageId,
                 header.MessageType,
                 header.CreatedAt,

--- a/source/IncomingMessages.Domain/MeteredDataForMeasurementPointMessage.cs
+++ b/source/IncomingMessages.Domain/MeteredDataForMeasurementPointMessage.cs
@@ -21,17 +21,44 @@ namespace Energinet.DataHub.EDI.IncomingMessages.Domain;
 /// <summary>
 /// Represents the message for metered data for measurement point known as RSM-012.
 /// </summary>
-public record MeteredDataForMeasurementPointMessage(
-    string MessageId,
-    string MessageType,
-    string CreatedAt,
-    string SenderNumber,
-    string ReceiverNumber,
-    string SenderRoleCode,
-    string BusinessReason,
-    string ReceiverRoleCode,
-    string? BusinessType,
-    IReadOnlyCollection<IIncomingMessageSeries> Series) : IIncomingMessage;
+public class MeteredDataForMeasurementPointMessageBase(
+    string messageId,
+    string messageType,
+    string createdAt,
+    string senderNumber,
+    string receiverNumber,
+    string senderRoleCode,
+    string businessReason,
+    string receiverRoleCode,
+    string? businessType,
+    IReadOnlyCollection<IIncomingMessageSeries> series) : IIncomingMessage
+{
+    public string MessageId { get; } = messageId;
+
+    public string ReceiverNumber { get; } = receiverNumber;
+
+    public string ReceiverRoleCode { get; } = receiverRoleCode;
+
+    public string SenderNumber { get; } = senderNumber;
+
+    public string SenderRoleCode { get; } = senderRoleCode;
+
+    public string BusinessReason { get; } = businessReason;
+
+    public string MessageType { get; } = messageType;
+
+    public string CreatedAt { get; } = createdAt;
+
+    public string? BusinessType { get; } = businessType;
+
+    public IReadOnlyCollection<IIncomingMessageSeries> Series { get; } = series;
+
+    public IReadOnlyCollection<string> AllowedMessageTypes => ["E66"];
+
+    public IReadOnlyCollection<BusinessReason> AllowedBusinessReasons => [Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.BusinessReason.PeriodicMetering];
+
+    public IReadOnlyCollection<ActorRole> AllowedSenderRoles => [ActorRole.MeteredDataResponsible];
+}
 
 public record MeteredDataForMeasurementPointSeries(
     string TransactionId,

--- a/source/IncomingMessages.Domain/MeteredDataForMeasurementPointMessage.cs
+++ b/source/IncomingMessages.Domain/MeteredDataForMeasurementPointMessage.cs
@@ -53,11 +53,17 @@ public class MeteredDataForMeasurementPointMessageBase(
 
     public IReadOnlyCollection<IIncomingMessageSeries> Series { get; } = series;
 
-    public IReadOnlyCollection<string> AllowedMessageTypes => ["E66"];
+    public IReadOnlyCollection<MessageType> AllowedMessageTypes => [
+        Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.MessageType.ValidatedMeteredData,
+    ];
 
-    public IReadOnlyCollection<BusinessReason> AllowedBusinessReasons => [Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.BusinessReason.PeriodicMetering];
+    public IReadOnlyCollection<BusinessReason> AllowedBusinessReasons => [
+        Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.BusinessReason.PeriodicMetering,
+    ];
 
-    public IReadOnlyCollection<ActorRole> AllowedSenderRoles => [ActorRole.MeteredDataResponsible];
+    public IReadOnlyCollection<ActorRole> AllowedSenderRoles => [
+        ActorRole.MeteredDataResponsible,
+    ];
 }
 
 public record MeteredDataForMeasurementPointSeries(

--- a/source/IncomingMessages.Domain/RequestAggregatedMeasureDataMessage.cs
+++ b/source/IncomingMessages.Domain/RequestAggregatedMeasureDataMessage.cs
@@ -30,7 +30,9 @@ public record RequestAggregatedMeasureDataMessage(
     string? BusinessType,
     IReadOnlyCollection<IIncomingMessageSeries> Series) : IIncomingMessage
 {
-    public IReadOnlyCollection<string> AllowedMessageTypes => ["E74"];
+    public IReadOnlyCollection<MessageType> AllowedMessageTypes => [
+        Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.MessageType.RequestAggregatedMeteredData,
+    ];
 
     public IReadOnlyCollection<BusinessReason> AllowedBusinessReasons =>
     [

--- a/source/IncomingMessages.Domain/RequestAggregatedMeasureDataMessage.cs
+++ b/source/IncomingMessages.Domain/RequestAggregatedMeasureDataMessage.cs
@@ -28,7 +28,24 @@ public record RequestAggregatedMeasureDataMessage(
     string MessageId,
     string CreatedAt,
     string? BusinessType,
-    IReadOnlyCollection<IIncomingMessageSeries> Series) : IIncomingMessage;
+    IReadOnlyCollection<IIncomingMessageSeries> Series) : IIncomingMessage
+{
+    public IReadOnlyCollection<string> AllowedMessageTypes => ["E74"];
+
+    public IReadOnlyCollection<BusinessReason> AllowedBusinessReasons =>
+    [
+        Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.BusinessReason.PreliminaryAggregation,
+        Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.BusinessReason.BalanceFixing,
+        Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.BusinessReason.WholesaleFixing,
+        Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.BusinessReason.Correction,
+    ];
+
+    public IReadOnlyCollection<ActorRole> AllowedSenderRoles => [
+        ActorRole.EnergySupplier,
+        ActorRole.MeteredDataResponsible,
+        ActorRole.BalanceResponsibleParty,
+    ];
+}
 
 public record RequestAggregatedMeasureDataMessageSeries(
     string TransactionId,

--- a/source/IncomingMessages.Domain/RequestWholesaleServicesMessage.cs
+++ b/source/IncomingMessages.Domain/RequestWholesaleServicesMessage.cs
@@ -30,7 +30,9 @@ public record RequestWholesaleServicesMessage(
     string? BusinessType,
     IReadOnlyCollection<IIncomingMessageSeries> Series) : IIncomingMessage
 {
-    public IReadOnlyCollection<string> AllowedMessageTypes => ["D21"];
+    public IReadOnlyCollection<MessageType> AllowedMessageTypes => [
+        Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.MessageType.RequestForAggregatedBillingInformation,
+    ];
 
     public IReadOnlyCollection<BusinessReason> AllowedBusinessReasons =>
     [

--- a/source/IncomingMessages.Domain/RequestWholesaleServicesMessage.cs
+++ b/source/IncomingMessages.Domain/RequestWholesaleServicesMessage.cs
@@ -28,7 +28,22 @@ public record RequestWholesaleServicesMessage(
     string MessageId,
     string CreatedAt,
     string? BusinessType,
-    IReadOnlyCollection<IIncomingMessageSeries> Series) : IIncomingMessage;
+    IReadOnlyCollection<IIncomingMessageSeries> Series) : IIncomingMessage
+{
+    public IReadOnlyCollection<string> AllowedMessageTypes => ["D21"];
+
+    public IReadOnlyCollection<BusinessReason> AllowedBusinessReasons =>
+    [
+        Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.BusinessReason.WholesaleFixing,
+        Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.BusinessReason.Correction,
+    ];
+
+    public IReadOnlyCollection<ActorRole> AllowedSenderRoles => [
+        ActorRole.EnergySupplier,
+        ActorRole.GridAccessProvider,
+        ActorRole.SystemOperator,
+    ];
+}
 
 public record RequestWholesaleServicesSeries(
     string TransactionId,

--- a/source/IncomingMessages.Domain/Validation/MessageTypeValidator.cs
+++ b/source/IncomingMessages.Domain/Validation/MessageTypeValidator.cs
@@ -19,32 +19,12 @@ namespace Energinet.DataHub.EDI.IncomingMessages.Domain.Validation;
 
 public class MessageTypeValidator : IMessageTypeValidator
 {
-    private static readonly IReadOnlyCollection<string> _aggregatedMeasureDataWhiteList = new[] { "E74" };
-    private static readonly IReadOnlyCollection<string> _wholesaleServicesWhiteList = new[] { "D21" };
-    private static readonly IReadOnlyCollection<string> _meteredDataForMeasurementPointWhiteList = new[] { "E66" };
-
-    public async Task<Result> ValidateAsync(IIncomingMessage message, CancellationToken cancellationToken)
+    public Task<Result> ValidateAsync(IIncomingMessage message, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        return await Task.FromResult(
-                message switch
-                {
-                    RequestAggregatedMeasureDataMessage ramdm =>
-                        _aggregatedMeasureDataWhiteList.Contains(ramdm.MessageType)
-                            ? Result.Succeeded()
-                            : Result.Failure(
-                                new NotSupportedMessageType(ramdm.MessageType)),
-                    RequestWholesaleServicesMessage rwsm =>
-                        _wholesaleServicesWhiteList.Contains(rwsm.MessageType)
-                            ? Result.Succeeded()
-                            : Result.Failure(new NotSupportedMessageType(rwsm.MessageType)),
-                    MeteredDataForMeasurementPointMessage mdfmpm =>
-                        _meteredDataForMeasurementPointWhiteList.Contains(mdfmpm.MessageType)
-                            ? Result.Succeeded()
-                            : Result.Failure(new NotSupportedMessageType(mdfmpm.MessageType)),
-                    _ => throw new InvalidOperationException($"The baw's on the slates! {message.GetType().Name}"),
-                })
-            .ConfigureAwait(false);
+        return Task.FromResult(message.AllowedMessageTypes.Contains(message.MessageType)
+            ? Result.Succeeded()
+            : Result.Failure(new NotSupportedMessageType(message.MessageType)));
     }
 }

--- a/source/IncomingMessages.Domain/Validation/MessageTypeValidator.cs
+++ b/source/IncomingMessages.Domain/Validation/MessageTypeValidator.cs
@@ -23,7 +23,7 @@ public class MessageTypeValidator : IMessageTypeValidator
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        return Task.FromResult(message.AllowedMessageTypes.Contains(message.MessageType)
+        return Task.FromResult(message.AllowedMessageTypes.Select(x => x.Code).Contains(message.MessageType)
             ? Result.Succeeded()
             : Result.Failure(new NotSupportedMessageType(message.MessageType)));
     }

--- a/source/IncomingMessages.Domain/Validation/SenderAuthorizer.cs
+++ b/source/IncomingMessages.Domain/Validation/SenderAuthorizer.cs
@@ -68,10 +68,12 @@ public class SenderAuthorizer(AuthenticatedActor actorAuthenticator) : ISenderAu
             return;
         }
 
-        if (message.AllowedSenderRoles.Contains(ActorRole.FromCode(message.SenderRoleCode)) == false)
+        if (message.AllowedSenderRoles.Contains(ActorRole.FromCode(message.SenderRoleCode)))
         {
-            _validationErrors.Add(new SenderRoleTypeIsNotAuthorized());
+            return;
         }
+
+        _validationErrors.Add(new SenderRoleTypeIsNotAuthorized());
     }
 
     private bool AllSeriesAreDelegatedToSender(bool allSeriesAreDelegated)

--- a/source/IncomingMessages.Domain/Validation/SenderAuthorizer.cs
+++ b/source/IncomingMessages.Domain/Validation/SenderAuthorizer.cs
@@ -20,15 +20,9 @@ using Energinet.DataHub.EDI.IncomingMessages.Domain.Validation.ValidationErrors;
 
 namespace Energinet.DataHub.EDI.IncomingMessages.Domain.Validation;
 
-public class SenderAuthorizer : ISenderAuthorizer
+public class SenderAuthorizer(AuthenticatedActor actorAuthenticator) : ISenderAuthorizer
 {
-    private readonly AuthenticatedActor _actorAuthenticator;
     private readonly List<ValidationError> _validationErrors = new();
-
-    public SenderAuthorizer(AuthenticatedActor actorAuthenticator)
-    {
-        _actorAuthenticator = actorAuthenticator;
-    }
 
     public Task<Result> AuthorizeAsync(IIncomingMessage message, bool allSeriesAreDelegated)
     {
@@ -57,7 +51,7 @@ public class SenderAuthorizer : ISenderAuthorizer
         if (AllSeriesAreDelegatedToSender(allSeriesAreDelegated))
             return;
 
-        if (!_actorAuthenticator.CurrentActorIdentity.HasRole(ActorRole.FromCode(senderRole)))
+        if (!actorAuthenticator.CurrentActorIdentity.HasRole(ActorRole.FromCode(senderRole)))
         {
             _validationErrors.Add(new AuthenticatedUserDoesNotHoldRequiredRoleType());
         }
@@ -68,59 +62,26 @@ public class SenderAuthorizer : ISenderAuthorizer
         if (AllSeriesAreDelegatedToSender(allSeriesAreDelegated))
             return;
 
-        switch (message)
+        if (message is RequestAggregatedMeasureDataMessage
+            && !HackThatAllowDdmToDoRequestsAsMdr(message.SenderRoleCode))
         {
-            case RequestAggregatedMeasureDataMessage ramdm:
-                switch (ramdm.SenderRoleCode)
-                {
-                    case var sc1 when sc1.Equals(ActorRole.EnergySupplier.Code, StringComparison.OrdinalIgnoreCase):
-                    case var sc2 when sc2.Equals(ActorRole.MeteredDataResponsible.Code, StringComparison.OrdinalIgnoreCase):
-                    case var sc3 when sc3.Equals(ActorRole.BalanceResponsibleParty.Code, StringComparison.OrdinalIgnoreCase):
-                    case var sc4 when !HackThatAllowDdmToDoRequestsAsMdr(sc4):
-                        break;
-                    default:
-                        _validationErrors.Add(new SenderRoleTypeIsNotAuthorized());
-                        break;
-                }
+            return;
+        }
 
-                break;
-            case RequestWholesaleServicesMessage rwsm:
-                switch (rwsm.SenderRoleCode)
-                {
-                    case var sc1 when sc1.Equals(ActorRole.EnergySupplier.Code, StringComparison.OrdinalIgnoreCase):
-                    case var sc2 when sc2.Equals(ActorRole.GridAccessProvider.Code, StringComparison.OrdinalIgnoreCase):
-                    case var sc3 when sc3.Equals(ActorRole.SystemOperator.Code, StringComparison.OrdinalIgnoreCase):
-                        break;
-                    default:
-                        _validationErrors.Add(new SenderRoleTypeIsNotAuthorized());
-                        break;
-                }
-
-                break;
-            case MeteredDataForMeasurementPointMessage mdfmpm:
-                switch (mdfmpm.SenderRoleCode)
-                {
-                    case var sc1 when sc1.Equals(ActorRole.MeteredDataResponsible.Code, StringComparison.OrdinalIgnoreCase):
-                        break;
-                    default:
-                        _validationErrors.Add(new SenderRoleTypeIsNotAuthorized());
-                        break;
-                }
-
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(message));
+        if (message.AllowedSenderRoles.Contains(ActorRole.FromCode(message.SenderRoleCode)) == false)
+        {
+            _validationErrors.Add(new SenderRoleTypeIsNotAuthorized());
         }
     }
 
     private bool AllSeriesAreDelegatedToSender(bool allSeriesAreDelegated)
     {
-        return allSeriesAreDelegated && _actorAuthenticator.CurrentActorIdentity.HasAnyOfRoles(ActorRole.Delegated, ActorRole.GridAccessProvider);
+        return allSeriesAreDelegated && actorAuthenticator.CurrentActorIdentity.HasAnyOfRoles(ActorRole.Delegated, ActorRole.GridAccessProvider);
     }
 
     private void EnsureSenderIdMatches(string senderNumber)
     {
-        if (_actorAuthenticator.CurrentActorIdentity.ActorNumber.Value.Equals(
+        if (actorAuthenticator.CurrentActorIdentity.ActorNumber.Value.Equals(
                 senderNumber,
                 StringComparison.OrdinalIgnoreCase) == false)
         {
@@ -132,6 +93,6 @@ public class SenderAuthorizer : ISenderAuthorizer
     {
         return WorkaroundFlags.MeteredDataResponsibleToGridOperatorHack
                && senderRole == ActorRole.MeteredDataResponsible.Code
-               && _actorAuthenticator.CurrentActorIdentity.HasRole(ActorRole.GridAccessProvider);
+               && actorAuthenticator.CurrentActorIdentity.HasRole(ActorRole.GridAccessProvider);
     }
 }

--- a/source/IncomingMessages.Infrastructure/Factories/InitializeMeteredDataForMeasurementPointProcessDtoFactory.cs
+++ b/source/IncomingMessages.Infrastructure/Factories/InitializeMeteredDataForMeasurementPointProcessDtoFactory.cs
@@ -20,11 +20,11 @@ namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Factories;
 
 public static class InitializeMeteredDataForMeasurementPointProcessDtoFactory
 {
-    public static InitializeMeteredDataForMeasurementPointMessageProcessDto Create(MeteredDataForMeasurementPointMessage meteredDataForMeasurementPointMessage, AuthenticatedActor authenticatedActor)
+    public static InitializeMeteredDataForMeasurementPointMessageProcessDto Create(MeteredDataForMeasurementPointMessageBase meteredDataForMeasurementPointMessageBase, AuthenticatedActor authenticatedActor)
     {
-        ArgumentNullException.ThrowIfNull(meteredDataForMeasurementPointMessage);
+        ArgumentNullException.ThrowIfNull(meteredDataForMeasurementPointMessageBase);
 
-        var series = meteredDataForMeasurementPointMessage.Series
+        var series = meteredDataForMeasurementPointMessageBase.Series
             .Cast<MeteredDataForMeasurementPointSeries>()
             .Select(
                 series =>
@@ -54,11 +54,11 @@ public static class InitializeMeteredDataForMeasurementPointProcessDtoFactory
             .ToList().AsReadOnly();
 
         return new InitializeMeteredDataForMeasurementPointMessageProcessDto(
-            meteredDataForMeasurementPointMessage.MessageId,
-            meteredDataForMeasurementPointMessage.MessageType,
-            meteredDataForMeasurementPointMessage.CreatedAt,
-            meteredDataForMeasurementPointMessage.BusinessReason,
-            meteredDataForMeasurementPointMessage.BusinessType,
+            meteredDataForMeasurementPointMessageBase.MessageId,
+            meteredDataForMeasurementPointMessageBase.MessageType,
+            meteredDataForMeasurementPointMessageBase.CreatedAt,
+            meteredDataForMeasurementPointMessageBase.BusinessReason,
+            meteredDataForMeasurementPointMessageBase.BusinessType,
             series);
     }
 }

--- a/source/IncomingMessages.Infrastructure/IncomingMessagePublisher.cs
+++ b/source/IncomingMessages.Infrastructure/IncomingMessagePublisher.cs
@@ -58,7 +58,7 @@ public class IncomingMessagePublisher
             case RequestWholesaleServicesMessage wholesaleSettlementMessage:
                 await SendInitializeWholesaleServicesProcessAsync(InitializeWholesaleServicesProcessDtoFactory.Create(wholesaleSettlementMessage), cancellationToken).ConfigureAwait(false);
                 break;
-            case MeteredDataForMeasurementPointMessage meteredDataForMeasurementPointMessage:
+            case MeteredDataForMeasurementPointMessageBase meteredDataForMeasurementPointMessage:
                 await SendInitializeMeteredDataForMeasurementPointMessageProcessAsync(InitializeMeteredDataForMeasurementPointProcessDtoFactory.Create(meteredDataForMeasurementPointMessage, _authenticatedActor), cancellationToken).ConfigureAwait(false);
                 break;
             default:

--- a/source/IncomingMessages.IntegrationTests/IncomingMessages/GivenIncomingMeteredDataForMeasurementMessageTests.cs
+++ b/source/IncomingMessages.IntegrationTests/IncomingMessages/GivenIncomingMeteredDataForMeasurementMessageTests.cs
@@ -604,7 +604,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
         messageParser.ParserResult.Success.Should().BeFalse();
     }
 
-    private async Task<(MeteredDataForMeasurementPointMessage? IncomingMessage, IncomingMarketMessageParserResult ParserResult)> ParseMessageAsync(
+    private async Task<(MeteredDataForMeasurementPointMessageBase? IncomingMessage, IncomingMarketMessageParserResult ParserResult)> ParseMessageAsync(
         Stream message,
         DocumentFormat documentFormat)
     {
@@ -612,7 +612,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
         if (_messageParsers.TryGetValue((IncomingDocumentType.MeteredDataForMeasurementPoint, documentFormat), out var messageParser))
         {
             var result = await messageParser.ParseAsync(incomingMarketMessageStream, CancellationToken.None).ConfigureAwait(false);
-            return (IncomingMessage: (MeteredDataForMeasurementPointMessage?)result.IncomingMessage, ParserResult: result);
+            return (IncomingMessage: (MeteredDataForMeasurementPointMessageBase?)result.IncomingMessage, ParserResult: result);
         }
 
         throw new NotSupportedException($"No message parser found for message format '{documentFormat}' and document type '{IncomingDocumentType.MeteredDataForMeasurementPoint}'");

--- a/source/Tests/CimMessageAdapter/Messages/MeteredDataForMeasurementPointMessageParserTests/MessageParserTests.cs
+++ b/source/Tests/CimMessageAdapter/Messages/MeteredDataForMeasurementPointMessageParserTests/MessageParserTests.cs
@@ -84,7 +84,7 @@ public sealed class MessageParserTests
         using var assertionScope = new AssertionScope();
         result.Success.Should().BeTrue();
 
-        var marketMessage = (MeteredDataForMeasurementPointMessage)result.IncomingMessage!;
+        var marketMessage = (MeteredDataForMeasurementPointMessageBase)result.IncomingMessage!;
         marketMessage.Should().NotBeNull();
         marketMessage.MessageId.Should().Be("111131835");
         marketMessage.MessageType.Should().Be("E66");

--- a/source/Tests/Infrastructure/IncomingMessages/SenderAuthorizerTests.cs
+++ b/source/Tests/Infrastructure/IncomingMessages/SenderAuthorizerTests.cs
@@ -93,7 +93,7 @@ public class SenderAuthorizerTests
             senderRole);
         var sut = CreateSut(authenticatedActor);
 
-        var incomingMessage = new MeteredDataForMeasurementPointMessage(
+        var incomingMessage = new MeteredDataForMeasurementPointMessageBase(
             "MessageId",
             "MessageType",
             "CreatedAt",
@@ -120,7 +120,7 @@ public class SenderAuthorizerTests
             senderRole);
         var sut = CreateSut(authenticatedActor);
 
-        var incomingMessage = new MeteredDataForMeasurementPointMessage(
+        var incomingMessage = new MeteredDataForMeasurementPointMessageBase(
             "MessageId",
             "MessageType",
             "CreatedAt",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

I refactored the IIncomingMessage interface to include properties for specifying allowed values for business validation in the sync flow:

- IReadOnlyCollection<string> AllowedMessageTypes { get; }
- IReadOnlyCollection<BusinessReason> AllowedBusinessReasons { get; }
- IReadOnlyCollection<ActorRole> AllowedSenderRoles { get; }

With this refactoring, any new implementation of IIncomingMessage must define the allowed values for these properties. The validation framework will then automatically validate the document against these values. As a result, it is no longer necessary to extend the validation framework when introducing a new IIncomingMessage implementation.



## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/12176796485
- [x] Is there time to monitor state of the release to Production?
- [ ] Reference to the task