### PR TITLE
feat: log if DataLakeFileStorageClient uses obsolete blobclient

### DIFF
--- a/source/BuildingBlocks.Infrastructure/DataLakeFileStorageClient.cs
+++ b/source/BuildingBlocks.Infrastructure/DataLakeFileStorageClient.cs
@@ -89,7 +89,7 @@ public class DataLakeFileStorageClient : IFileStorageClient
         if (blobExists == null || blobExists is { Value: false })
         {
             // This logging is only temporary while we verify data migration is successful.
-            _logger.LogInformation($"Blob does not exist in the new storage account, trying the obsoleted storage account. Category {reference.Category.Value}, Path {reference.Path}");
+            _logger.LogInformation("Blob does not exist in the new storage account, trying the obsoleted storage account. Category {Category}, Path {Path}", reference.Category.Value, reference.Path);
             var containerObsoleted = _blobServiceClientObsoleted.GetBlobContainerClient(reference.Category.Value);
             blob = containerObsoleted.GetBlobClient(reference.Path);
         }

--- a/source/BuildingBlocks.Infrastructure/DataLakeFileStorageClient.cs
+++ b/source/BuildingBlocks.Infrastructure/DataLakeFileStorageClient.cs
@@ -21,6 +21,7 @@ using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration.Options;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.FeatureFlag;
 using Energinet.DataHub.EDI.BuildingBlocks.Interfaces;
 using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Text;
@@ -30,15 +31,18 @@ namespace Energinet.DataHub.EDI.BuildingBlocks.Infrastructure;
 public class DataLakeFileStorageClient : IFileStorageClient
 {
     private readonly IFeatureFlagManager _featureFlagManager;
+    private readonly ILogger<DataLakeFileStorageClient> _logger;
     private readonly BlobServiceClient _blobServiceClientObsoleted;
     private readonly BlobServiceClient _blobServiceClient;
 
     public DataLakeFileStorageClient(
         IAzureClientFactory<BlobServiceClient> clientFactory,
         IOptions<BlobServiceClientConnectionOptions> options,
-        IFeatureFlagManager featureFlagManager)
+        IFeatureFlagManager featureFlagManager,
+        ILogger<DataLakeFileStorageClient> logger)
     {
         _featureFlagManager = featureFlagManager;
+        _logger = logger;
         _blobServiceClientObsoleted = clientFactory.CreateClient(options.Value.ClientNameObsoleted);
         _blobServiceClient = clientFactory.CreateClient(options.Value.ClientName);
     }
@@ -84,6 +88,8 @@ public class DataLakeFileStorageClient : IFileStorageClient
         var blobExists = await blob.ExistsAsync(cancellationToken).ConfigureAwait(false);
         if (blobExists == null || blobExists is { Value: false })
         {
+            // This logging is only temporary while we verify data migration is successful.
+            _logger.LogInformation($"Blob does not exist in the new storage account, trying the obsoleted storage account. Category {reference.Category.Value}, Path {reference.Path}");
             var containerObsoleted = _blobServiceClientObsoleted.GetBlobContainerClient(reference.Category.Value);
             blob = containerObsoleted.GetBlobClient(reference.Path);
         }

--- a/source/Tests/BuildingBlocks/FileStorageClient/DataLakeFileStorageClientTests.cs
+++ b/source/Tests/BuildingBlocks/FileStorageClient/DataLakeFileStorageClientTests.cs
@@ -20,6 +20,7 @@ using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.Configuration.Options;
 using Energinet.DataHub.EDI.BuildingBlocks.Infrastructure.FeatureFlag;
 using Energinet.DataHub.EDI.BuildingBlocks.Tests.TestDoubles;
 using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -43,7 +44,7 @@ public class DataLakeFileStorageClientTests
         featureFlagManager
             .Setup(x => x.UseStandardBlobServiceClientAsync())
             .ReturnsAsync(true);
-        _sut = new DataLakeFileStorageClient(clientFactoryMock.Object, options, featureFlagManager.Object);
+        _sut = new DataLakeFileStorageClient(clientFactoryMock.Object, options, featureFlagManager.Object, new Mock<ILogger<DataLakeFileStorageClient>>().Object);
     }
 
     [Fact]
@@ -63,7 +64,7 @@ public class DataLakeFileStorageClientTests
             .Setup(x => x.UseStandardBlobServiceClientAsync())
             .ReturnsAsync(false);
 
-        var sut = new DataLakeFileStorageClient(GetClientFactoryMock(GetOptions()).Object, GetOptions(), featureFlagManager.Object);
+        var sut = new DataLakeFileStorageClient(GetClientFactoryMock(GetOptions()).Object, GetOptions(), featureFlagManager.Object, new Mock<ILogger<DataLakeFileStorageClient>>().Object);
 
         // Act
         await sut.UploadAsync(reference, stream);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
This logging is to help ensure that the migration of the obsolete document storage is succesful, will be removed when we have verified the migration and the `DataLakeFileStorageClient` is cleaned up.

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task