### PR TITLE
feat: extend DataLakeFileStorageClient with a client to the new storage account

### DIFF
--- a/source/ArchitectureTests/RegistrationTests.cs
+++ b/source/ArchitectureTests/RegistrationTests.cs
@@ -68,6 +68,9 @@ public class RegistrationTests
         Environment.SetEnvironmentVariable(
             $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrl)}",
             TestEnvironment.CreateFakeStorageUrl());
+        Environment.SetEnvironmentVariable(
+            $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrlObsoleted)}",
+            TestEnvironment.CreateFakeStorageUrl());
 
         Environment.SetEnvironmentVariable($"{ServiceBusNamespaceOptions.SectionName}__{nameof(ServiceBusNamespaceOptions.FullyQualifiedNamespace)}", TestEnvironment.CreateFakeServiceBusFullyQualifiedNamespace());
 

--- a/source/ArchivedMessages.IntegrationTests/Fixture/ArchivedMessagesFixture.cs
+++ b/source/ArchivedMessages.IntegrationTests/Fixture/ArchivedMessagesFixture.cs
@@ -149,8 +149,6 @@ public class ArchivedMessagesFixture : IDisposable, IAsyncLifetime
                 AzuriteManager.BlobStorageServiceUri.AbsoluteUri,
             [$"{BlobServiceClientConnectionOptions.SectionName}:{nameof(BlobServiceClientConnectionOptions.StorageAccountUrl)}"] =
                 AzuriteManager.BlobStorageServiceUri.AbsoluteUri,
-            [$"{BlobServiceClientConnectionOptions.SectionName}:{nameof(BlobServiceClientConnectionOptions.CutOffDate)}"] =
-                "2025-01-01T00:00:00Z",
             // TODO: fix this
             // Archived messages does not depend on ServiceBus, but the dependency injection in building blocks require it :(
             [$"{ServiceBusNamespaceOptions.SectionName}:{nameof(ServiceBusNamespaceOptions.FullyQualifiedNamespace)}"] = "Fake",

--- a/source/B2BApi.AppTests/Fixtures/B2BApiAppFixture.cs
+++ b/source/B2BApi.AppTests/Fixtures/B2BApiAppFixture.cs
@@ -442,6 +442,9 @@ public class B2BApiAppFixture : IAsyncLifetime
         appHostSettings.ProcessEnvironmentVariables.Add(
             $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrl)}",
             AzuriteManager.BlobStorageServiceUri.AbsoluteUri);
+        appHostSettings.ProcessEnvironmentVariables.Add(
+            $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrlObsoleted)}",
+            AzuriteManager.BlobStorageServiceUri.AbsoluteUri);
 
         // Dead-letter logging
         appHostSettings.ProcessEnvironmentVariables.Add(

--- a/source/B2CWebApi.AppTests/Fixture/B2CWebApiFixture.cs
+++ b/source/B2CWebApi.AppTests/Fixture/B2CWebApiFixture.cs
@@ -126,6 +126,10 @@ public class B2CWebApiFixture : IAsyncLifetime
                 $"{BlobServiceClientConnectionOptions.SectionName}:{nameof(BlobServiceClientConnectionOptions.StorageAccountUrl)}",
                 AzuriteManager.BlobStorageServiceUri.AbsoluteUri
             },
+            {
+                $"{BlobServiceClientConnectionOptions.SectionName}:{nameof(BlobServiceClientConnectionOptions.StorageAccountUrlObsoleted)}",
+                AzuriteManager.BlobStorageServiceUri.AbsoluteUri
+            },
             { "UserAuthentication:MitIdExternalMetadataAddress", "YourMitIdExternalMetadataAddress" },
             { "UserAuthentication:ExternalMetadataAddress", OpenIdJwtManager.ExternalMetadataAddress },
             { "UserAuthentication:InternalMetadataAddress", OpenIdJwtManager.InternalMetadataAddress },

--- a/source/BuildingBlocks.Infrastructure/Configuration/Options/BlobServiceClientConnectionOptions.cs
+++ b/source/BuildingBlocks.Infrastructure/Configuration/Options/BlobServiceClientConnectionOptions.cs
@@ -31,9 +31,6 @@ public class BlobServiceClientConnectionOptions
     public string StorageAccountUrl { get; init; } = string.Empty;
 
     [Required]
