### PR TITLE
feat: Add actor identification to MeteredDataForMeteringPointMessageInputV1

### DIFF
--- a/source/B2BApi.AppTests/B2BApi.AppTests.csproj
+++ b/source/B2BApi.AppTests/B2BApi.AppTests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="7.1.1" />
     <PackageReference Include="Energinet.DataHub.ProcessManager.Abstractions" Version="0.25.1" />
-      <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="0.17.1" />
+    <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="0.18.0-alpha-91"/>
     <PackageReference Include="Energinet.DataHub.Wholesale.Contracts" Version="11.0.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
       <PrivateAssets>all</PrivateAssets>

--- a/source/B2BApi/B2BApi.csproj
+++ b/source/B2BApi/B2BApi.csproj
@@ -25,7 +25,6 @@ limitations under the License.
     <ItemGroup>
         <PackageReference Include="Energinet.DataHub.Core.Databricks.SqlStatementExecution" Version="12.0.0" />
         <PackageReference Include="Energinet.DataHub.Core.Outbox" Version="1.0.1" />
-        <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="0.17.3" />
         <PackageReference Include="Energinet.DataHub.ProcessManager.Abstractions" Version="0.25.1" />
         <PackageReference Include="Energinet.DataHub.ProcessManager.Client" Version="0.25.1" />
         <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="0.18.0"/>

--- a/source/B2BApi/B2BApi.csproj
+++ b/source/B2BApi/B2BApi.csproj
@@ -27,7 +27,7 @@ limitations under the License.
         <PackageReference Include="Energinet.DataHub.Core.Outbox" Version="1.0.1" />
         <PackageReference Include="Energinet.DataHub.ProcessManager.Abstractions" Version="0.25.1" />
         <PackageReference Include="Energinet.DataHub.ProcessManager.Client" Version="0.25.1" />
-        <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="0.17.1" />
+        <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="0.18.0-alpha-91"/>
         <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.2.1" />
         <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />

--- a/source/B2CWebApi.AppTests/B2CWebApi.AppTests.csproj
+++ b/source/B2CWebApi.AppTests/B2CWebApi.AppTests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="6.1.1" />
         <PackageReference Include="Energinet.DataHub.ProcessManager.Abstractions" Version="0.25.1" />
-        <PackageReference Include="Energinet.DataHub.ProcessManager.Client" Version="0.25.1" />
+        <PackageReference Include="Energinet.DataHub.ProcessManager.Client" Version="0.25.1"/>
         <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/B2CWebApi.AppTests/B2CWebApi.AppTests.csproj
+++ b/source/B2CWebApi.AppTests/B2CWebApi.AppTests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Energinet.DataHub.Core.Messaging" Version="6.1.1" />
         <PackageReference Include="Energinet.DataHub.ProcessManager.Abstractions" Version="0.25.1" />
-        <PackageReference Include="Energinet.DataHub.ProcessManager.Client" Version="0.25.1"/>
+        <PackageReference Include="Energinet.DataHub.ProcessManager.Client" Version="0.25.1" />
         <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/IncomingMessages.Infrastructure/IncomingMessages.Infrastructure.csproj
+++ b/source/IncomingMessages.Infrastructure/IncomingMessages.Infrastructure.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.ProcessManager.Abstractions" Version="0.25.1" />
     <PackageReference Include="Energinet.DataHub.ProcessManager.Client" Version="0.25.1" />
-    <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="0.17.1" />
+    <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="0.18.0-alpha-91"/>
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.9.0" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19">

--- a/source/IncomingMessages.Infrastructure/ProcessManager/MeteredDataOrchestrationStarter.cs
+++ b/source/IncomingMessages.Infrastructure/ProcessManager/MeteredDataOrchestrationStarter.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Authentication;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.Process.Interfaces;
@@ -23,6 +24,10 @@ using NodaTime.Text;
 
 namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.ProcessManager;
 
