### PR TITLE
fix: Read Point from Period and not Series elements

### DIFF
--- a/source/IncomingMessages.Domain/MessageParsers/RSM012/MeteredDateForMeasurementPointJsonMessageParser.cs
+++ b/source/IncomingMessages.Domain/MessageParsers/RSM012/MeteredDateForMeasurementPointJsonMessageParser.cs
@@ -52,31 +52,48 @@ public class MeteredDateForMeasurementPointJsonMessageParser(JsonSchemaProvider 
         var meteringPointLocationId = transactionElement.GetProperty(MeteringPointIdentificationElementName)
             .GetProperty(ValueElementName)
             .ToString();
+
         var meteringPointType =
             transactionElement.GetProperty(MeteringPointTypeElementName).GetProperty(ValueElementName).ToString();
+
         var registrationDateAndOrTime =
             transactionElement.GetProperty(RegistrationDateAndOrTimeElementName).ToString();
+
         var productNumber =
             transactionElement.GetProperty(ProductNumberElementName).ToString();
+
         var productUnitType =
             transactionElement.GetProperty(ProductUnitTypeElementName).GetProperty(ValueElementName).ToString();
+
         var periodElement = transactionElement.GetProperty(PeriodElementName);
         var resolution = periodElement.GetProperty(ResolutionElementName).ToString();
         var startDateAndOrTimeDateTime = periodElement.GetProperty(TimeIntervalElementName).GetProperty(StartElementName).GetProperty(ValueElementName).ToString();
         var endDateAndOrTimeDateTime = periodElement.GetProperty(TimeIntervalElementName).GetProperty(EndElementName).GetProperty(ValueElementName).ToString();
 
         var energyObservations = new List<EnergyObservation>();
-        JsonElement? pointsElements = transactionElement.TryGetProperty(PointElementName, out var pointsElement)
+        JsonElement? pointsElements = periodElement.TryGetProperty(PointElementName, out var pointsElement)
             ? pointsElement
             : null;
+
         if (pointsElements != null)
         {
             foreach (var pointElement in pointsElements.Value.EnumerateArray())
             {
-                energyObservations.Add(new EnergyObservation(
-                    pointElement.GetProperty(PositionElementName).GetProperty(ValueElementName).ToString(),
-                    pointElement.GetProperty(QualityElementName).GetProperty(ValueElementName).ToString(),
-                    pointElement.GetProperty(QuantityElementName).ToString()));
+                var position = pointElement.GetProperty(PositionElementName).GetProperty(ValueElementName).ToString();
+                string? quality = null;
+                string? quantity = null;
+
+                if (pointElement.TryGetProperty(QualityElementName, out var qualityElement))
+                {
+                    quality = qualityElement.GetProperty(ValueElementName).ToString();
+                }
+
+                if (pointElement.TryGetProperty(QuantityElementName, out var quantityElement))
+                {
+                    quantity = quantityElement.ToString();
+                }
+
+                energyObservations.Add(new EnergyObservation(position, quantity, quality));
             }
         }
 

--- a/source/IncomingMessages.IntegrationTests/Builders/MeteredDataForMeasurementPointBuilder.cs
+++ b/source/IncomingMessages.IntegrationTests/Builders/MeteredDataForMeasurementPointBuilder.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using System.Xml;
@@ -73,7 +72,8 @@ public static class MeteredDataForMeasurementPointBuilder
                 businessType,
                 messageId,
                 senderRole,
-                receiverNumber);
+                receiverNumber,
+                schema ?? "NotifyValidatedMeasureData_MarketDocument");
         }
         else
         {
@@ -200,10 +200,11 @@ public static class MeteredDataForMeasurementPointBuilder
         string businessType,
         string messageId,
         string senderRole,
-        string receiverNumber) =>
+        string receiverNumber,
+        string schema) =>
         $$"""
           {
-            "NotifyValidatedMeasureData_MarketDocument": {
+            "{{schema}}": {
               "mRID": "{{messageId}}",
               "businessSector.type": {
                 "value": "{{businessType}}"

--- a/source/IncomingMessages.IntegrationTests/Builders/MeteredDataForMeasurementPointBuilder.cs
+++ b/source/IncomingMessages.IntegrationTests/Builders/MeteredDataForMeasurementPointBuilder.cs
@@ -246,7 +246,7 @@ public static class MeteredDataForMeasurementPointBuilder
                       {
                         "mRID": "{{s.TransactionId}}",
                         "marketEvaluationPoint.mRID": {
-                        "codingScheme": "A10",
+                          "codingScheme": "A10",
                           "value": "579999993331812345"
                         },
                         "marketEvaluationPoint.type": {

--- a/source/IncomingMessages.IntegrationTests/Builders/MeteredDataForMeasurementPointBuilder.cs
+++ b/source/IncomingMessages.IntegrationTests/Builders/MeteredDataForMeasurementPointBuilder.cs
@@ -136,13 +136,7 @@ public static class MeteredDataForMeasurementPointBuilder
             <ns0:MeteringPointDomainLocation>
                 <ns0:Identification schemeAgencyIdentifier=""9"">571313000000002000</ns0:Identification>
             </ns0:MeteringPointDomainLocation>
-        {string.Join("\n", GetEnergyObservations().Select(e => $@"
-            <ns0:IntervalEnergyObservation>
-                <ns0:Position>{e.Position}</ns0:Position>
-                <ns0:EnergyQuantity>{e.Quantity}</ns0:EnergyQuantity>
-                <ns0:QuantityQuality listAgencyIdentifier=""260"">E01</ns0:QuantityQuality>
-            </ns0:IntervalEnergyObservation>
-        "))}
+        {EnergyObservationEbixBuilder(GetEnergyObservations())}
     </ns0:PayloadEnergyTimeSeries>
     "))}
 </ns0:DK_MeteredDataTimeSeries>");
@@ -336,6 +330,40 @@ public static class MeteredDataForMeasurementPointBuilder
                     }
 
                     builder.AppendLine("</cim:Point>");
+
+                    return builder.ToString();
+                }));
+    }
+
+    private static string EnergyObservationEbixBuilder(
+        IReadOnlyCollection<(int Position, string? Quality, decimal? Quantity)> observations)
+    {
+        return string.Join(
+            "\n",
+            observations.Select(
+                e =>
+                {
+                    var builder = new StringBuilder();
+                    builder.AppendLine("<ns0:IntervalEnergyObservation>");
+                    builder.AppendLine($"<ns0:Position>{e.Position}</ns0:Position>");
+
+                    if (e.Quantity.HasValue)
+                    {
+                        builder.AppendLine(
+                            $"<ns0:EnergyQuantity>{e.Quantity.Value.ToString(CultureInfo.InvariantCulture)}</ns0:EnergyQuantity>");
+                    }
+                    else
+                    {
+                        builder.AppendLine("<ns0:QuantityMissing>true</ns0:QuantityMissing>");
+                    }
+
+                    if (e.Quality != null)
+                    {
+                        builder.AppendLine(
+                            "<ns0:QuantityQuality listAgencyIdentifier=\"260\">E01</ns0:QuantityQuality>");
+                    }
+
+                    builder.AppendLine("</ns0:IntervalEnergyObservation>");
 
                     return builder.ToString();
                 }));

--- a/source/IncomingMessages.IntegrationTests/Builders/MeteredDataForMeasurementPointBuilder.cs
+++ b/source/IncomingMessages.IntegrationTests/Builders/MeteredDataForMeasurementPointBuilder.cs
@@ -22,10 +22,6 @@ using NodaTime;
 
 namespace Energinet.DataHub.EDI.IncomingMessages.IntegrationTests.Builders;
 
-[SuppressMessage(
-    "StyleCop.CSharp.MaintainabilityRules",
-    "SA1407:Arithmetic expressions should declare precedence",
-    Justification = "Conflicting with another rule")]
 public static class MeteredDataForMeasurementPointBuilder
 {
     public static IncomingMarketMessageStream CreateIncomingMessage(

--- a/source/IncomingMessages.IntegrationTests/Builders/MeteredDataForMeasurementPointBuilder.cs
+++ b/source/IncomingMessages.IntegrationTests/Builders/MeteredDataForMeasurementPointBuilder.cs
@@ -315,12 +315,6 @@ public static class MeteredDataForMeasurementPointBuilder
     private static string EnergyObservationXmlBuilder(
         IReadOnlyCollection<(int Position, string? Quality, decimal? Quantity)> observations)
     {
-        // <cim:Point>
-        // <cim:position>{e.Position}</cim:position>
-        // <cim:quantity>{e.Quantity}</cim:quantity>
-        // <cim:quality>A03</cim:quality>
-        // </cim:Point>
-
         return string.Join(
             "\n",
             observations.Select(

--- a/source/IncomingMessages.IntegrationTests/IncomingMessages/GivenIncomingMeteredDataForMeasurementMessageTests.cs
+++ b/source/IncomingMessages.IntegrationTests/IncomingMessages/GivenIncomingMeteredDataForMeasurementMessageTests.cs
@@ -59,7 +59,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     public async Task When_ReceiverIdIsDatahub_Then_ValidationSucceed()
     {
         var validDataHubReceiverId = "5790001330552";
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
             _actorIdentity.ActorNumber,
@@ -85,7 +85,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     public async Task When_ReceiverIdIsNotDatahub_Then_ResultContainExceptedValidationError()
     {
         var invalidDataHubReceiverId = "5790001330052";
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
             _actorIdentity.ActorNumber,
@@ -110,7 +110,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     [Fact]
     public async Task When_SenderIdDoesNotMatchTheAuthenticatedUser_Then_ResultContainExceptedValidationError()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var invalidSenderId = ActorNumber.Create("5790001330550");
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
@@ -135,7 +135,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     [Fact]
     public async Task When_MultipleTransactionsWithSameId_Then_ResultContainExceptedValidationError()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var duplicatedTransactionId = "123456";
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
@@ -164,7 +164,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     [Fact]
     public async Task When_MultipleTransactionsWithSameIdAsExisting_Then_ResultContainExceptedValidationError()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var existingTransactionIdForSender = "123456";
         var newTransactionIdForSender = "654321";
         await StoreTransactionIdForActorAsync(existingTransactionIdForSender, _actorIdentity.ActorNumber.Value);
@@ -195,7 +195,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     [Fact]
     public async Task When_TransactionIdIsEmpty_Then_ResultContainExceptedValidationError()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var emptyTransactionId = string.Empty;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
@@ -220,7 +220,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     [Fact]
     public async Task When_MessageIdIsEmpty_Then_ResultContainExceptedValidationError()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var emptyMessageId = string.Empty;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
@@ -246,7 +246,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     [Fact]
     public async Task When_MessageIdAlreadyExists_Then_ResultContainExceptedValidationError()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var existingMessageId = "123564789";
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
@@ -271,7 +271,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     [Fact]
     public async Task When_SenderRoleInMessageIsMeteredDataResponsible_Then_ValidationSucceed()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var validSenderRoleInMessage = ActorRole.MeteredDataResponsible;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
@@ -294,7 +294,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     [Fact]
     public async Task When_AuthenticatedSenderRoleIsIncorrect_Then_ResultContainExceptedValidationError()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var authenticatedActor = GetService<AuthenticatedActor>();
         var invalidSenderRole = ActorRole.EnergySupplier;
         var actorIdentity = new ActorIdentity(ActorNumber.Create("1234567890123"), restriction: Restriction.None, invalidSenderRole, ActorId);
@@ -319,8 +319,8 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     [Fact]
     public async Task When_BusinessProcessIsIncorrect_Then_ResultContainExceptedValidationError()
     {
-        var invalidBusinessProcess = "un:unece:260:data:EEM-DK_DataTimeSeries:v3";
-        var documentFormat = DocumentFormat.Ebix;
+        var invalidBusinessProcess = "urn:ediel.org:measure:notifywholesaleservices:0:2";
+        var documentFormat = DocumentFormat.Xml;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
             _actorIdentity.ActorNumber,
@@ -339,7 +339,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     public async Task When_SchemaIsIncorrect_Then_ResultContainExceptedValidationError()
     {
         var invalidSchema = "EEM-DK_MeteredDataTimeSeries:v3";
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
             _actorIdentity.ActorNumber,
@@ -358,7 +358,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     public async Task When_ProcessTypeIsNotAllowed_Then_ResultContainExceptedValidationError()
     {
         var notAllowedProcessType = "1880";
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
             _actorIdentity.ActorNumber,
@@ -373,7 +373,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
         result.Errors.Should().Contain(error => error is InvalidMessageStructure);
     }
 
-    [Theory]
+    [Theory(Skip = "We do not support eBix anymore")]
     [InlineData("E23")]
     [InlineData("D42")]
     public async Task When_ProcessTypeIsAllowedForEbix_Then_ValidationSucceed(string allowedProcessType)
@@ -447,7 +447,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     public async Task When_MessageTypeIsNotAllowed_Then_ResultContainExceptedValidationError()
     {
         var notAllowedMessageType = "1880";
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
             _actorIdentity.ActorNumber,
@@ -469,7 +469,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     public async Task When_MessageTypeIsAllowed_Then_ResultContainExceptedValidationError()
     {
         var allowedMessageType = "E66";
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
             _actorIdentity.ActorNumber,
@@ -487,7 +487,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     [Fact]
     public async Task When_MessageIdIs35Characters_Then_ValidationSucceed()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var validMessageId = "12356478912356478912356478912356478";
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
@@ -509,10 +509,10 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     }
 
     [Fact]
-    public async Task When_MessageIdExceed35Characters_Then_ExpectedValidationError()
+    public async Task When_MessageIdExceed35Characters_Then_NoValidationError()
     {
         var invalidMessageId = "123564789123564789123564789123564789_123564789123564789123564789123564789";
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
             _actorIdentity.ActorNumber,
@@ -526,14 +526,14 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
 
         var messageParser = await ParseMessageAsync(message.Stream, documentFormat);
 
-        messageParser.ParserResult.Errors.Should().Contain(error => error is InvalidMessageStructure);
-        messageParser.ParserResult.Success.Should().BeFalse();
+        messageParser.ParserResult.Errors.Should().BeEmpty();
+        messageParser.ParserResult.Success.Should().BeTrue();
     }
 
     [Fact]
     public async Task When_TransactionIdIsLessThen35Characters_Then_ValidationSucceed()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var validTransactionId = "1235647891235647891235647891";
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
@@ -557,7 +557,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     [Fact]
     public async Task When_TransactionIdIs35Characters_Then_ValidationSucceed()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var validTransactionId = "12356478912356478912356478912356478";
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
@@ -578,10 +578,10 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     }
 
     [Fact]
-    public async Task When_TransactionIdExceed35Characters_Then_ExpectedValidationError()
+    public async Task When_TransactionIdExceed35Characters_Then_NoValidationError()
     {
         var invalidTransactionId = "123564789123564789123564789123564789_123564789123564789123564789123564789";
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
             _actorIdentity.ActorNumber,
@@ -594,14 +594,14 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
 
         var messageParser = await ParseMessageAsync(message.Stream, documentFormat);
 
-        messageParser.ParserResult.Errors.Should().Contain(error => error is InvalidMessageStructure);
-        messageParser.ParserResult.Success.Should().BeFalse();
+        messageParser.ParserResult.Errors.Should().BeEmpty();
+        messageParser.ParserResult.Success.Should().BeTrue();
     }
 
     [Fact]
     public async Task When_BusinessTypeIsAllowed_Then_ValidationSucceed()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
             _actorIdentity.ActorNumber,
@@ -624,7 +624,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
     [Fact]
     public async Task When_BusinessTypeIsNotAllowed_Then_ExpectedValidationError()
     {
-        var documentFormat = DocumentFormat.Ebix;
+        var documentFormat = DocumentFormat.Xml;
         var message = MeteredDataForMeasurementPointBuilder.CreateIncomingMessage(
             documentFormat,
             _actorIdentity.ActorNumber,
@@ -632,7 +632,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
                 ("555555555",
                     Instant.FromUtc(2024, 1, 1, 0, 0), Instant.FromUtc(2024, 1, 2, 0, 0), Resolution.QuarterHourly),
             ],
-            businessType: "27");
+            businessType: "42");
 
         var messageParser = await ParseMessageAsync(message.Stream, documentFormat);
         messageParser.ParserResult.Errors.Should().Contain(error => error is InvalidMessageStructure);

--- a/source/IncomingMessages.IntegrationTests/IncomingMessages/GivenIncomingMeteredDataForMeasurementMessageTests.cs
+++ b/source/IncomingMessages.IntegrationTests/IncomingMessages/GivenIncomingMeteredDataForMeasurementMessageTests.cs
@@ -373,7 +373,7 @@ public class GivenIncomingMeteredDataForMeasurementMessageTests : IncomingMessag
         result.Errors.Should().Contain(error => error is InvalidMessageStructure);
     }
 
-    [Theory(Skip = "We do not support eBix anymore")]
+    [Theory]
     [InlineData("E23")]
     [InlineData("D42")]
     public async Task When_ProcessTypeIsAllowedForEbix_Then_ValidationSucceed(string allowedProcessType)

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenMeteredDataForMeasurementPointTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenMeteredDataForMeasurementPointTests.cs
@@ -121,51 +121,37 @@ public sealed class GivenMeteredDataForMeasurementPointTests(
                     new OptionalHeaderDocumentFields(
                         "23",
                         [
-                            isTransOne
-                            ? new AssertSeriesDocumentFieldsInput(
+                            new AssertSeriesDocumentFieldsInput(
                                 1,
                                 new RequiredSeriesFields(
-                                    TransactionId.From(string.Join(string.Empty, transactionId1.Reverse())),
+                                    TransactionId.From(
+                                        string.Join(
+                                            string.Empty,
+                                            isTransOne ? transactionId1.Reverse() : transactionId2.Reverse())),
                                     "579999993331812345",
                                     "A10",
                                     "E17",
                                     "KWH",
                                     new RequiredPeriodDocumentFields(
-                                        "PT1H",
-                                        "2024-11-28T13:51Z",
-                                        "2024-11-29T09:15Z",
-                                        Enumerable.Range(1, 24)
-                                            .Select(
-                                                i => new AssertPointDocumentFieldsInput(
-                                                    new RequiredPointDocumentFields(i),
-                                                    new OptionalPointDocumentFields("A03", 1000 + i)))
-                                            .ToList())),
+                                        isTransOne ? "PT1H" : "PT15M",
+                                        isTransOne ? "2024-11-28T13:51Z" : "2024-11-24T18:51Z",
+                                        isTransOne ? "2024-11-29T09:15Z" : "2024-11-25T03:39Z",
+                                        [
+                                            new AssertPointDocumentFieldsInput(
+                                                new RequiredPointDocumentFields(1),
+                                                new OptionalPointDocumentFields(null, null)),
+                                            new AssertPointDocumentFieldsInput(
+                                                new RequiredPointDocumentFields(2),
+                                                new OptionalPointDocumentFields("A03", null)),
+                                            new AssertPointDocumentFieldsInput(
+                                                new RequiredPointDocumentFields(3),
+                                                new OptionalPointDocumentFields(null, 123.456m)),
+                                            new AssertPointDocumentFieldsInput(
+                                                new RequiredPointDocumentFields(4),
+                                                new OptionalPointDocumentFields("A03", 654.321m)),
+                                        ])),
                                 new OptionalSeriesFields(
-                                    transactionId1,
-                                    "2022-12-17T09:30:47Z",
-                                    null,
-                                    null,
-                                    "8716867000030"))
-                            : new AssertSeriesDocumentFieldsInput(
-                                1,
-                                new RequiredSeriesFields(
-                                    TransactionId.From(string.Join(string.Empty, transactionId2.Reverse())),
-                                    "579999993331812345",
-                                    "A10",
-                                    "E17",
-                                    "KWH",
-                                    new RequiredPeriodDocumentFields(
-                                        "PT15M",
-                                        "2024-11-24T18:51Z",
-                                        "2024-11-25T03:39Z",
-                                        Enumerable.Range(1, 96)
-                                            .Select(
-                                                i => new AssertPointDocumentFieldsInput(
-                                                    new RequiredPointDocumentFields(i),
-                                                    new OptionalPointDocumentFields("A03", 1000 + i)))
-                                            .ToList())),
-                                new OptionalSeriesFields(
-                                    transactionId2,
+                                    isTransOne ? transactionId1 : transactionId2,
                                     "2022-12-17T09:30:47Z",
                                     null,
                                     null,

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenMeteredDataForMeasurementPointTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenMeteredDataForMeasurementPointTests.cs
@@ -37,15 +37,26 @@ public sealed class GivenMeteredDataForMeasurementPointTests(
     ITestOutputHelper testOutputHelper)
     : MeteredDataForMeasurementPointBehaviourTestBase(integrationTestFixture, testOutputHelper)
 {
-    public static TheoryData<DocumentFormat> PeekFormats =>
-    [
-        DocumentFormat.Json,
-        DocumentFormat.Xml,
-    ];
+    public static TheoryData<DocumentFormat, DocumentFormat> RequestAndPeekFormatPairs
+    {
+        get
+        {
+            var data = new TheoryData<DocumentFormat, DocumentFormat>();
+            foreach (var requestFormat in (DocumentFormat[])[DocumentFormat.Json, DocumentFormat.Xml])
+            {
+                foreach (var peekFormat in (DocumentFormat[])[DocumentFormat.Json, DocumentFormat.Xml])
+                {
+                    data.Add(requestFormat, peekFormat);
+                }
+            }
+
+            return data;
+        }
+    }
 
     [Theory]
-    [MemberData(nameof(PeekFormats))]
-    public async Task When_ActorPeeksAllMessages_Then_ReceivesOneDocumentWithCorrectContent(DocumentFormat peekFormat)
+    [MemberData(nameof(RequestAndPeekFormatPairs))]
+    public async Task When_ActorPeeksAllMessages_Then_ReceivesOneDocumentWithCorrectContent(DocumentFormat requestFormat, DocumentFormat peekFormat)
     {
         // Arrange
         var senderSpy = CreateServiceBusSenderSpy();
@@ -60,7 +71,7 @@ public sealed class GivenMeteredDataForMeasurementPointTests(
         var transactionId2 = $"{transactionIdPrefix}-2";
 
         await GivenReceivedMeteredDataForMeasurementPoint(
-            documentFormat: DocumentFormat.Xml,
+            documentFormat: requestFormat,
             senderActorNumber: currentActor.ActorNumber,
             [
                 (transactionId1,
@@ -164,8 +175,9 @@ public sealed class GivenMeteredDataForMeasurementPointTests(
     }
 
     [Theory]
-    [MemberData(nameof(PeekFormats))]
+    [MemberData(nameof(RequestAndPeekFormatPairs))]
     public async Task AndGiven_MessageIsEmpty_When_ActorPeeksAllMessages_Then_ReceivesNoMessages(
+        DocumentFormat requestFormat,
         DocumentFormat peekFormat)
     {
         // Arrange
@@ -176,7 +188,7 @@ public sealed class GivenMeteredDataForMeasurementPointTests(
         GivenAuthenticatedActorIs(currentActor.ActorNumber, currentActor.ActorRole);
 
         await GivenReceivedMeteredDataForMeasurementPoint(
-            documentFormat: DocumentFormat.Xml,
+            documentFormat: requestFormat,
             senderActorNumber: currentActor.ActorNumber,
             []);
 

--- a/source/IntegrationTests/Behaviours/MeteredDataForMeasurementPointBehaviourTestBase.cs
+++ b/source/IntegrationTests/Behaviours/MeteredDataForMeasurementPointBehaviourTestBase.cs
@@ -67,9 +67,13 @@ public abstract class MeteredDataForMeasurementPointBehaviourTestBase : Behaviou
         }
 
         using var scope = new AssertionScope();
+        incomingMessageStream.Stream.Position = 0;
+        using var reader = new StreamReader(incomingMessageStream.Stream);
         response.IsErrorResponse
             .Should()
-            .BeFalse("the response should not have an error. Actual response: {0}", response.MessageBody);
+            .BeFalse(
+                "the response should not have an error. Actual response: {0}",
+                response.MessageBody + "\n\n\n" + await reader.ReadToEndAsync());
 
         response.MessageBody.Should().BeEmpty();
 

--- a/source/Process.Application/ProcessInitializationHandlers/InitializeMeteredDataForMeasurementPointHandler.cs
+++ b/source/Process.Application/ProcessInitializationHandlers/InitializeMeteredDataForMeasurementPointHandler.cs
@@ -84,10 +84,10 @@ public class InitializeMeteredDataForMeasurementPointHandler(
                             series.EnergyObservations.Select(
                                     o => new EnergyObservationDto(
                                         o.Position != null
-                                            ? int.Parse(o.Position)
+                                            ? int.Parse(o.Position, CultureInfo.InvariantCulture)
                                             : throw new ArgumentNullException(nameof(o.Position)),
                                         o.EnergyQuantity != null
-                                            ? decimal.Parse(o.EnergyQuantity)
+                                            ? decimal.Parse(o.EnergyQuantity, CultureInfo.InvariantCulture)
                                             : null,
                                         o.QuantityQuality))
                                 .ToList())),

--- a/source/Tests/CimMessageAdapter/Messages/MeteredDataForMeasurementPointMessageParserTests/MessageParserTests.cs
+++ b/source/Tests/CimMessageAdapter/Messages/MeteredDataForMeasurementPointMessageParserTests/MessageParserTests.cs
@@ -122,7 +122,7 @@ public sealed class MessageParserTests
                 energyObservation.Position.Should().Be(position.ToString());
                 energyObservation.EnergyQuantity.Should().NotBeEmpty();
                 energyObservation.QuantityQuality.Should()
-                    .Match(quality => quality == "E01" || quality == "56" || quality == "A03");
+                    .Match(quality => quality == null || quality == "E01" || quality == "56" || quality == "A03" || quality == "A02" || quality == "A05");
                 position++;
             }
         }

--- a/source/Tests/CimMessageAdapter/Messages/MeteredDataForMeasurementPointMessageParserTests/MessageParserTests.cs
+++ b/source/Tests/CimMessageAdapter/Messages/MeteredDataForMeasurementPointMessageParserTests/MessageParserTests.cs
@@ -121,8 +121,30 @@ public sealed class MessageParserTests
                 energyObservation.Should().NotBeNull();
                 energyObservation.Position.Should().Be(position.ToString());
                 energyObservation.EnergyQuantity.Should().NotBeEmpty();
-                energyObservation.QuantityQuality.Should()
-                    .Match(quality => quality == null || quality == "E01" || quality == "56" || quality == "A03" || quality == "A02" || quality == "A05");
+
+                if (format != DocumentFormat.Ebix)
+                {
+                    energyObservation.QuantityQuality.Should()
+                        .Match(
+                            quality => quality == null
+                                       || quality == "A01"
+                                       || quality == "A02"
+                                       || quality == "A03"
+                                       || quality == "A04"
+                                       || quality == "A05"
+                                       || quality == "A06");
+                }
+                else
+                {
+                    energyObservation.QuantityQuality.Should()
+                        .Match(
+                            quality => quality == null
+                                       || quality == "56"
+                                       || quality == "D01"
+                                       || quality == "36"
+                                       || quality == "E01");
+                }
+
                 position++;
             }
         }

--- a/source/Tests/Infrastructure/OutgoingMessages/RSM012/AssertMeteredDateForMeasurementPointXmlDocument.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/RSM012/AssertMeteredDateForMeasurementPointXmlDocument.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Globalization;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.Tests.Infrastructure.OutgoingMessages.Asserts;
 using FluentAssertions;
@@ -238,12 +239,12 @@ public class AssertMeteredDateForMeasurementPointXmlDocument : IAssertMeteredDat
                     $"Series[{seriesIndex}]/Period/Point[{i + 1}]/position",
                     requiredPointDocumentFields.Position.ToString());
 
-            if (optionalPointDocumentFields.Quantity != null)
+            if (optionalPointDocumentFields.Quantity.HasValue)
             {
                 _documentAsserter
                     .HasValue(
                         $"Series[{seriesIndex}]/Period/Point[{i + 1}]/quantity",
-                        optionalPointDocumentFields.Quantity!.ToString()!);
+                        optionalPointDocumentFields.Quantity.Value.ToString(CultureInfo.InvariantCulture));
             }
             else
             {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

- We accidentally read the points from the `Series` element, instead of the `Period` for JSON.
- We assumed that a `Point` always had all its values for JSON. This is incorrect, as two of them are nullable.
- We created a lot of points for our behaviour tests. This is now reduced to four: one for each structural case.
- We did not handle decimals correctly wrt assertion and temporary serialisation.

### Observation
- `GivenIncomingMessagesWithDelegationTests` relies on eBix for RSM-12. It should work for XML/JSON too, but it does not. We should fix this in another PR.

## References

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/377

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task