### PR TITLE
fix: added arhived message filter to ignore NotifyValidatedMeasureData

### DIFF
--- a/source/ArchivedMessages.Infrastructure/QueryBuilder.cs
+++ b/source/ArchivedMessages.Infrastructure/QueryBuilder.cs
@@ -122,8 +122,8 @@ internal sealed class QueryBuilder
 
         // TODO: Ensure B2C app, BFF and frontend can handle NotifyValidatedMeasureData before we remove this filter
         AddFilter(
-            "DocumentType!=@DocumentType",
-            new KeyValuePair<string, object>("DocumentType", DocumentType.NotifyValidatedMeasureData.Name));
+            "DocumentType != @ExcludedDocumentType",
+            new KeyValuePair<string, object>("ExcludedDocumentType", DocumentType.NotifyValidatedMeasureData.Name));
 
         return new QueryInput(BuildStatement(query), BuildTotalCountStatement(query), _queryParameters);
     }

--- a/source/ArchivedMessages.Infrastructure/QueryBuilder.cs
+++ b/source/ArchivedMessages.Infrastructure/QueryBuilder.cs
@@ -16,6 +16,7 @@ using Dapper;
 using Energinet.DataHub.EDI.ArchivedMessages.Domain.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Authentication;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Exceptions;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 
 namespace Energinet.DataHub.EDI.ArchivedMessages.Infrastructure;
 
@@ -118,6 +119,11 @@ internal sealed class QueryBuilder
         {
             throw new InvalidRestrictionException($"Invalid restriction for fetching archived messages. Must be either {nameof(Restriction.Owned)} or {nameof(Restriction.None)}. ActorNumber: {_actorIdentity.ActorNumber.Value}; Restriction: {_actorIdentity.Restriction.Name}");
         }
+
+        // TODO: Ensure B2C app, BFF and frontend can handle NotifyValidatedMeasureData before we remove this filter
+        AddFilter(
+            "DocumentType!=@DocumentType",
+            new KeyValuePair<string, object>("DocumentType", DocumentType.NotifyValidatedMeasureData.Name));
 
         return new QueryInput(BuildStatement(query), BuildTotalCountStatement(query), _queryParameters);
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
B2C app, BFF and Frontend is not prepared to receive NotifyValidatedMeasureData. 

This PR contains a workaround to fix this: Document type not supported: NotifyValidatedMeasureData The unsupported member type is located on type 'Energinet.DataHub.EDI.B2CWebApi.Models.ArchivedMessageResultV3'. Path: $.Messages. Document type not supported: NotifyValidatedMeasureData  

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/12824731549
- [x] Is there time to monitor state of the release to Production?
- [ ] Reference to the task