-    public string CutOffDate { get; init; } = string.Empty;
-
-    [Required]
     public string ClientNameObsoleted { get; init; } = DefaultClientNameObsoleted;
 
     [Required]

--- a/source/BuildingBlocks.Infrastructure/Configuration/Options/BlobServiceClientConnectionOptions.cs
+++ b/source/BuildingBlocks.Infrastructure/Configuration/Options/BlobServiceClientConnectionOptions.cs
@@ -20,10 +20,21 @@ public class BlobServiceClientConnectionOptions
 {
     public const string SectionName = "FileStorage";
 
-    private const string DefaultClientName = "FileStorageClient";
+    private const string DefaultClientNameObsoleted = "FileStorageClient";
+
+    private const string DefaultClientName = "ClassicFileStorageClient";
+
+    [Required]
+    public string StorageAccountUrlObsoleted { get; init; } = string.Empty;
 
     [Required]
     public string StorageAccountUrl { get; init; } = string.Empty;
+
+    [Required]
+    public string CutOffDate { get; init; } = string.Empty;
+
+    [Required]
+    public string ClientNameObsoleted { get; init; } = DefaultClientNameObsoleted;
 
     [Required]
     public string ClientName { get; init; } = DefaultClientName;

--- a/source/BuildingBlocks.Infrastructure/Extensions/DependencyInjection/FileStorageExtensions.cs
+++ b/source/BuildingBlocks.Infrastructure/Extensions/DependencyInjection/FileStorageExtensions.cs
@@ -23,6 +23,7 @@ namespace Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Extensions.Depende
 
 public static class FileStorageExtensions
 {
+    private const string HealthCheckNameObsoleted = "EDI blob file storage obsoleted";
     private const string HealthCheckName = "EDI blob file storage";
 
     public static IServiceCollection AddFileStorage(this IServiceCollection services, IConfiguration configuration)
@@ -46,6 +47,10 @@ public static class FileStorageExtensions
                 builder.UseCredential(new DefaultAzureCredential());
 
                 builder
+                    .AddBlobServiceClient(new Uri(blobServiceClientConnectionOptions.StorageAccountUrlObsoleted))
+                    .WithName(blobServiceClientConnectionOptions.ClientNameObsoleted);
+
+                builder
                     .AddBlobServiceClient(new Uri(blobServiceClientConnectionOptions.StorageAccountUrl))
                     .WithName(blobServiceClientConnectionOptions.ClientName);
             });
@@ -53,6 +58,10 @@ public static class FileStorageExtensions
         services.TryAddBlobStorageHealthCheck(
             HealthCheckName,
             blobServiceClientConnectionOptions.ClientName);
+
+        services.TryAddBlobStorageHealthCheck(
+            HealthCheckNameObsoleted,
+            blobServiceClientConnectionOptions.ClientNameObsoleted);
 
         services.AddTransient<IFileStorageClient, DataLakeFileStorageClient>();
 

--- a/source/BuildingBlocks.Infrastructure/FeatureFlag/FeatureFlagName.cs
+++ b/source/BuildingBlocks.Infrastructure/FeatureFlag/FeatureFlagName.cs
@@ -49,4 +49,9 @@ public enum FeatureFlagName
     /// Whether to use orchestration for handling RequestAggregatedMeasureData processes.
     /// </summary>
     UseRequestAggregatedMeasureDataProcessOrchestration,
+
+    /// <summary>
+    /// Whether to start using standard blob service client.
+    /// </summary>
+    UseStandardBlobServiceClient,
 }

--- a/source/BuildingBlocks.Infrastructure/FeatureFlag/IFeatureFlagManager.cs
+++ b/source/BuildingBlocks.Infrastructure/FeatureFlag/IFeatureFlagManager.cs
@@ -53,4 +53,9 @@ public interface IFeatureFlagManager
     /// Whether to use the RequestAggregatedMeasureData process orchestration.
     /// </summary>
     Task<bool> UseRequestAggregatedMeasureDataProcessOrchestrationAsync();
+
+    /// <summary>
+    /// Whether to use the StandardBlobServiceClient.
+    /// </summary>
+    Task<bool> UseStandardBlobServiceClientAsync();
 }

