### PR TITLE
test: Extend timeout for clean-up in load test

### DIFF
--- a/source/SubsystemTests/Drivers/EdiDatabaseDriver.cs
+++ b/source/SubsystemTests/Drivers/EdiDatabaseDriver.cs
@@ -233,7 +233,7 @@ internal sealed class EdiDatabaseDriver
                 ";
 
             deleteOutgoingMessagesCommand.Connection = connection;
-            deleteOutgoingMessagesCommand.CommandTimeout = (int)TimeSpan.FromMinutes(2).TotalSeconds;
+            deleteOutgoingMessagesCommand.CommandTimeout = (int)TimeSpan.FromMinutes(4).TotalSeconds;
 
             await deleteOutgoingMessagesCommand.ExecuteNonQueryAsync().ConfigureAwait(false);
         }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

We had a timeout of our load test. Since it does enqueue a lot of messages, the timeout has been extended.

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task