### PR TITLE
refac: PeriodValidationRule for WholesaleRequsts

### DIFF
--- a/source/Edi.UnitTests/Validators/WholesaleServicesRequest/PeriodValidationRuleTests.cs
+++ b/source/Edi.UnitTests/Validators/WholesaleServicesRequest/PeriodValidationRuleTests.cs
@@ -273,7 +273,8 @@ public class PeriodValidationRuleTests
         var errors = await _sut.ValidateAsync(message);
 
         // Assert
-        errors.Should().ContainSingle().Subject.Should().Be(_invalidWinterMidnightFormat.WithPropertyName("Period Start"));
+        errors[0].Message.Should().Be(_invalidWinterMidnightFormat.WithPropertyName("Period Start").Message);
+        errors[1].Message.Should().Be(_invalidPeriodAcrossMonths.Message);
     }
 
     [Fact]

--- a/source/Edi.UnitTests/Validators/WholesaleServicesRequest/PeriodValidationRuleTests.cs
+++ b/source/Edi.UnitTests/Validators/WholesaleServicesRequest/PeriodValidationRuleTests.cs
@@ -480,6 +480,28 @@ public class PeriodValidationRuleTests
         errors.Should().ContainSingle().Subject.Should().Be(_invalidPeriodAcrossMonths);
     }
 
+    [Fact]
+    public async Task Validate_WhenPeriodIsBetweenTwoYears_ReturnsNoValidationError()
+    {
+        // Arrange
+        var periodStartDate = new LocalDateTime(2024, 12, 1, 0, 0, 0)
+            .InZoneStrictly(_dateTimeZone!)
+            .ToInstant();
+        var periodEndDate = new LocalDateTime(2025, 1, 1, 0, 0, 0)
+            .InZoneStrictly(_dateTimeZone!)
+            .ToInstant();
+        var message = new WholesaleServicesRequestBuilder()
+            .WithPeriodStart(periodStartDate.ToString())
+            .WithPeriodEnd(periodEndDate.ToString())
+            .Build();
+
+        // Act
+        var errors = await _sut.ValidateAsync(message);
+
+        // Assert
+        errors.Should().BeEmpty();
+    }
+
     private sealed class MockClock(Func<Instant> getInstant) : IClock
     {
         public Instant GetCurrentInstant() => getInstant.Invoke();

--- a/source/Edi/Validation/WholesaleServicesRequest/Rules/PeriodValidationRule.cs
+++ b/source/Edi/Validation/WholesaleServicesRequest/Rules/PeriodValidationRule.cs
@@ -132,7 +132,7 @@ public sealed class PeriodValidationRule(
             return;
         }
 
-        if (zonedEndDateTime.LocalDateTime.Month - zonedStartDateTime.LocalDateTime.Month != 1)
+        if ((zonedEndDateTime.LocalDateTime - zonedStartDateTime.LocalDateTime).Months != 1)
             errors.Add(_invalidPeriodAcrossMonths);
     }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
This PR will fix a bug with requesting `WholesaleServices` over a period when a year changes. It is copied from `Wholesale` repo's changes in this PR: 
https://github.com/Energinet-DataHub/opengeh-wholesale/commit/d42ae1c23302191c5035a476e06529a1b4dbcd8b

## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/internal-repo/1535
## Checklist
- [ ] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task