### PR TITLE
Update cd: fix typo in job name

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ jobs:
   # Only dispatch if there are changes to either dotnet or database migrations. No need to deploy if only C4 model views are updated.
   #
 
-  dispatch_deploment_event:
+  dispatch_deployment_event:
     if: ${{ needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.db_migrations == 'true' }}
     runs-on: ubuntu-latest
     needs: [dotnet_promote_prerelease, changes]
@@ -72,7 +72,7 @@ jobs:
   #
 
   dispatch_failed:
-    needs: [dotnet_promote_prerelease, dispatch_deploment_event]
+    needs: [dotnet_promote_prerelease, dispatch_deployment_event]
     if: |
       always() &&
       contains(needs.*.result, 'failure')


### PR DESCRIPTION
This pull request includes a correction to the `dispatch_deployment_event` job name in the `.github/workflows/cd.yml` file to ensure proper workflow execution.

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L46-R46): Corrected the job name from `dispatch_deploment_event` to `dispatch_deployment_event` in two places to fix a typo. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L46-R46) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L75-R75)