### PR TITLE
fix: ensure old load test data is not included for metered data result

### DIFF
--- a/source/SubsystemTests/Drivers/EdiDatabaseDriver.cs
+++ b/source/SubsystemTests/Drivers/EdiDatabaseDriver.cs
@@ -230,6 +230,7 @@ internal sealed class EdiDatabaseDriver
                     UPDATE Bundles
                     SET DequeuedAt = DATEADD(DAY, -1, DATEADD(MONTH, -1, GETDATE()))
                     WHERE [RelatedToMessageId] like 'perf_test_%'
+                    AND DequeuedAt is null
                 """;
 
             updateBundles.Connection = connection;
@@ -324,6 +325,7 @@ internal sealed class EdiDatabaseDriver
                  FROM [Bundles]
                  WHERE [DocumentTypeInBundle] = 'NotifyValidatedMeasureData'
                  AND RelatedToMessageId like 'perf_test_%'
+                 AND DequeuedAt is null
                  """);
 
         return enqueuedMessagesCount;

--- a/source/SubsystemTests/LoadTest/ForwardMeteredData.cs
+++ b/source/SubsystemTests/LoadTest/ForwardMeteredData.cs
@@ -44,10 +44,9 @@ public sealed class ForwardMeteredData : IClassFixture<LoadTestFixture>
     }
 
     [Fact]
-    public Task Before_load_test()
+    public async Task Before_load_test()
     {
-        // Nothing to do before the load test
-        return Task.CompletedTask;
+        await CleanUp();
     }
 
     [Fact]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task