### PR TITLE
fix: capacitysettlement is not a valid MeteringPointType name

### DIFF
--- a/source/BuildingBlocks.Domain/Models/MeteringPointType.cs
+++ b/source/BuildingBlocks.Domain/Models/MeteringPointType.cs
@@ -37,7 +37,7 @@ public class MeteringPointType : DataHubType<MeteringPointType>
     public static readonly MeteringPointType TotalConsumption = new("TotalConsumption", "D12");
     public static readonly MeteringPointType ElectricalHeating = new("ElectricalHeating", "D14");
     public static readonly MeteringPointType NetConsumption = new("NetConsumption", "D15");
-    public static readonly MeteringPointType EffectSettlement = new("EffectSettlement", "D19");
+    public static readonly MeteringPointType CapacitySettlement = new("CapacitySettlement", "D19");
 
     [JsonConstructor]
     private MeteringPointType(string name, string code)

--- a/source/Process.Application/Transactions/WholesaleServices/Mappers/MeteringPointTypeMapper.cs
+++ b/source/Process.Application/Transactions/WholesaleServices/Mappers/MeteringPointTypeMapper.cs
@@ -36,7 +36,7 @@ public static class MeteringPointTypeMapper
             WholesaleServicesRequestSeries.Types.MeteringPointType.TotalConsumption => MeteringPointType.TotalConsumption,
             WholesaleServicesRequestSeries.Types.MeteringPointType.ElectricalHeating => MeteringPointType.ElectricalHeating,
             WholesaleServicesRequestSeries.Types.MeteringPointType.NetConsumption => MeteringPointType.NetConsumption,
-            WholesaleServicesRequestSeries.Types.MeteringPointType.EffectSettlement => MeteringPointType.EffectSettlement,
+            WholesaleServicesRequestSeries.Types.MeteringPointType.EffectSettlement => MeteringPointType.CapacitySettlement,
             WholesaleServicesRequestSeries.Types.MeteringPointType.Unspecified => throw new InvalidOperationException("Unknown metering point type"),
             _ => throw new ArgumentOutOfRangeException(nameof(meteringPointType), meteringPointType, "Unknown metering point type"),
         };
@@ -59,7 +59,7 @@ public static class MeteringPointTypeMapper
             Wholesale.CalculationResults.Interfaces.CalculationResults.Model.MeteringPointType.TotalConsumption => MeteringPointType.TotalConsumption,
             Wholesale.CalculationResults.Interfaces.CalculationResults.Model.MeteringPointType.ElectricalHeating => MeteringPointType.ElectricalHeating,
             Wholesale.CalculationResults.Interfaces.CalculationResults.Model.MeteringPointType.NetConsumption => MeteringPointType.NetConsumption,
-            Wholesale.CalculationResults.Interfaces.CalculationResults.Model.MeteringPointType.EffectSettlement => MeteringPointType.EffectSettlement,
+            Wholesale.CalculationResults.Interfaces.CalculationResults.Model.MeteringPointType.EffectSettlement => MeteringPointType.CapacitySettlement,
             Wholesale.CalculationResults.Interfaces.CalculationResults.Model.MeteringPointType.Exchange => MeteringPointType.Exchange,
             _ => throw new ArgumentOutOfRangeException(nameof(meteringPointType), meteringPointType, "Unknown metering point type"),
         };

--- a/source/Tests/BuildingBlocks/Models/MeteringPointTypeTests.cs
+++ b/source/Tests/BuildingBlocks/Models/MeteringPointTypeTests.cs
@@ -51,7 +51,7 @@ public class MeteringPointTypeTests
             (MeteringPointType.TotalConsumption, "TotalConsumption", "D12"),
             (MeteringPointType.ElectricalHeating, "ElectricalHeating", "D14"),
             (MeteringPointType.NetConsumption, "NetConsumption", "D15"),
-            (MeteringPointType.EffectSettlement, "EffectSettlement", "D19"),
+            (MeteringPointType.CapacitySettlement, "CapacitySettlement", "D19"),
         };
 
         using var scope = new AssertionScope();


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
MeteringPointType EffectSettlement has been renamed to CapacitySettlement in the calculation results

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/12685639892
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/12686009281/job/35357513481