### PR TITLE
test: clean up file storage during performance test

### DIFF
--- a/source/SubsystemTests/Drivers/EdiFileStorageDriver.cs
+++ b/source/SubsystemTests/Drivers/EdiFileStorageDriver.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Azure;
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+
+namespace Energinet.DataHub.EDI.SubsystemTests.Drivers;
+
+public class EdiFileStorageDriver(string connectionString)
+{
+    private readonly BlobServiceClient _blobServiceClient = new(
+        new Uri(connectionString),
+        new DefaultAzureCredential());
+
+    public async Task DeleteOutgoingMessagesIfExistsAsync(IList<string> fileStorageReferences, CancellationToken cancellationToken)
+    {
+        var container = _blobServiceClient.GetBlobContainerClient("outgoing");
+        var blobBatchClient = _blobServiceClient.GetBlobBatchClient();
+        var blobUris = fileStorageReferences
+            .Select(reference => container.GetBlobClient(reference).Uri)
+            .ToList();
+
+        // Each batch request supports a maximum of 256 blobs.
+        var take = 256;
+        var skip = 0;
+        while (true)
+        {
+            var batch = blobUris.Skip(skip).Take(take).ToList();
+            skip += take;
+            if (batch.Count == 0)
+                break;
+
+            try
+            {
+                await blobBatchClient.DeleteBlobsAsync(batch, DeleteSnapshotsOption.IncludeSnapshots, cancellationToken).ConfigureAwait(false);
+            }
+            catch (AggregateException e) when (e.InnerExceptions.Any(x => x is RequestFailedException && x.Message.Contains("BlobNotFound")))
+            {
+                // One or more Blobs did not exist, no need to delete.
+                return;
+            }
+        }
+    }
+}

--- a/source/SubsystemTests/LoadTest/ForwardMeteredData.cs
+++ b/source/SubsystemTests/LoadTest/ForwardMeteredData.cs
@@ -35,18 +35,20 @@ public sealed class ForwardMeteredData : IClassFixture<LoadTestFixture>
     private readonly LoadTestFixture _fixture;
     private readonly ITestOutputHelper _logger;
     private readonly EdiDatabaseDriver _ediDatabaseDriver;
+    private readonly EdiFileStorageDriver _ediFileStorageDriver;
 
     public ForwardMeteredData(LoadTestFixture fixture, ITestOutputHelper logger)
     {
         _fixture = fixture;
         _logger = logger;
         _ediDatabaseDriver = new EdiDatabaseDriver(_fixture.DatabaseConnectionString);
+        _ediFileStorageDriver = new EdiFileStorageDriver(_fixture.FileStorageConnectionString);
     }
 
     [Fact]
     public async Task Before_load_test()
     {
-        await _ediDatabaseDriver.DeleteOutgoingMessagesForFromLoadTestAsync();
+        await CleanUp();
     }
 
     [Fact]
@@ -61,5 +63,14 @@ public sealed class ForwardMeteredData : IClassFixture<LoadTestFixture>
         enqueuedMessagesCount.Should().BeGreaterThanOrEqualTo(
             _fixture.MinimumEnqueuedMessagesCount,
             $"because the system should be performant enough to enqueue at least {_fixture.MinimumEnqueuedMessagesCount} messages during the load test");
+
+        await CleanUp();
+    }
+
+    private async Task CleanUp()
+    {
+        var outgoingMessagesFileStorageReferences = await _ediDatabaseDriver.GetOutgoingMessagesFileStorageReferencesForFromLoadTestAsync(CancellationToken.None);
+        await _ediFileStorageDriver.DeleteOutgoingMessagesIfExistsAsync(outgoingMessagesFileStorageReferences, CancellationToken.None);
+        await _ediDatabaseDriver.DeleteOutgoingMessagesForFromLoadTestAsync(CancellationToken.None);
     }
 }