--- a/source/BuildingBlocks.Infrastructure/FeatureFlag/MicrosoftFeatureFlagManager.cs
+++ b/source/BuildingBlocks.Infrastructure/FeatureFlag/MicrosoftFeatureFlagManager.cs
@@ -40,5 +40,7 @@ public class MicrosoftFeatureFlagManager : IFeatureFlagManager
 
     public Task<bool> UseRequestAggregatedMeasureDataProcessOrchestrationAsync() => IsEnabledAsync(FeatureFlagName.UseRequestAggregatedMeasureDataProcessOrchestration);
 
+    public Task<bool> UseStandardBlobServiceClientAsync() => IsEnabledAsync(FeatureFlagName.UseStandardBlobServiceClient);
+
     private Task<bool> IsEnabledAsync(FeatureFlagName featureFlagName) => _featureManager.IsEnabledAsync(featureFlagName.ToString());
 }

--- a/source/BuildingBlocks.Tests/TestDoubles/FeatureFlagManagerStub.cs
+++ b/source/BuildingBlocks.Tests/TestDoubles/FeatureFlagManagerStub.cs
@@ -34,4 +34,6 @@ public class FeatureFlagManagerStub : IFeatureFlagManager
     public Task<bool> UseRequestWholesaleServicesProcessOrchestrationAsync() => Task.FromResult(false);
 
     public Task<bool> UseRequestAggregatedMeasureDataProcessOrchestrationAsync() => Task.FromResult(false);
+
+    public Task<bool> UseStandardBlobServiceClientAsync() => Task.FromResult(false);
 }

--- a/source/Edi.UnitTests/EdiTestBase.cs
+++ b/source/Edi.UnitTests/EdiTestBase.cs
@@ -50,6 +50,8 @@ public class EdiTestBase
             ["DB_CONNECTION_STRING"] = _ediFixture.DatabaseManager.ConnectionString,
             [$"{BlobServiceClientConnectionOptions.SectionName}:{nameof(BlobServiceClientConnectionOptions.StorageAccountUrl)}"] =
                 "https://fake.fakeurl.com",
+            [$"{BlobServiceClientConnectionOptions.SectionName}:{nameof(BlobServiceClientConnectionOptions.StorageAccountUrlObsoleted)}"] =
+                "https://fake.fakeurl.com",
             [$"{ServiceBusNamespaceOptions.SectionName}:{nameof(ServiceBusNamespaceOptions.FullyQualifiedNamespace)}"] = "Fake",
         });
 

--- a/source/IncomingMessages.IntegrationTests/IncomingMessagesTestBase.cs
+++ b/source/IncomingMessages.IntegrationTests/IncomingMessagesTestBase.cs
@@ -163,6 +163,9 @@ public class IncomingMessagesTestBase : IDisposable
     {
         Environment.SetEnvironmentVariable("DB_CONNECTION_STRING", Fixture.DatabaseManager.ConnectionString);
         Environment.SetEnvironmentVariable(
+            $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrlObsoleted)}",
+            Fixture.AzuriteManager.BlobStorageServiceUri.AbsoluteUri);
+        Environment.SetEnvironmentVariable(
             $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrl)}",
             Fixture.AzuriteManager.BlobStorageServiceUri.AbsoluteUri);
 

--- a/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
+++ b/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
@@ -338,14 +338,6 @@ public class BehavioursTestBase : IDisposable
         return messages;
     }
 
-    protected async Task GivenIntegrationEventReceived(IEventMessage @event)
-    {
-        var integrationEvent = new IntegrationEvent(Guid.NewGuid(), @event.EventName, @event.EventMinorVersion, @event);
-
-        using var serviceScope = _serviceProvider.CreateScope();
-        await serviceScope.ServiceProvider.GetRequiredService<IIntegrationEventHandler>().HandleAsync(integrationEvent);
-    }
-
     protected async Task<PeekResultDto?> WhenActorPeeksMessage(ActorNumber actorNumber, ActorRole actorRole, DocumentFormat documentFormat, MessageCategory messageCategory)
     {
         await using var scope = _serviceProvider.CreateAsyncScope();
@@ -441,6 +433,9 @@ public class BehavioursTestBase : IDisposable
         Environment.SetEnvironmentVariable("DB_CONNECTION_STRING", _integrationTestFixture.DatabaseManager.ConnectionString);
         Environment.SetEnvironmentVariable(
             $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrl)}",