+[SuppressMessage(
+    "StyleCop.CSharp.ReadabilityRules",
+    "SA1118:Parameter should not span multiple lines",
+    Justification = "Needed for inline ebix exception")]
 public class MeteredDataOrchestrationStarter(IProcessManagerMessageClient processManagerMessageClient, AuthenticatedActor authenticatedActor)
 {
     private readonly IProcessManagerMessageClient _processManagerMessageClient = processManagerMessageClient;
@@ -32,8 +37,11 @@ public class MeteredDataOrchestrationStarter(IProcessManagerMessageClient proces
         InitializeMeteredDataForMeteringPointMessageProcessDto initializeProcessDto,
         CancellationToken cancellationToken)
     {
-        var actorId = GetAuthenticatedActorId(initializeProcessDto.MessageId);
-        var actorIdentity = new ActorIdentityDto(actorId);
+        var actorIdentity = GetAuthenticatedActorId(initializeProcessDto.MessageId);
+        var actorIdentityDto = new ActorIdentityDto(
+            actorIdentity.ActorId
+            ?? throw new InvalidOperationException(
+                $"Current actor id was null when initializing process (MessageId={initializeProcessDto.MessageId})"));
 
         var startProcessTasks = new List<Task>();
         foreach (var transaction in initializeProcessDto.Series)
@@ -56,15 +64,20 @@ public class MeteredDataOrchestrationStarter(IProcessManagerMessageClient proces
 
             var startCommand =
                 new StartForwardMeteredDataCommandV1(
-                    operatingIdentity: actorIdentity,
+                    operatingIdentity: actorIdentityDto,
                     new MeteredDataForMeteringPointMessageInputV1(
-                        AuthenticatedActorId: actorId,
+                        AuthenticatedActorId: actorIdentity.ActorId.Value,
+                        ActorNumber: actorIdentity.ActorNumber.Value,
+                        ActorRole: actorIdentity.ActorRole.Code,
                         TransactionId: transaction.TransactionId,
                         MeteringPointId: transaction.MeteringPointLocationId,
                         MeteringPointType: meteringPointType,
                         ProductNumber: transaction.ProductNumber,
                         MeasureUnit: productUnitType,
-                        RegistrationDateTime: registeredAt ?? throw new ArgumentNullException("RegistrationDateTime is only allowed to be null in Ebix."),
+                        RegistrationDateTime: registeredAt
+                                              ?? throw new ArgumentNullException(
+                                                  nameof(transaction.RegisteredAt),
+                                                  "RegistrationDateTime is only allowed to be null in Ebix."),
                         Resolution: resolution,
                         StartDateTime: transaction.StartDateTime,
                         EndDateTime: transaction.EndDateTime,
@@ -88,12 +101,11 @@ public class MeteredDataOrchestrationStarter(IProcessManagerMessageClient proces
         await Task.WhenAll(startProcessTasks).ConfigureAwait(false);
     }
 
-    private Guid GetAuthenticatedActorId(string messageId)
-    {
-        if (!_authenticatedActor.TryGetCurrentActorIdentity(out var actorIdentity))
-            throw new InvalidOperationException($"Cannot get current actor when initializing process (MessageId={messageId})");
-
-        return actorIdentity?.ActorId
-               ?? throw new InvalidOperationException($"Current actor id was null when initializing process (MessageId={messageId})");
-    }
+    private ActorIdentity GetAuthenticatedActorId(string messageId) =>
+        !_authenticatedActor.TryGetCurrentActorIdentity(out var actorIdentity)
+            ? throw new InvalidOperationException(
+                $"Cannot get current actor when initializing process (MessageId={messageId})")
+            : actorIdentity
+              ?? throw new InvalidOperationException(
+                  $"Current actor id was null when initializing process (MessageId={messageId})");
 }

--- a/source/Tests/Infrastructure/IncomingMessages/RequestProcessOrchestrationStarterTests.cs
+++ b/source/Tests/Infrastructure/IncomingMessages/RequestProcessOrchestrationStarterTests.cs
@@ -357,6 +357,8 @@ public class RequestProcessOrchestrationStarterTests
             operatingIdentity: new ActorIdentityDto(expectedActorId),
             inputParameter: new MeteredDataForMeteringPointMessageInputV1(
                 AuthenticatedActorId: expectedActorId,
+                ActorNumber: requestedByActor.ActorNumber.Value,
+                ActorRole: requestedByActor.ActorRole.Code,
                 TransactionId: transactionId,
                 MeteringPointId: expectedMeteringPointId,
                 MeteringPointType: meteringPointType?.Name,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Add actor number and role to BRS-021 input for the PM.

## References

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/490

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task