--- a/source/SubsystemTests/LoadTest/LoadTestFixture.cs
+++ b/source/SubsystemTests/LoadTest/LoadTestFixture.cs
@@ -34,6 +34,7 @@ public sealed class LoadTestFixture : IAsyncLifetime, IAsyncDisposable
     public LoadTestFixture()
     {
         var configurationBuilder = new ConfigurationBuilder()
+            .AddJsonFile("loadtests.test001.settings.json", true)
             .AddEnvironmentVariables();
 
         var baseConfiguration = configurationBuilder.Build();
@@ -49,6 +50,8 @@ public sealed class LoadTestFixture : IAsyncLifetime, IAsyncDisposable
         DatabaseConnectionString = SubsystemTestFixture.BuildDbConnectionString(
             GetConfigurationValue<string>(configuration, "mssql-data-url"),
             GetConfigurationValue<string>(configuration, "mssql-edi-database-name"));
+
+        FileStorageConnectionString = GetConfigurationValue<string>(configuration, "FileStorage__StorageAccountUrl");
 
         _serviceBusClient = new ServiceBusClient(
             $"{GetConfigurationValue<string>(configuration, "sb-domain-relay-namespace-name")}.servicebus.windows.net",
@@ -99,6 +102,8 @@ public sealed class LoadTestFixture : IAsyncLifetime, IAsyncDisposable
     internal IntegrationEventPublisher IntegrationEventPublisher { get; }
 
     internal string DatabaseConnectionString { get; }
+
+    internal string FileStorageConnectionString { get; }
 
     internal TelemetryClient TelemetryClient { get; }
 

--- a/source/SubsystemTests/LoadTest/LoadTestFixture.cs
+++ b/source/SubsystemTests/LoadTest/LoadTestFixture.cs
@@ -51,7 +51,7 @@ public sealed class LoadTestFixture : IAsyncLifetime, IAsyncDisposable
             GetConfigurationValue<string>(configuration, "mssql-data-url"),
             GetConfigurationValue<string>(configuration, "mssql-edi-database-name"));
 
-        FileStorageConnectionString = GetConfigurationValue<string>(configuration, "FileStorage__StorageAccountUrl");
+        FileStorageConnectionString = GetConfigurationValue<string>(configuration, "FILE_STORAGE_ACCOUNT_URL");
 
         _serviceBusClient = new ServiceBusClient(
             $"{GetConfigurationValue<string>(configuration, "sb-domain-relay-namespace-name")}.servicebus.windows.net",

--- a/source/SubsystemTests/SubsystemTests.csproj
+++ b/source/SubsystemTests/SubsystemTests.csproj
@@ -67,12 +67,16 @@
       <None Update="Drivers\Ebix\DH3-test-Mosaic-GridAccessProvider.pfx">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="loadtests.dev002.settings.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Azure.Core" Version="1.44.1"/>
         <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
         <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0"/>
+        <PackageReference Include="Azure.Storage.Blobs.Batch" Version="12.20.0" />
         <PackageReference Include="Dapper" Version="2.1.35" />
         <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="7.1.1" />
         <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.1.1" />

--- a/source/SubsystemTests/loadtests.local.settings.sample.json
+++ b/source/SubsystemTests/loadtests.local.settings.sample.json
@@ -1,5 +1,5 @@
 ﻿{
   "SHARED_KEYVAULT_NAME": "<SHARED_KEYVAULT_NAME>",
   "INTERNAL_KEYVAULT_NAME": "<INTERNAL_KEYVAULT_NAME>",
-  "FileStorage__StorageAccountUrl": "<FileStorage__StorageAccountUrl>"
+  "FILE_STORAGE_ACCOUNT_URL": "<FileStorage__StorageAccountUrl>"
 }

--- a/source/SubsystemTests/loadtests.local.settings.sample.json
+++ b/source/SubsystemTests/loadtests.local.settings.sample.json
@@ -1,0 +1,5 @@
+﻿{
+  "SHARED_KEYVAULT_NAME": "<SHARED_KEYVAULT_NAME>",
+  "INTERNAL_KEYVAULT_NAME": "<INTERNAL_KEYVAULT_NAME>",
+  "FileStorage__StorageAccountUrl": "<FileStorage__StorageAccountUrl>"
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
All data from the previous performance test is being cleaned up. 

This is executed before the test in case the Azure Load test has been started manually and after to ensure we free up space as soon as possible. 

## References
- https://github.com/Energinet-DataHub/dh3-environments/pull/1320

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003)
  - https://github.com/Energinet-DataHub/dh3-environments/actions/runs/12597916588
  - https://github.com/Energinet-DataHub/dh3-environments/actions/runs/12597931062
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/448