+            _integrationTestFixture.AzuriteManager.BlobStorageServiceUri.AbsoluteUri);
+        Environment.SetEnvironmentVariable(
+            $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrlObsoleted)}",
             _integrationTestFixture.AzuriteManager.BlobStorageServiceUri.AbsoluteUri);
 
         var config = new ConfigurationBuilder()

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -123,26 +123,6 @@ public class TestBase : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    protected static async Task<string> GetFileContentFromFileStorageAsync(
-        string container,
-        string fileStorageReference)
-    {
-        var azuriteBlobUrl = Environment.GetEnvironmentVariable(
-            $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrl)}");
-        var blobServiceClient = new BlobServiceClient(new Uri(azuriteBlobUrl!)); // Uses new client to avoid some form of caching or similar
-
-        var containerClient = blobServiceClient.GetBlobContainerClient(container);
-        var blobClient = containerClient.GetBlobClient(fileStorageReference);
-
-        var blobContent = await blobClient.DownloadAsync();
-
-        if (!blobContent.HasValue)
-            throw new InvalidOperationException($"Couldn't get file content from file storage (container: {container}, blob: {fileStorageReference})");
-
-        var fileStringContent = await GetStreamContentAsStringAsync(blobContent.Value.Content);
-        return fileStringContent;
-    }
-
     protected static async Task<string> GetStreamContentAsStringAsync(Stream stream)
     {
         ArgumentNullException.ThrowIfNull(stream);
@@ -306,6 +286,9 @@ public class TestBase : IDisposable
         Environment.SetEnvironmentVariable("DB_CONNECTION_STRING", Fixture.DatabaseManager.ConnectionString);
         Environment.SetEnvironmentVariable(
             $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrl)}",
+            Fixture.AzuriteManager.BlobStorageServiceUri.AbsoluteUri);
+        Environment.SetEnvironmentVariable(
+            $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrlObsoleted)}",
             Fixture.AzuriteManager.BlobStorageServiceUri.AbsoluteUri);
 
         var config = new ConfigurationBuilder()

--- a/source/MasterData.IntegrationTests/Fixture/MasterDataTestBase.cs
+++ b/source/MasterData.IntegrationTests/Fixture/MasterDataTestBase.cs
@@ -52,6 +52,8 @@ public class MasterDataTestBase
             ["DB_CONNECTION_STRING"] = _masterDataFixture.DatabaseManager.ConnectionString,
             [$"{BlobServiceClientConnectionOptions.SectionName}:{nameof(BlobServiceClientConnectionOptions.StorageAccountUrl)}"] =
                 "https://fake.fakeurl.com",
+            [$"{BlobServiceClientConnectionOptions.SectionName}:{nameof(BlobServiceClientConnectionOptions.StorageAccountUrlObsoleted)}"] =
+                "https://fake.fakeurl.com",
             [$"{ServiceBusNamespaceOptions.SectionName}:{nameof(ServiceBusNamespaceOptions.FullyQualifiedNamespace)}"] = "Fake",
         });
 

--- a/source/OutgoingMessages.IntegrationTests/OutgoingMessagesTestBase.cs
+++ b/source/OutgoingMessages.IntegrationTests/OutgoingMessagesTestBase.cs
@@ -195,6 +195,9 @@ public class OutgoingMessagesTestBase : IDisposable
         Environment.SetEnvironmentVariable(
             $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrl)}",
             Fixture.AzuriteManager.BlobStorageServiceUri.AbsoluteUri);
+        Environment.SetEnvironmentVariable(
+            $"{BlobServiceClientConnectionOptions.SectionName}__{nameof(BlobServiceClientConnectionOptions.StorageAccountUrlObsoleted)}",
+            Fixture.AzuriteManager.BlobStorageServiceUri.AbsoluteUri);
 
         var config = new ConfigurationBuilder()
             .AddEnvironmentVariables()

