### PR TITLE
Only deny incoming message if it is an RSM-12

### DIFF
--- a/source/B2BApi/IncomingMessages/IncomingMessageReceiver.cs
+++ b/source/B2BApi/IncomingMessages/IncomingMessageReceiver.cs
@@ -59,7 +59,9 @@ public class IncomingMessageReceiver
         var stopwatch = Stopwatch.StartNew();
         var cancellationToken = request.GetCancellationToken(hostCancellationToken);
 
-        if (!await _featureFlagManager.ReceiveMeteredDataForMeasurementPointsAsync().ConfigureAwait(false))
+        if (incomingDocumentTypeName != null &&
+            incomingDocumentTypeName.Equals(IncomingDocumentType.NotifyValidatedMeasureData.Name, StringComparison.OrdinalIgnoreCase)
+            && !await _featureFlagManager.ReceiveMeteredDataForMeasurementPointsAsync().ConfigureAwait(false))
         {
             /*
              * The HTTP 403 Forbidden client error response status code indicates that the server understood the request


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Fix RSM-012 feature flag to only disallow RSM-012 documents 

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task