--- a/source/Tests/BuildingBlocks/FileStorageClient/DataLakeFileStorageClientTests.cs
+++ b/source/Tests/BuildingBlocks/FileStorageClient/DataLakeFileStorageClientTests.cs
@@ -29,57 +29,53 @@ namespace Energinet.DataHub.EDI.Tests.BuildingBlocks.FileStorageClient;
 public class DataLakeFileStorageClientTests
 {
     private readonly DataLakeFileStorageClient _sut;
-    private readonly Mock<BlobContainerClient> _blobContainerClientMock;
-    private readonly Mock<BlobContainerClient> _blobContainerClientObsoletedMock;
-    private readonly Mock<BlobClient> _blobClientMock;
+    private Mock<BlobContainerClient> _blobContainerClientMock;
+    private Mock<BlobContainerClient> _blobContainerClientObsoletedMock;
+    private Mock<BlobClient> _blobClientMock;
 
+#pragma warning disable CS8618, CS9264
     public DataLakeFileStorageClientTests()
+#pragma warning restore CS8618, CS9264
     {
-        Mock<IAzureClientFactory<BlobServiceClient>> clientFactoryMock = new();
-        Mock<BlobServiceClient> blobServiceClientMock = new();
-        _blobContainerClientMock = new();
-        _blobClientMock = new();
-
-        var options = Options.Create(
-            new BlobServiceClientConnectionOptions
-            {
-                ClientName = "ClientName",
-                ClientNameObsoleted = "ClientNameObsoleted",
-            });
-
-        clientFactoryMock
-            .Setup(x => x.CreateClient(options.Value.ClientName))
-            .Returns(blobServiceClientMock.Object);
-
-        blobServiceClientMock
-            .Setup(x => x.GetBlobContainerClient(It.IsAny<string>()))
-            .Returns(_blobContainerClientMock.Object);
-
-        _blobContainerClientMock
-            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
-            .Returns(_blobClientMock.Object);
-
-        // Obsoleted client
-        Mock<BlobServiceClient> blobServiceClientObsoletedMock = new();
-        _blobContainerClientObsoletedMock = new();
-        clientFactoryMock
-            .Setup(x => x.CreateClient(options.Value.ClientNameObsoleted))
-            .Returns(blobServiceClientObsoletedMock.Object);
-
-        blobServiceClientObsoletedMock
-            .Setup(x => x.GetBlobContainerClient(It.IsAny<string>()))
-            .Returns(_blobContainerClientObsoletedMock.Object);
-
-        _blobContainerClientObsoletedMock
-            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
-            .Returns(_blobClientMock.Object);
-        // End: Obsoleted client
-
+        var options = GetOptions();
+        var clientFactoryMock = GetClientFactoryMock(options);
         Mock<IFeatureFlagManager> featureFlagManager = new();
         featureFlagManager
             .Setup(x => x.UseStandardBlobServiceClientAsync())
             .ReturnsAsync(true);
         _sut = new DataLakeFileStorageClient(clientFactoryMock.Object, options, featureFlagManager.Object);
+    }
+
+    [Fact]
+    public async Task Given_UploadAsync_When_UseStandardBlobServiceClientAsyncIsFalse_Then_ObsoleteBlobClientIsCalled()
+    {
+        // Arrange
+        var reference = new FileStorageReference(FileStorageCategory.ArchivedMessage(), "path");
+        var content = "test content";
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream);
+        await writer.WriteAsync(content);
+        await writer.FlushAsync();
+        stream.Position = 0;
+
+        Mock<IFeatureFlagManager> featureFlagManager = new();
+        featureFlagManager
+            .Setup(x => x.UseStandardBlobServiceClientAsync())
+            .ReturnsAsync(false);
+
+        var sut = new DataLakeFileStorageClient(GetClientFactoryMock(GetOptions()).Object, GetOptions(), featureFlagManager.Object);
+
+        // Act
+        await sut.UploadAsync(reference, stream);
+
+        // Assert
+        _blobContainerClientObsoletedMock.Verify(
+            x => x.UploadBlobAsync(reference.Path, stream, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _blobContainerClientMock.Verify(
+            x => x.UploadBlobAsync(reference.Path, stream, It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
@@ -98,6 +94,10 @@ public class DataLakeFileStorageClientTests
         await _sut.UploadAsync(reference, stream);
 
         // Assert
+        _blobContainerClientObsoletedMock.Verify(
+            x => x.UploadBlobAsync(reference.Path, stream, It.IsAny<CancellationToken>()),
+            Times.Never);
+
         _blobContainerClientMock.Verify(
             x => x.UploadBlobAsync(reference.Path, stream, It.IsAny<CancellationToken>()),
             Times.Once);
@@ -146,5 +146,52 @@ public class DataLakeFileStorageClientTests
         _blobContainerClientObsoletedMock.Verify(
             x => x.GetBlobClient(reference.Path),
             Times.Never);
+    }
+
+    private static IOptions<BlobServiceClientConnectionOptions> GetOptions()
+    {
+        var options = Options.Create(
+            new BlobServiceClientConnectionOptions
+            {
+                ClientName = "ClientName",
+                ClientNameObsoleted = "ClientNameObsoleted",
+            });
+        return options;
+    }
+
+    private Mock<IAzureClientFactory<BlobServiceClient>> GetClientFactoryMock(IOptions<BlobServiceClientConnectionOptions> options)
+    {
+        Mock<IAzureClientFactory<BlobServiceClient>> clientFactoryMock = new();
+        Mock<BlobServiceClient> blobServiceClientMock = new();
+        _blobContainerClientMock = new();
+        _blobClientMock = new();
+
+        clientFactoryMock
+            .Setup(x => x.CreateClient(options.Value.ClientName))
+            .Returns(blobServiceClientMock.Object);
+
+        blobServiceClientMock
+            .Setup(x => x.GetBlobContainerClient(It.IsAny<string>()))
+            .Returns(_blobContainerClientMock.Object);
+
+        _blobContainerClientMock
+            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
+            .Returns(_blobClientMock.Object);
+
+        // Obsoleted client
+        Mock<BlobServiceClient> blobServiceClientObsoletedMock = new();
+        _blobContainerClientObsoletedMock = new();
+        clientFactoryMock
+            .Setup(x => x.CreateClient(options.Value.ClientNameObsoleted))
+            .Returns(blobServiceClientObsoletedMock.Object);
+
+        blobServiceClientObsoletedMock
+            .Setup(x => x.GetBlobContainerClient(It.IsAny<string>()))
+            .Returns(_blobContainerClientObsoletedMock.Object);
+
+        _blobContainerClientObsoletedMock
+            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
+            .Returns(_blobClientMock.Object);
+        return clientFactoryMock;
     }
 }

--- a/source/Tests/BuildingBlocks/FileStorageClient/DataLakeFileStorageClientTests.cs
+++ b/source/Tests/BuildingBlocks/FileStorageClient/DataLakeFileStorageClientTests.cs
@@ -17,6 +17,8 @@ using Azure.Storage.Blobs;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration.Options;
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.FeatureFlag;
+using Energinet.DataHub.EDI.BuildingBlocks.Tests.TestDoubles;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -73,7 +75,11 @@ public class DataLakeFileStorageClientTests
             .Returns(_blobClientMock.Object);
         // End: Obsoleted client
 
-        _sut = new DataLakeFileStorageClient(clientFactoryMock.Object, options);
+        Mock<IFeatureFlagManager> featureFlagManager = new();
+        featureFlagManager
+            .Setup(x => x.UseStandardBlobServiceClientAsync())
+            .ReturnsAsync(true);
+        _sut = new DataLakeFileStorageClient(clientFactoryMock.Object, options, featureFlagManager.Object);
     }
 
     [Fact]

--- a/source/Tests/BuildingBlocks/FileStorageClient/DataLakeFileStorageClientTests.cs
+++ b/source/Tests/BuildingBlocks/FileStorageClient/DataLakeFileStorageClientTests.cs
@@ -1,0 +1,223 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
+using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration.Options;
+using Energinet.DataHub.EDI.BuildingBlocks.Tests.TestDoubles;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Options;
+using Moq;
+using NodaTime;
+using NodaTime.Text;
+using Xunit;
+
+namespace Energinet.DataHub.EDI.Tests.BuildingBlocks.FileStorageClient;
+
+public class DataLakeFileStorageClientTests
+{
+    private readonly DataLakeFileStorageClient _sut;
+    private readonly Mock<BlobContainerClient> _blobContainerClientMock;
+    private readonly Mock<BlobContainerClient> _blobContainerClientObsoletedMock;
+    private readonly ClockStub _clockStub;
+    private readonly Instant _cutOffDate = InstantPattern.General.Parse("2025-01-01T00:00:00Z").Value;
+    private readonly Mock<BlobClient> _blobClientMock;
+
+    public DataLakeFileStorageClientTests()
+    {
+        Mock<IAzureClientFactory<BlobServiceClient>> clientFactoryMock = new();
+        Mock<BlobServiceClient> blobServiceClientMock = new();
+        _blobContainerClientMock = new();
+        _blobClientMock = new();
+
+        var options = Options.Create(
+            new BlobServiceClientConnectionOptions
+            {
+                ClientName = "ClientName",
+                ClientNameObsoleted = "ClientNameObsoleted",
+                CutOffDate = _cutOffDate.ToString(),
+            });
+
+        clientFactoryMock
+            .Setup(x => x.CreateClient(options.Value.ClientName))
+            .Returns(blobServiceClientMock.Object);
+
+        blobServiceClientMock
+            .Setup(x => x.GetBlobContainerClient(It.IsAny<string>()))
+            .Returns(_blobContainerClientMock.Object);
+
+        _blobContainerClientMock
+            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
+            .Returns(_blobClientMock.Object);
+
+        // Obsoleted client
+        Mock<BlobServiceClient> blobServiceClientObsoletedMock = new();
+        _blobContainerClientObsoletedMock = new();
+        clientFactoryMock
+            .Setup(x => x.CreateClient(options.Value.ClientNameObsoleted))
+            .Returns(blobServiceClientObsoletedMock.Object);
+
+        blobServiceClientObsoletedMock
+            .Setup(x => x.GetBlobContainerClient(It.IsAny<string>()))
+            .Returns(_blobContainerClientObsoletedMock.Object);
+
+        _blobContainerClientObsoletedMock
+            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
+            .Returns(_blobClientMock.Object);
+        // End: Obsoleted client
+
+        _clockStub = new ClockStub();
+        _sut = new DataLakeFileStorageClient(clientFactoryMock.Object, options, _clockStub);
+    }
+
+    [Fact]
+    public async Task Given_Stream_When_UploadAsync_Then_ShouldCallUploadBlobAsync()
+    {
+        // Arrange
+        var reference = new FileStorageReference(FileStorageCategory.ArchivedMessage(), "path");
+        var content = "test content";
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream);
+        await writer.WriteAsync(content);
+        await writer.FlushAsync();
+        stream.Position = 0;
+
+        // Act
+        await _sut.UploadAsync(reference, stream);
+
+        // Assert
+        _blobContainerClientMock.Verify(
+            x => x.UploadBlobAsync(reference.Path, stream, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Given_Stream_When_UploadAsyncBeforeCutOffDate_Then_ShouldCallUploadBlobAsyncOnBlobContainerClientObsoleted()
+    {
+        // Arrange
+        var now = _cutOffDate.Minus(Duration.FromDays(1));
+        _clockStub.SetCurrentInstant(now);
+
+        var reference = new FileStorageReference(FileStorageCategory.ArchivedMessage(), "path");
+        var content = "test content";
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream);
+        await writer.WriteAsync(content);
+        await writer.FlushAsync();
+        stream.Position = 0;
+
+        // Act
+        await _sut.UploadAsync(reference, stream);
+
+        // Assert
+        _blobContainerClientObsoletedMock.Verify(
+            x => x.UploadBlobAsync(reference.Path, stream, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _blobContainerClientMock.Verify(
+            x => x.UploadBlobAsync(reference.Path, stream, It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Given_Stream_When_UploadAsyncAfterCutOffDate_Then_ShouldCallUploadBlobAsyncOnBlobContainerClient()
+    {
+        // Arrange
+        var now = _cutOffDate.Plus(Duration.FromDays(1));
+        _clockStub.SetCurrentInstant(now);
+
+        var reference = new FileStorageReference(FileStorageCategory.ArchivedMessage(), "path");
+        var content = "test content";
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream);
+        await writer.WriteAsync(content);
+        await writer.FlushAsync();
+        stream.Position = 0;
+
+        // Act
+        await _sut.UploadAsync(reference, stream);
+
+        // Assert
+        _blobContainerClientMock.Verify(
+            x => x.UploadBlobAsync(reference.Path, stream, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _blobContainerClientObsoletedMock.Verify(
+            x => x.UploadBlobAsync(reference.Path, stream, It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Given_ReferenceToUploadedBlob_When_DownloadAsync_Then_ShouldCallGetBlobClientOnBlobContainerClientObsoleted()
+    {
+        // Arrange
+        var now = _cutOffDate.Minus(Duration.FromDays(1));
+        _clockStub.SetCurrentInstant(now);
+
+        var reference = new FileStorageReference(FileStorageCategory.ArchivedMessage(), "path");
+        var content = "test content";
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream);
+        await writer.WriteAsync(content);
+        await writer.FlushAsync();
+        stream.Position = 0;
+        await _sut.UploadAsync(reference, stream);
+
+        // Act
+        var file = await _sut.DownloadAsync(reference);
+
+        // Assert
+        Assert.NotNull(file);
+        _blobContainerClientObsoletedMock.Verify(
+            x => x.GetBlobClient(reference.Path),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Given_ReferenceToUploadedBlob_When_DownloadAsync_Then_ShouldCallGetBlobClientOnBlobContainerClient()
+    {
+        // Arrange
+        var now = _cutOffDate.Plus(Duration.FromDays(1));
+        _clockStub.SetCurrentInstant(now);
+
+        var reference = new FileStorageReference(FileStorageCategory.ArchivedMessage(), "path");
+        var content = "test content";
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream);
+        await writer.WriteAsync(content);
+        await writer.FlushAsync();
+        stream.Position = 0;
+        await _sut.UploadAsync(reference, stream);
+
+        var responseMock = new Mock<Response>();
+        responseMock.SetupGet(r => r.Status).Returns(200);
+        responseMock.SetupGet(r => r.IsError).Returns(false);
+        _blobClientMock
+            .Setup(x => x.ExistsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(true, responseMock.Object));
+
+        // Act
+        var file = await _sut.DownloadAsync(reference);
+
+        // Assert
+        Assert.NotNull(file);
+        _blobContainerClientMock.Verify(
+            x => x.GetBlobClient(reference.Path),
+            Times.Once);
+        _blobContainerClientObsoletedMock.Verify(
+            x => x.GetBlobClient(reference.Path),
+            Times.Never);
+    }
+}

--- a/source/Tests/BuildingBlocks/FileStorageClient/DataLakeFileStorageClientTests.cs
+++ b/source/Tests/BuildingBlocks/FileStorageClient/DataLakeFileStorageClientTests.cs
@@ -76,6 +76,9 @@ public class DataLakeFileStorageClientTests
         _blobContainerClientMock.Verify(
             x => x.UploadBlobAsync(reference.Path, stream, It.IsAny<CancellationToken>()),
             Times.Never);
+
+        // Teardown
+        await stream.DisposeAsync();
     }
 
     [Fact]
@@ -101,6 +104,9 @@ public class DataLakeFileStorageClientTests
         _blobContainerClientMock.Verify(
             x => x.UploadBlobAsync(reference.Path, stream, It.IsAny<CancellationToken>()),
             Times.Once);
+
+        // Teardown
+        await stream.DisposeAsync();
     }
 
     [Fact]

--- a/source/Tests/BuildingBlocks/FileStorageClient/DataLakeFileStorageClientTests.cs
+++ b/source/Tests/BuildingBlocks/FileStorageClient/DataLakeFileStorageClientTests.cs
@@ -68,6 +68,10 @@ public class DataLakeFileStorageClientTests
         // Act
         await sut.UploadAsync(reference, stream);
 
+        // Teardown
+        await stream.DisposeAsync();
+        await writer.DisposeAsync();
+
         // Assert
         _blobContainerClientObsoletedMock.Verify(
             x => x.UploadBlobAsync(reference.Path, stream, It.IsAny<CancellationToken>()),
@@ -79,6 +83,7 @@ public class DataLakeFileStorageClientTests
 
         // Teardown
         await stream.DisposeAsync();
+        await writer.DisposeAsync();
     }
 
     [Fact]
@@ -107,6 +112,7 @@ public class DataLakeFileStorageClientTests
 
         // Teardown
         await stream.DisposeAsync();
+        await writer.DisposeAsync();
     }
 
     [Fact]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

## References
- infra: https://github.com/Energinet-DataHub/dh3-infrastructure/pull/2793

## Checklist
- [x] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) https://github.com/Energinet-DataHub/dh3-environments/actions/runs/12949817090
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task