### PR TITLE
refac: DataHubNames constants

### DIFF
--- a/source/B2BApi/Functions/EnqueueMessages/BRS_026/EnqueueHandler_Brs_026_V1.cs
+++ b/source/B2BApi/Functions/EnqueueMessages/BRS_026/EnqueueHandler_Brs_026_V1.cs
@@ -191,20 +191,20 @@ public class EnqueueHandler_Brs_026_V1(
 
     private static CalculationType MapCalculationType(string businessReason, string? settlementVersion)
     {
-        if (businessReason != DataHubNames.BusinessReason.Correction && settlementVersion != null)
+        if (businessReason == BusinessReason.Correction.Name && settlementVersion != null)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(settlementVersion),
                 settlementVersion,
-                $"Value must be null when {nameof(businessReason)} is not {nameof(DataHubNames.BusinessReason.Correction)}.");
+                $"Value must be null when {nameof(businessReason)} is not {nameof(BusinessReason.Correction.Name)}.");
         }
 
         return businessReason switch
         {
-            DataHubNames.BusinessReason.BalanceFixing => CalculationType.BalanceFixing,
-            DataHubNames.BusinessReason.PreliminaryAggregation => CalculationType.Aggregation,
-            DataHubNames.BusinessReason.WholesaleFixing => CalculationType.WholesaleFixing,
-            DataHubNames.BusinessReason.Correction => settlementVersion switch
+            _ when businessReason == BusinessReason.BalanceFixing.Name => CalculationType.BalanceFixing,
+            _ when businessReason == BusinessReason.PreliminaryAggregation.Name => CalculationType.Aggregation,
+            _ when businessReason == BusinessReason.WholesaleFixing.Name => CalculationType.WholesaleFixing,
+            _ when businessReason == BusinessReason.Correction.Name => settlementVersion switch
             {
                 DataHubNames.SettlementVersion.FirstCorrection => CalculationType.FirstCorrectionSettlement,
                 DataHubNames.SettlementVersion.SecondCorrection => CalculationType.SecondCorrectionSettlement,

--- a/source/B2BApi/Functions/EnqueueMessages/BRS_026/EnqueueHandler_Brs_026_V1.cs
+++ b/source/B2BApi/Functions/EnqueueMessages/BRS_026/EnqueueHandler_Brs_026_V1.cs
@@ -225,9 +225,9 @@ public class EnqueueHandler_Brs_026_V1(
     {
         return meteringPointType switch
         {
-            DataHubNames.MeteringPointType.Production => TimeSeriesType.Production,
-            DataHubNames.MeteringPointType.Exchange => TimeSeriesType.NetExchangePerGa,
-            DataHubNames.MeteringPointType.Consumption => settlementMethod switch
+            _ when meteringPointType == MeteringPointType.Production.Name => TimeSeriesType.Production,
+            _ when meteringPointType == MeteringPointType.Exchange.Name => TimeSeriesType.NetExchangePerGa,
+            _ when meteringPointType == MeteringPointType.Consumption.Name => settlementMethod switch
             {
                 DataHubNames.SettlementMethod.NonProfiled => TimeSeriesType.NonProfiledConsumption,
                 DataHubNames.SettlementMethod.Flex => TimeSeriesType.FlexConsumption,

--- a/source/BuildingBlocks.Domain/DataHub/DataHubNames.cs
+++ b/source/BuildingBlocks.Domain/DataHub/DataHubNames.cs
@@ -27,14 +27,6 @@ namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
 [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Keep names in a single file to easily share with Wholesale")]
 public static class DataHubNames
 {
-    // TODO: Obsolete now that we get the name from PM.Components.Abstractions
-    public static class ChargeType
-    {
-        public const string Subscription = "Subscription";
-        public const string Fee = "Fee";
-        public const string Tariff = "Tariff";
-    }
-
     public static class Currency
     {
         public const string DanishCrowns = "DanishCrowns";

--- a/source/BuildingBlocks.Domain/DataHub/DataHubNames.cs
+++ b/source/BuildingBlocks.Domain/DataHub/DataHubNames.cs
@@ -28,18 +28,6 @@ namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
 public static class DataHubNames
 {
     // TODO: Obsolete now that we get the name from PM.Components.Abstractions
-    public static class BusinessReason
-    {
-        public const string MoveIn = "MoveIn";
-        public const string BalanceFixing = "BalanceFixing";
-        public const string PreliminaryAggregation = "PreliminaryAggregation";
-        public const string WholesaleFixing = "WholesaleFixing";
-        public const string Correction = "Correction";
-        public const string PeriodicMetering = "PeriodicMetering";
-        public const string PeriodicFlexMetering = "PeriodicFlexMetering";
-    }
-
-    // TODO: Obsolete now that we get the name from PM.Components.Abstractions
     public static class ChargeType
     {
         public const string Subscription = "Subscription";

--- a/source/BuildingBlocks.Domain/DataHub/DataHubNames.cs
+++ b/source/BuildingBlocks.Domain/DataHub/DataHubNames.cs
@@ -33,15 +33,6 @@ public static class DataHubNames
     }
 
     // TODO: Obsolete now that we get the name from PM.Components.Abstractions
-    public static class Resolution
-    {
-        public const string QuarterHourly = "QuarterHourly";
-        public const string Hourly = "Hourly";
-        public const string Daily = "Daily";
-        public const string Monthly = "Monthly";
-    }
-
-    // TODO: Obsolete now that we get the name from PM.Components.Abstractions
     public static class SettlementMethod
     {
         public const string NonProfiled = "NonProfiled";

--- a/source/BuildingBlocks.Domain/DataHub/DataHubNames.cs
+++ b/source/BuildingBlocks.Domain/DataHub/DataHubNames.cs
@@ -53,21 +53,6 @@ public static class DataHubNames
     }
 
     // TODO: Obsolete now that we get the name from PM.Components.Abstractions
-    public static class MeasurementUnit
-    {
-        public const string Kwh = "Kwh";
-        public const string Pieces = "Pieces";
-    }
-
-    // TODO: Obsolete now that we get the name from PM.Components.Abstractions
-    public static class MeteringPointType
-    {
-        public const string Consumption = "Consumption";
-        public const string Production = "Production";
-        public const string Exchange = "Exchange";
-    }
-
-    // TODO: Obsolete now that we get the name from PM.Components.Abstractions
     public static class Resolution
     {
         public const string QuarterHourly = "QuarterHourly";

--- a/source/Edi.UnitTests/Builders/AggregatedTimeSeriesRequestBuilder.cs
+++ b/source/Edi.UnitTests/Builders/AggregatedTimeSeriesRequestBuilder.cs
@@ -42,7 +42,7 @@ public class AggregatedTimeSeriesRequestBuilder
         _requestedByActorRole = DataHubNames.ActorRole.EnergySupplier;
         _requestedByActorNumber = EnergySupplierValidatorTest.ValidGlnNumber;
         _energySupplierId = _requestedByActorNumber;
-        _businessReason = DataHubNames.BusinessReason.BalanceFixing;
+        _businessReason = BusinessReason.BalanceFixing.Name;
     }
 
     public static AggregatedTimeSeriesRequestBuilder AggregatedTimeSeriesRequest()

--- a/source/Edi.UnitTests/Builders/AggregatedTimeSeriesRequestBuilder.cs
+++ b/source/Edi.UnitTests/Builders/AggregatedTimeSeriesRequestBuilder.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Validators.AggregatedTimeSeriesRequest;
 using NodaTime;
 using AggregatedTimeSeriesRequest = Energinet.DataHub.Edi.Requests.AggregatedTimeSeriesRequest;
@@ -22,7 +23,7 @@ namespace Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
 public class AggregatedTimeSeriesRequestBuilder
 {
     private readonly List<string> _gridAreaCodes = [];
-    private string? _meteringPointType = DataHubNames.MeteringPointType.Production;
+    private string? _meteringPointType = MeteringPointType.Production.Name;
     private string _start;
     private string _end;
     private string? _energySupplierId;

--- a/source/Edi.UnitTests/Builders/WholesaleServicesRequestBuilder.cs
+++ b/source/Edi.UnitTests/Builders/WholesaleServicesRequestBuilder.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Validators.AggregatedTimeSeriesRequest;
 using NodaTime;
 using ChargeType = Energinet.DataHub.Edi.Requests.ChargeType;
@@ -24,7 +25,7 @@ public class WholesaleServicesRequestBuilder
 {
     private string _requestedByActorId = EnergySupplierValidatorTest.ValidGlnNumber;
     private string _requestedByActorRole = DataHubNames.ActorRole.SystemOperator;
-    private string _businessReason = DataHubNames.BusinessReason.WholesaleFixing;
+    private string _businessReason = BusinessReason.WholesaleFixing.Name;
     private string? _resolution;
     private string _periodStart = Instant.FromUtc(2023, 1, 31, 23, 0, 0).ToString();
     private string? _periodEnd = Instant.FromUtc(2023, 2, 28, 23, 0, 0).ToString();

--- a/source/Edi.UnitTests/Factories/AggregatedTimeSeries/AggregatedTimeSeriesRequestFactoryTests.cs
+++ b/source/Edi.UnitTests/Factories/AggregatedTimeSeries/AggregatedTimeSeriesRequestFactoryTests.cs
@@ -250,7 +250,7 @@ public class AggregatedTimeSeriesRequestFactoryTests
             },
             RequestedForActorNumber = "1234567891234",
             RequestedForActorRole = DataHubNames.ActorRole.EnergySupplier,
-            BusinessReason = DataHubNames.BusinessReason.BalanceFixing,
+            BusinessReason = BusinessReason.BalanceFixing.Name,
 
             // Optional
             SettlementMethod = settlementMethod,

--- a/source/Edi.UnitTests/Factories/AggregatedTimeSeries/AggregatedTimeSeriesRequestFactoryTests.cs
+++ b/source/Edi.UnitTests/Factories/AggregatedTimeSeries/AggregatedTimeSeriesRequestFactoryTests.cs
@@ -36,7 +36,8 @@ public class AggregatedTimeSeriesRequestFactoryTests
             gridAreaCodes: [],
             energySupplier: energySupplier,
             balanceResponsible: balanceResponsibleId,
-            meteringPointType: MeteringPointType.Production.Name);
+            meteringPointType: MeteringPointType.Production.Name,
+            settlementMethod: SettlementMethod.Flex.Name);
 
         // Act
         var actual = AggregatedTimeSeriesRequestFactory.Parse(request);
@@ -61,7 +62,8 @@ public class AggregatedTimeSeriesRequestFactoryTests
             gridAreaCodes: [gridAreaCode],
             energySupplier: energySupplier,
             balanceResponsible: balanceResponsibleId,
-            meteringPointType: MeteringPointType.Production.Name);
+            meteringPointType: MeteringPointType.Production.Name,
+            settlementMethod: SettlementMethod.Flex.Name);
 
         // Act
         var actual = AggregatedTimeSeriesRequestFactory.Parse(request);
@@ -86,7 +88,8 @@ public class AggregatedTimeSeriesRequestFactoryTests
             gridAreaCodes: [gridAreaCode],
             energySupplier: energySupplier,
             balanceResponsible: balanceResponsibleId,
-            meteringPointType: MeteringPointType.Production.Name);
+            meteringPointType: MeteringPointType.Production.Name,
+            settlementMethod: SettlementMethod.Flex.Name);
 
         // Act
         var actual = AggregatedTimeSeriesRequestFactory.Parse(request);
@@ -238,7 +241,7 @@ public class AggregatedTimeSeriesRequestFactoryTests
         string? energySupplier,
         string? balanceResponsible,
         string? meteringPointType,
-        string? settlementMethod = DataHubNames.SettlementMethod.Flex)
+        string? settlementMethod)
     {
         var request = new AggregatedTimeSeriesRequest()
         {

--- a/source/Edi.UnitTests/Factories/AggregatedTimeSeries/AggregatedTimeSeriesRequestFactoryTests.cs
+++ b/source/Edi.UnitTests/Factories/AggregatedTimeSeries/AggregatedTimeSeriesRequestFactoryTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.Factories.AggregatedTimeSeries;
 using Energinet.DataHub.Wholesale.Edi.Models;
 using FluentAssertions;
@@ -35,7 +36,7 @@ public class AggregatedTimeSeriesRequestFactoryTests
             gridAreaCodes: [],
             energySupplier: energySupplier,
             balanceResponsible: balanceResponsibleId,
-            meteringPointType: DataHubNames.MeteringPointType.Production);
+            meteringPointType: MeteringPointType.Production.Name);
 
         // Act
         var actual = AggregatedTimeSeriesRequestFactory.Parse(request);
@@ -59,7 +60,8 @@ public class AggregatedTimeSeriesRequestFactoryTests
         var request = CreateRequest(
             gridAreaCodes: [gridAreaCode],
             energySupplier: energySupplier,
-            balanceResponsible: balanceResponsibleId);
+            balanceResponsible: balanceResponsibleId,
+            meteringPointType: MeteringPointType.Production.Name);
 
         // Act
         var actual = AggregatedTimeSeriesRequestFactory.Parse(request);
@@ -83,7 +85,8 @@ public class AggregatedTimeSeriesRequestFactoryTests
         var request = CreateRequest(
             gridAreaCodes: [gridAreaCode],
             energySupplier: energySupplier,
-            balanceResponsible: balanceResponsibleId);
+            balanceResponsible: balanceResponsibleId,
+            meteringPointType: MeteringPointType.Production.Name);
 
         // Act
         var actual = AggregatedTimeSeriesRequestFactory.Parse(request);
@@ -234,7 +237,7 @@ public class AggregatedTimeSeriesRequestFactoryTests
         IReadOnlyCollection<string> gridAreaCodes,
         string? energySupplier,
         string? balanceResponsible,
-        string? meteringPointType = DataHubNames.MeteringPointType.Production,
+        string? meteringPointType,
         string? settlementMethod = DataHubNames.SettlementMethod.Flex)
     {
         var request = new AggregatedTimeSeriesRequest()

--- a/source/Edi.UnitTests/Mappers/ChargeTypeMapperTests.cs
+++ b/source/Edi.UnitTests/Mappers/ChargeTypeMapperTests.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.Mappers;
 using FluentAssertions;
 using Xunit;
@@ -21,10 +21,15 @@ namespace Energinet.DataHub.Wholesale.Edi.UnitTests.Mappers;
 
 public class ChargeTypeMapperTests
 {
+    public static IEnumerable<object[]> GetChargeTypeTestData()
+    {
+        yield return [ChargeType.Tariff.Name, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.ChargeType.Tariff];
+        yield return [ChargeType.Fee.Name, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.ChargeType.Fee];
+        yield return [ChargeType.Subscription.Name, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.ChargeType.Subscription];
+    }
+
     [Theory]
-    [InlineData(DataHubNames.ChargeType.Tariff, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.ChargeType.Tariff)]
-    [InlineData(DataHubNames.ChargeType.Fee, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.ChargeType.Fee)]
-    [InlineData(DataHubNames.ChargeType.Subscription, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.ChargeType.Subscription)]
+    [MemberData(nameof(GetChargeTypeTestData))]
     public void Map_WhenValid_ReturnsExpectedChargeType(string chargeType, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.ChargeType expectedResult)
     {
         // Act

--- a/source/Edi.UnitTests/Mappers/RequestedCalculationTypeMapperTests.cs
+++ b/source/Edi.UnitTests/Mappers/RequestedCalculationTypeMapperTests.cs
@@ -40,12 +40,9 @@ public class RequestedCalculationTypeMapperTests
         yield return [BusinessReason.BalanceFixing.Name, null!, RequestedCalculationType.BalanceFixing];
         yield return [BusinessReason.PreliminaryAggregation.Name, null!, RequestedCalculationType.PreliminaryAggregation];
         yield return [BusinessReason.WholesaleFixing.Name, null!, RequestedCalculationType.WholesaleFixing];
-        yield return [BusinessReason.Correction.Name, DataHubNames.SettlementVersion.FirstCorrection, RequestedCalculationType.FirstCorrection,
-        ];
-        yield return [BusinessReason.Correction.Name, DataHubNames.SettlementVersion.SecondCorrection, RequestedCalculationType.SecondCorrection,
-        ];
-        yield return [BusinessReason.Correction.Name, DataHubNames.SettlementVersion.ThirdCorrection, RequestedCalculationType.ThirdCorrection,
-        ];
+        yield return [BusinessReason.Correction.Name, DataHubNames.SettlementVersion.FirstCorrection, RequestedCalculationType.FirstCorrection];
+        yield return [BusinessReason.Correction.Name, DataHubNames.SettlementVersion.SecondCorrection, RequestedCalculationType.SecondCorrection];
+        yield return [BusinessReason.Correction.Name, DataHubNames.SettlementVersion.ThirdCorrection, RequestedCalculationType.ThirdCorrection];
         yield return [BusinessReason.Correction.Name, null!, RequestedCalculationType.LatestCorrection];
     }
 

--- a/source/Edi.UnitTests/Mappers/RequestedCalculationTypeMapperTests.cs
+++ b/source/Edi.UnitTests/Mappers/RequestedCalculationTypeMapperTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.Mappers;
 using Energinet.DataHub.Wholesale.Edi.Models;
 using FluentAssertions;
@@ -22,14 +23,34 @@ namespace Energinet.DataHub.Wholesale.Edi.UnitTests.Mappers;
 
 public class RequestedCalculationTypeMapperTests
 {
+    public static IEnumerable<object[]> InvalidBusinessReasonAndSettlementVersionData()
+    {
+        yield return [BusinessReason.BalanceFixing.Name, DataHubNames.SettlementVersion.FirstCorrection];
+        yield return [BusinessReason.PreliminaryAggregation.Name, "random-string"];
+        yield return [BusinessReason.WholesaleFixing.Name, DataHubNames.SettlementVersion.FirstCorrection];
+        yield return [BusinessReason.Correction.Name, string.Empty];
+        yield return [BusinessReason.Correction.Name, "random-string"];
+        yield return [string.Empty, string.Empty];
+        yield return ["random-string", string.Empty];
+        yield return ["random-string", DataHubNames.SettlementVersion.FirstCorrection];
+    }
+
+    public static IEnumerable<object[]> ValidBusinessReasonAndSettlementVersionData()
+    {
+        yield return [BusinessReason.BalanceFixing.Name, null!, RequestedCalculationType.BalanceFixing];
+        yield return [BusinessReason.PreliminaryAggregation.Name, null!, RequestedCalculationType.PreliminaryAggregation];
+        yield return [BusinessReason.WholesaleFixing.Name, null!, RequestedCalculationType.WholesaleFixing];
+        yield return [BusinessReason.Correction.Name, DataHubNames.SettlementVersion.FirstCorrection, RequestedCalculationType.FirstCorrection,
+        ];
+        yield return [BusinessReason.Correction.Name, DataHubNames.SettlementVersion.SecondCorrection, RequestedCalculationType.SecondCorrection,
+        ];
+        yield return [BusinessReason.Correction.Name, DataHubNames.SettlementVersion.ThirdCorrection, RequestedCalculationType.ThirdCorrection,
+        ];
+        yield return [BusinessReason.Correction.Name, null!, RequestedCalculationType.LatestCorrection];
+    }
+
     [Theory]
-    [InlineData(DataHubNames.BusinessReason.BalanceFixing, null, RequestedCalculationType.BalanceFixing)]
-    [InlineData(DataHubNames.BusinessReason.PreliminaryAggregation, null, RequestedCalculationType.PreliminaryAggregation)]
-    [InlineData(DataHubNames.BusinessReason.WholesaleFixing, null, RequestedCalculationType.WholesaleFixing)]
-    [InlineData(DataHubNames.BusinessReason.Correction, DataHubNames.SettlementVersion.FirstCorrection, RequestedCalculationType.FirstCorrection)]
-    [InlineData(DataHubNames.BusinessReason.Correction, DataHubNames.SettlementVersion.SecondCorrection, RequestedCalculationType.SecondCorrection)]
-    [InlineData(DataHubNames.BusinessReason.Correction, DataHubNames.SettlementVersion.ThirdCorrection, RequestedCalculationType.ThirdCorrection)]
-    [InlineData(DataHubNames.BusinessReason.Correction, null, RequestedCalculationType.LatestCorrection)]
+    [MemberData(nameof(ValidBusinessReasonAndSettlementVersionData))]
     public void ToRequestedCalculationType_WhenValidBusinessReasonAndSettlementVersion_ReturnsExpectedType(string businessReason, string? settlementVersion, RequestedCalculationType expectedType)
     {
         // Act
@@ -40,14 +61,7 @@ public class RequestedCalculationTypeMapperTests
     }
 
     [Theory]
-    [InlineData(DataHubNames.BusinessReason.BalanceFixing, DataHubNames.SettlementVersion.FirstCorrection)]
-    [InlineData(DataHubNames.BusinessReason.PreliminaryAggregation, "random-string")]
-    [InlineData(DataHubNames.BusinessReason.WholesaleFixing, DataHubNames.SettlementVersion.FirstCorrection)]
-    [InlineData(DataHubNames.BusinessReason.Correction, "")]
-    [InlineData(DataHubNames.BusinessReason.Correction, "random-string")]
-    [InlineData("", "")]
-    [InlineData("random-string", "")]
-    [InlineData("random-string", DataHubNames.SettlementVersion.FirstCorrection)]
+    [MemberData(nameof(InvalidBusinessReasonAndSettlementVersionData))]
     public void ToRequestedCalculationType_WhenInvalidBusinessReasonAndSettlementVersionCombination_ThrowsArgumentOutOfRangeException(string businessReason, string? settlementVersion)
     {
         // Act

--- a/source/Edi.UnitTests/Mappers/ResolutionMapperTests.cs
+++ b/source/Edi.UnitTests/Mappers/ResolutionMapperTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.Mappers;
 using FluentAssertions;
 using Xunit;
@@ -21,10 +22,15 @@ namespace Energinet.DataHub.Wholesale.Edi.UnitTests.Mappers;
 
 public class ResolutionMapperTests
 {
+    public static IEnumerable<object[]> GetValidResolutions()
+    {
+        yield return [Resolution.Monthly.Name, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.Resolution.Month];
+        yield return [Resolution.Hourly.Name, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.Resolution.Hour];
+        yield return [Resolution.Daily.Name, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.Resolution.Day];
+    }
+
     [Theory]
-    [InlineData(DataHubNames.Resolution.Monthly, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.Resolution.Month)]
-    [InlineData(DataHubNames.Resolution.Hourly, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.Resolution.Hour)]
-    [InlineData(DataHubNames.Resolution.Daily, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.Resolution.Day)]
+    [MemberData(nameof(GetValidResolutions))]
     public void Map_WhenValid_ReturnsExpectedChargeType(string resolution, DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.WholesaleResults.Resolution expectedResult)
     {
         // Act

--- a/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/AggregatedTimeSeriesRequestValidatorTests.cs
+++ b/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/AggregatedTimeSeriesRequestValidatorTests.cs
@@ -128,7 +128,7 @@ public class AggregatedTimeSeriesRequestValidatorTests : EdiTestBase
         // Arrange
         var request = AggregatedTimeSeriesRequestBuilder
             .AggregatedTimeSeriesRequest()
-            .WithBusinessReason(DataHubNames.BusinessReason.Correction)
+            .WithBusinessReason(BusinessReason.Correction.Name)
             .WithSettlementVersion("invalid-settlement-version")
             .Build();
 

--- a/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/AggregatedTimeSeriesRequestValidatorTests.cs
+++ b/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/AggregatedTimeSeriesRequestValidatorTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
 using Energinet.DataHub.Wholesale.Edi.Validation;
 using FluentAssertions;
@@ -145,7 +146,7 @@ public class AggregatedTimeSeriesRequestValidatorTests : EdiTestBase
         // Arrange
         var request = AggregatedTimeSeriesRequestBuilder
             .AggregatedTimeSeriesRequest()
-            .WithMeteringPointType(DataHubNames.MeteringPointType.Consumption)
+            .WithMeteringPointType(MeteringPointType.Consumption.Name)
             .WithSettlementMethod(null)
             .WithRequestedByActorId(EnergySupplierValidatorTest.ValidGlnNumber)
             .WithRequestedByActorRole(DataHubNames.ActorRole.EnergySupplier)

--- a/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/BalanceResponsibleValidatorTest.cs
+++ b/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/BalanceResponsibleValidatorTest.cs
@@ -14,6 +14,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
 using Energinet.DataHub.Wholesale.Edi.Validation;
 using Energinet.DataHub.Wholesale.Edi.Validation.AggregatedTimeSeriesRequest.Rules;
@@ -163,7 +164,7 @@ public class BalanceResponsibleValidatorTest
             .WithRequestedByActorId(ValidGlnNumber)
             .WithRequestedByActorRole(BalanceResponsibleRole)
             .WithBalanceResponsibleId(ValidGlnNumber)
-            .WithBusinessReason(DataHubNames.BusinessReason.BalanceFixing)
+            .WithBusinessReason(BusinessReason.BalanceFixing.Name)
             .Build();
 
         // Act
@@ -182,7 +183,7 @@ public class BalanceResponsibleValidatorTest
             .WithRequestedByActorId(ValidGlnNumber)
             .WithRequestedByActorRole(BalanceResponsibleRole)
             .WithBalanceResponsibleId(ValidGlnNumber)
-            .WithBusinessReason(DataHubNames.BusinessReason.PreliminaryAggregation)
+            .WithBusinessReason(BusinessReason.PreliminaryAggregation.Name)
             .Build();
 
         // Act
@@ -201,7 +202,7 @@ public class BalanceResponsibleValidatorTest
             .WithRequestedByActorId(ValidGlnNumber)
             .WithRequestedByActorRole(BalanceResponsibleRole)
             .WithBalanceResponsibleId(ValidGlnNumber)
-            .WithBusinessReason(DataHubNames.BusinessReason.WholesaleFixing)
+            .WithBusinessReason(BusinessReason.WholesaleFixing.Name)
             .Build();
 
         // Act
@@ -225,7 +226,7 @@ public class BalanceResponsibleValidatorTest
             .WithRequestedByActorId(ValidGlnNumber)
             .WithRequestedByActorRole(BalanceResponsibleRole)
             .WithBalanceResponsibleId("invalid-format")
-            .WithBusinessReason(DataHubNames.BusinessReason.Correction)
+            .WithBusinessReason(BusinessReason.Correction.Name)
             .Build();
 
         // Act

--- a/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/MeteringPointTypeValidatorTests.cs
+++ b/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/MeteringPointTypeValidatorTests.cs
@@ -33,10 +33,10 @@ public class MeteringPointTypeValidatorTests
 
     public static IEnumerable<object?[]> ValidMeteringPointTypes()
     {
-        yield return new object[] { MeteringPointType.Consumption.Name };
-        yield return new object[] { MeteringPointType.Production.Name };
-        yield return new object[] { MeteringPointType.Exchange.Name };
-        yield return new object?[] { null };
+        yield return [MeteringPointType.Consumption.Name];
+        yield return [MeteringPointType.Production.Name];
+        yield return [MeteringPointType.Exchange.Name];
+        yield return [null];
     }
 
     [Theory]

--- a/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/MeteringPointTypeValidatorTests.cs
+++ b/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/MeteringPointTypeValidatorTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
 using Energinet.DataHub.Wholesale.Edi.Validation;
 using Energinet.DataHub.Wholesale.Edi.Validation.AggregatedTimeSeriesRequest.Rules;
@@ -30,11 +31,16 @@ public class MeteringPointTypeValidatorTests
 
     private readonly MeteringPointTypeValidationRule _sut = new();
 
+    public static IEnumerable<object?[]> ValidMeteringPointTypes()
+    {
+        yield return new object[] { MeteringPointType.Consumption.Name };
+        yield return new object[] { MeteringPointType.Production.Name };
+        yield return new object[] { MeteringPointType.Exchange.Name };
+        yield return new object?[] { null };
+    }
+
     [Theory]
-    [InlineData(DataHubNames.MeteringPointType.Consumption)]
-    [InlineData(DataHubNames.MeteringPointType.Production)]
-    [InlineData(DataHubNames.MeteringPointType.Exchange)]
-    [InlineData(null)]
+    [MemberData(nameof(ValidMeteringPointTypes))]
     public async Task Validate_WhenMeteringPointIsValid_ReturnsExpectedNoValidationErrors(string? meteringPointType)
     {
         // Arrange

--- a/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/SettlementMethodValidatorTest.cs
+++ b/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/SettlementMethodValidatorTest.cs
@@ -28,7 +28,7 @@ public class SettlementMethodValidatorTest
 
     private readonly SettlementMethodValidationRule _sut = new();
 
-    public static IEnumerable<object[]> GetTestData()
+    public static IEnumerable<object[]> FaultedMeteringPointAndSettlementMethodCombinations()
     {
         yield return [MeteringPointType.Production.Name, DataHubNames.SettlementMethod.Flex];
         yield return [MeteringPointType.Production.Name, DataHubNames.SettlementMethod.NonProfiled];
@@ -113,7 +113,7 @@ public class SettlementMethodValidatorTest
     }
 
     [Theory]
-    [MemberData(nameof(GetTestData))]
+    [MemberData(nameof(FaultedMeteringPointAndSettlementMethodCombinations))]
     public async Task Validate_WhenNotConsumptionAndSettlementMethodIsGiven_ReturnsExpectedValidationErrorAsync(string? meteringPointType, string settlementMethod)
     {
         // Arrange

--- a/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/SettlementMethodValidatorTest.cs
+++ b/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/SettlementMethodValidatorTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
 using Energinet.DataHub.Wholesale.Edi.Validation;
 using Energinet.DataHub.Wholesale.Edi.Validation.AggregatedTimeSeriesRequest.Rules;
@@ -27,6 +28,32 @@ public class SettlementMethodValidatorTest
 
     private readonly SettlementMethodValidationRule _sut = new();
 
+    public static IEnumerable<object[]> GetTestData()
+    {
+        yield return [MeteringPointType.Production.Name, DataHubNames.SettlementMethod.Flex];
+        yield return [MeteringPointType.Production.Name, DataHubNames.SettlementMethod.NonProfiled];
+        yield return [MeteringPointType.Production.Name, "invalid-settlement-method"];
+        yield return [MeteringPointType.Exchange.Name, DataHubNames.SettlementMethod.Flex];
+        yield return [MeteringPointType.Exchange.Name, DataHubNames.SettlementMethod.NonProfiled];
+        yield return [MeteringPointType.Exchange.Name, "invalid-settlement-method"];
+        yield return ["not-consumption-metering-point", DataHubNames.SettlementMethod.Flex];
+        yield return ["not-consumption-metering-point", DataHubNames.SettlementMethod.NonProfiled];
+        yield return ["not-consumption-metering-point", "invalid-settlement-method"];
+        yield return [string.Empty, DataHubNames.SettlementMethod.Flex];
+        yield return [string.Empty, DataHubNames.SettlementMethod.NonProfiled];
+        yield return [string.Empty, "invalid-settlement-method"];
+        yield return [null!, DataHubNames.SettlementMethod.Flex];
+        yield return [null!, DataHubNames.SettlementMethod.NonProfiled];
+        yield return [null!, "invalid-settlement-method"];
+    }
+
+    public static IEnumerable<object[]> GetMeteringPointTypeTestData()
+    {
+        yield return new object[] { MeteringPointType.Production.Name };
+        yield return new object[] { MeteringPointType.Exchange.Name };
+        yield return new object[] { "not-consumption" };
+    }
+
     [Theory]
     [InlineData(DataHubNames.SettlementMethod.Flex)]
     [InlineData(DataHubNames.SettlementMethod.NonProfiled)]
@@ -35,7 +62,7 @@ public class SettlementMethodValidatorTest
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder
             .AggregatedTimeSeriesRequest()
-            .WithMeteringPointType(DataHubNames.MeteringPointType.Consumption)
+            .WithMeteringPointType(MeteringPointType.Consumption.Name)
             .WithSettlementMethod(settlementMethod)
             .Build();
 
@@ -47,9 +74,7 @@ public class SettlementMethodValidatorTest
     }
 
     [Theory]
-    [InlineData(DataHubNames.MeteringPointType.Production)]
-    [InlineData(DataHubNames.MeteringPointType.Exchange)]
-    [InlineData("not-consumption")]
+    [MemberData(nameof(GetMeteringPointTypeTestData))]
     public async Task Validate_WhenMeteringPointTypeIsGivenAndSettlementMethodIsNull_ReturnsNoValidationErrorsAsync(string meteringPointType)
     {
         // Arrange
@@ -72,7 +97,7 @@ public class SettlementMethodValidatorTest
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder
             .AggregatedTimeSeriesRequest()
-            .WithMeteringPointType(DataHubNames.MeteringPointType.Consumption)
+            .WithMeteringPointType(MeteringPointType.Consumption.Name)
             .WithSettlementMethod("invalid-settlement-method")
             .Build();
 
@@ -88,21 +113,7 @@ public class SettlementMethodValidatorTest
     }
 
     [Theory]
-    [InlineData(DataHubNames.MeteringPointType.Production, DataHubNames.SettlementMethod.Flex)]
-    [InlineData(DataHubNames.MeteringPointType.Production, DataHubNames.SettlementMethod.NonProfiled)]
-    [InlineData(DataHubNames.MeteringPointType.Production, "invalid-settlement-method")]
-    [InlineData(DataHubNames.MeteringPointType.Exchange, DataHubNames.SettlementMethod.Flex)]
-    [InlineData(DataHubNames.MeteringPointType.Exchange, DataHubNames.SettlementMethod.NonProfiled)]
-    [InlineData(DataHubNames.MeteringPointType.Exchange, "invalid-settlement-method")]
-    [InlineData("not-consumption-metering-point", DataHubNames.SettlementMethod.Flex)]
-    [InlineData("not-consumption-metering-point", DataHubNames.SettlementMethod.NonProfiled)]
-    [InlineData("not-consumption-metering-point", "invalid-settlement-method")]
-    [InlineData("", DataHubNames.SettlementMethod.Flex)]
-    [InlineData("", DataHubNames.SettlementMethod.NonProfiled)]
-    [InlineData("", "invalid-settlement-method")]
-    [InlineData(null, DataHubNames.SettlementMethod.Flex)]
-    [InlineData(null, DataHubNames.SettlementMethod.NonProfiled)]
-    [InlineData(null, "invalid-settlement-method")]
+    [MemberData(nameof(GetTestData))]
     public async Task Validate_WhenNotConsumptionAndSettlementMethodIsGiven_ReturnsExpectedValidationErrorAsync(string? meteringPointType, string settlementMethod)
     {
         // Arrange

--- a/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/SettlementVersionValidatorTest.cs
+++ b/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/SettlementVersionValidatorTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
 using Energinet.DataHub.Wholesale.Edi.Validation;
 using Energinet.DataHub.Wholesale.Edi.Validation.AggregatedTimeSeriesRequest.Rules;
@@ -36,7 +37,7 @@ public class SettlementVersionValidatorTest
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder
             .AggregatedTimeSeriesRequest()
-            .WithBusinessReason(DataHubNames.BusinessReason.Correction)
+            .WithBusinessReason(BusinessReason.Correction.Name)
             .WithSettlementVersion(invalidSettlementVersion)
             .Build();
 
@@ -60,7 +61,7 @@ public class SettlementVersionValidatorTest
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder
             .AggregatedTimeSeriesRequest()
-            .WithBusinessReason(DataHubNames.BusinessReason.WholesaleFixing)
+            .WithBusinessReason(BusinessReason.WholesaleFixing.Name)
             .WithSettlementVersion(settlementVersion)
             .Build();
 
@@ -81,7 +82,7 @@ public class SettlementVersionValidatorTest
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder
             .AggregatedTimeSeriesRequest()
-            .WithBusinessReason(DataHubNames.BusinessReason.Correction)
+            .WithBusinessReason(BusinessReason.Correction.Name)
             .WithSettlementVersion(validSettlementVersion)
             .Build();
 
@@ -98,7 +99,7 @@ public class SettlementVersionValidatorTest
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder
             .AggregatedTimeSeriesRequest()
-            .WithBusinessReason(DataHubNames.BusinessReason.Correction)
+            .WithBusinessReason(BusinessReason.Correction.Name)
             .WithSettlementVersion(null)
             .Build();
 
@@ -115,7 +116,7 @@ public class SettlementVersionValidatorTest
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder
             .AggregatedTimeSeriesRequest()
-            .WithBusinessReason(DataHubNames.BusinessReason.WholesaleFixing)
+            .WithBusinessReason(BusinessReason.WholesaleFixing.Name)
             .WithSettlementVersion(null)
             .Build();
 

--- a/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/TimeSeriesTypeValidatorTests.cs
+++ b/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/TimeSeriesTypeValidatorTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
 using Energinet.DataHub.Wholesale.Edi.Validation;
 using Energinet.DataHub.Wholesale.Edi.Validation.AggregatedTimeSeriesRequest.Rules;
@@ -27,12 +28,37 @@ public class TimeSeriesTypeValidatorTests
 
     private readonly TimeSeriesTypeValidationRule _sut = new();
 
+    public static IEnumerable<object[]> GetMeteringPointTypeData_Production()
+    {
+        yield return [MeteringPointType.Production.Name, null!];
+    }
+
+    public static IEnumerable<object[]> GetMeteringPointTypeData_Exchange()
+    {
+        yield return [MeteringPointType.Exchange.Name, null!];
+    }
+
+    public static IEnumerable<object[]> GetMeteringPointTypeData_Consumption()
+    {
+        yield return [MeteringPointType.Consumption.Name, null!];
+    }
+
+    public static IEnumerable<object[]> GetMeteringPointTypeData_Consumption_NonProfiled()
+    {
+        yield return [MeteringPointType.Consumption.Name, DataHubNames.SettlementMethod.NonProfiled];
+    }
+
+    public static IEnumerable<object[]> GetMeteringPointTypeData_Consumption_Flex()
+    {
+        yield return [MeteringPointType.Consumption.Name, DataHubNames.SettlementMethod.Flex];
+    }
+
     [Theory]
-    [InlineData(DataHubNames.MeteringPointType.Production, null)]
-    [InlineData(DataHubNames.MeteringPointType.Exchange, null)]
-    [InlineData(DataHubNames.MeteringPointType.Consumption, null)]
-    [InlineData(DataHubNames.MeteringPointType.Consumption, DataHubNames.SettlementMethod.NonProfiled)]
-    [InlineData(DataHubNames.MeteringPointType.Consumption, DataHubNames.SettlementMethod.Flex)]
+    [MemberData(nameof(GetMeteringPointTypeData_Production))]
+    [MemberData(nameof(GetMeteringPointTypeData_Exchange))]
+    [MemberData(nameof(GetMeteringPointTypeData_Consumption))]
+    [MemberData(nameof(GetMeteringPointTypeData_Consumption_NonProfiled))]
+    [MemberData(nameof(GetMeteringPointTypeData_Consumption_Flex))]
     public async Task Validate_AsMeteredDataResponsible_ReturnsNoValidationErrors(string meteringPointType, string? settlementMethod)
     {
         // Arrange
@@ -52,9 +78,9 @@ public class TimeSeriesTypeValidatorTests
     }
 
     [Theory]
-    [InlineData(DataHubNames.MeteringPointType.Production, null)]
-    [InlineData(DataHubNames.MeteringPointType.Consumption, DataHubNames.SettlementMethod.NonProfiled)]
-    [InlineData(DataHubNames.MeteringPointType.Consumption, DataHubNames.SettlementMethod.Flex)]
+    [MemberData(nameof(GetMeteringPointTypeData_Production))]
+    [MemberData(nameof(GetMeteringPointTypeData_Consumption_NonProfiled))]
+    [MemberData(nameof(GetMeteringPointTypeData_Consumption_Flex))]
     public async Task Validate_AsEnergySupplier_ReturnsNoValidationErrors(string meteringPointType, string? settlementMethod)
     {
         // Arrange
@@ -74,9 +100,9 @@ public class TimeSeriesTypeValidatorTests
     }
 
     [Theory]
-    [InlineData(DataHubNames.MeteringPointType.Production, null)]
-    [InlineData(DataHubNames.MeteringPointType.Consumption, DataHubNames.SettlementMethod.NonProfiled)]
-    [InlineData(DataHubNames.MeteringPointType.Consumption, DataHubNames.SettlementMethod.Flex)]
+    [MemberData(nameof(GetMeteringPointTypeData_Production))]
+    [MemberData(nameof(GetMeteringPointTypeData_Consumption_NonProfiled))]
+    [MemberData(nameof(GetMeteringPointTypeData_Consumption_Flex))]
     public async Task Validate_AsBalanceResponsible_ReturnsNoValidationErrors(string meteringPointType, string? settlementMethod)
     {
         // Arrange
@@ -96,15 +122,15 @@ public class TimeSeriesTypeValidatorTests
     }
 
     [Theory]
-    [InlineData(DataHubNames.MeteringPointType.Exchange)]
-    [InlineData(DataHubNames.MeteringPointType.Consumption)]
-    public async Task Validate_AsEnergySupplierAndNoSettlementMethod_ReturnsExceptedValidationErrors(string meteringPointType)
+    [MemberData(nameof(GetMeteringPointTypeData_Exchange))]
+    [MemberData(nameof(GetMeteringPointTypeData_Consumption))]
+    public async Task Validate_AsEnergySupplierAndNoSettlementMethod_ReturnsExceptedValidationErrors(string meteringPointType, string? settlementMethod)
     {
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder
             .AggregatedTimeSeriesRequest()
             .WithMeteringPointType(meteringPointType)
-            .WithSettlementMethod(null)
+            .WithSettlementMethod(settlementMethod)
             .WithRequestedByActorId("1234567890123")
             .WithRequestedByActorRole(DataHubNames.ActorRole.EnergySupplier)
             .Build();
@@ -121,15 +147,15 @@ public class TimeSeriesTypeValidatorTests
     }
 
     [Theory]
-    [InlineData(DataHubNames.MeteringPointType.Exchange)]
-    [InlineData(DataHubNames.MeteringPointType.Consumption)]
-    public async Task Validate_AsBalanceResponsibleAndNoSettlementMethod_ValidationErrors(string meteringPointType)
+    [MemberData(nameof(GetMeteringPointTypeData_Exchange))]
+    [MemberData(nameof(GetMeteringPointTypeData_Consumption))]
+    public async Task Validate_AsBalanceResponsibleAndNoSettlementMethod_ValidationErrors(string meteringPointType, string? settlementMethod)
     {
         // Arrange
         var message = AggregatedTimeSeriesRequestBuilder
             .AggregatedTimeSeriesRequest()
             .WithMeteringPointType(meteringPointType)
-            .WithSettlementMethod(null)
+            .WithSettlementMethod(settlementMethod)
             .WithRequestedByActorId("1234567890123")
             .WithRequestedByActorRole(DataHubNames.ActorRole.BalanceResponsibleParty)
             .Build();

--- a/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/TimeSeriesTypeValidatorTests.cs
+++ b/source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/TimeSeriesTypeValidatorTests.cs
@@ -38,7 +38,7 @@ public class TimeSeriesTypeValidatorTests
         yield return [MeteringPointType.Exchange.Name, null!];
     }
 
-    public static IEnumerable<object[]> GetMeteringPointTypeData_Consumption()
+    public static IEnumerable<object[]> GetMeteringPointTypeData_Total_Consumption()
     {
         yield return [MeteringPointType.Consumption.Name, null!];
     }
@@ -56,7 +56,7 @@ public class TimeSeriesTypeValidatorTests
     [Theory]
     [MemberData(nameof(GetMeteringPointTypeData_Production))]
     [MemberData(nameof(GetMeteringPointTypeData_Exchange))]
-    [MemberData(nameof(GetMeteringPointTypeData_Consumption))]
+    [MemberData(nameof(GetMeteringPointTypeData_Total_Consumption))]
     [MemberData(nameof(GetMeteringPointTypeData_Consumption_NonProfiled))]
     [MemberData(nameof(GetMeteringPointTypeData_Consumption_Flex))]
     public async Task Validate_AsMeteredDataResponsible_ReturnsNoValidationErrors(string meteringPointType, string? settlementMethod)
@@ -123,7 +123,7 @@ public class TimeSeriesTypeValidatorTests
 
     [Theory]
     [MemberData(nameof(GetMeteringPointTypeData_Exchange))]
-    [MemberData(nameof(GetMeteringPointTypeData_Consumption))]
+    [MemberData(nameof(GetMeteringPointTypeData_Total_Consumption))]
     public async Task Validate_AsEnergySupplierAndNoSettlementMethod_ReturnsExceptedValidationErrors(string meteringPointType, string? settlementMethod)
     {
         // Arrange
@@ -148,7 +148,7 @@ public class TimeSeriesTypeValidatorTests
 
     [Theory]
     [MemberData(nameof(GetMeteringPointTypeData_Exchange))]
-    [MemberData(nameof(GetMeteringPointTypeData_Consumption))]
+    [MemberData(nameof(GetMeteringPointTypeData_Total_Consumption))]
     public async Task Validate_AsBalanceResponsibleAndNoSettlementMethod_ValidationErrors(string meteringPointType, string? settlementMethod)
     {
         // Arrange

--- a/source/Edi.UnitTests/Validators/WholesaleServicesRequest/ResolutionValidationRuleTests.cs
+++ b/source/Edi.UnitTests/Validators/WholesaleServicesRequest/ResolutionValidationRuleTests.cs
@@ -14,6 +14,7 @@
 
 using System.Reflection;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
 using Energinet.DataHub.Wholesale.Edi.Validation;
 using Energinet.DataHub.Wholesale.Edi.Validation.WholesaleServicesRequest.Rules;
@@ -45,7 +46,7 @@ public class ResolutionValidationRuleTests
         {
             new object[] { "Monthly" },
             new object[] { null! },
-            new object[] { DataHubNames.Resolution.Monthly },
+            new object[] { Resolution.Monthly.Name },
         };
     }
 
@@ -60,7 +61,7 @@ public class ResolutionValidationRuleTests
 
         var allResolutions = GetAllResolutionsInDatahub();
         var invalidResolutions = allResolutions
-            .Where(res => res != DataHubNames.Resolution.Monthly);
+            .Where(res => res != Resolution.Monthly.Name);
 
         var invalidResolutionsWithCustomResolutions = invalidResolutions.Concat(customResolutions)
             .Select(res => new object[] { res! });
@@ -105,7 +106,7 @@ public class ResolutionValidationRuleTests
 
     private static IEnumerable<string?> GetAllResolutionsInDatahub()
     {
-        var resolutionType = typeof(DataHubNames.Resolution);
+        var resolutionType = typeof(Resolution);
         return resolutionType
             .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
             .ToList()

--- a/source/Edi.UnitTests/Validators/WholesaleServicesRequest/ResolutionValidationRuleTests.cs
+++ b/source/Edi.UnitTests/Validators/WholesaleServicesRequest/ResolutionValidationRuleTests.cs
@@ -107,9 +107,10 @@ public class ResolutionValidationRuleTests
     private static IEnumerable<string?> GetAllResolutionsInDatahub()
     {
         var resolutionType = typeof(Resolution);
-        return resolutionType
+        var resolutions = resolutionType
             .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
             .ToList()
-            .Select(res => (string)res.GetValue(null)!);
+            .Select(res => (Resolution)res.GetValue(null)!);
+        return resolutions.Select(x => x.Name);
     }
 }

--- a/source/Edi.UnitTests/Validators/WholesaleServicesRequest/SettlementVersionValidatorTest.cs
+++ b/source/Edi.UnitTests/Validators/WholesaleServicesRequest/SettlementVersionValidatorTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
 using Energinet.DataHub.Wholesale.Edi.Validation;
 using Energinet.DataHub.Wholesale.Edi.Validation.WholesaleServicesRequest.Rules;
@@ -35,7 +36,7 @@ public class SettlementVersionValidatorTest
     {
         // Arrange
         var message = new WholesaleServicesRequestBuilder()
-            .WithBusinessReason(DataHubNames.BusinessReason.Correction)
+            .WithBusinessReason(BusinessReason.Correction.Name)
             .WithSettlementVersion(invalidSettlementVersion)
             .Build();
 
@@ -58,7 +59,7 @@ public class SettlementVersionValidatorTest
     {
         // Arrange
         var message = new WholesaleServicesRequestBuilder()
-            .WithBusinessReason(DataHubNames.BusinessReason.WholesaleFixing)
+            .WithBusinessReason(BusinessReason.WholesaleFixing.Name)
             .WithSettlementVersion(settlementVersion)
             .Build();
 
@@ -78,7 +79,7 @@ public class SettlementVersionValidatorTest
     {
         // Arrange
         var message = new WholesaleServicesRequestBuilder()
-            .WithBusinessReason(DataHubNames.BusinessReason.Correction)
+            .WithBusinessReason(BusinessReason.Correction.Name)
             .WithSettlementVersion(validSettlementVersion)
             .Build();
 
@@ -94,7 +95,7 @@ public class SettlementVersionValidatorTest
     {
         // Arrange
         var message = new WholesaleServicesRequestBuilder()
-            .WithBusinessReason(DataHubNames.BusinessReason.Correction)
+            .WithBusinessReason(BusinessReason.Correction.Name)
             .WithSettlementVersion(null)
             .Build();
 
@@ -110,7 +111,7 @@ public class SettlementVersionValidatorTest
     {
         // Arrange
         var message = new WholesaleServicesRequestBuilder()
-            .WithBusinessReason(DataHubNames.BusinessReason.WholesaleFixing)
+            .WithBusinessReason(BusinessReason.WholesaleFixing.Name)
             .WithSettlementVersion(null)
             .Build();
 

--- a/source/Edi.UnitTests/Validators/WholesaleServicesRequest/WholesaleServicesRequestValidatorTests.cs
+++ b/source/Edi.UnitTests/Validators/WholesaleServicesRequest/WholesaleServicesRequestValidatorTests.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
-using Energinet.DataHub.Edi.Requests;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Wholesale.Edi.UnitTests.Builders;
 using Energinet.DataHub.Wholesale.Edi.Validation;
 using FluentAssertions;
@@ -21,6 +21,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using Xunit;
 using Xunit.Abstractions;
+using ChargeType = Energinet.DataHub.Edi.Requests.ChargeType;
 
 namespace Energinet.DataHub.Wholesale.Edi.UnitTests.Validators.WholesaleServicesRequest;
 
@@ -144,7 +145,7 @@ public sealed class WholesaleServicesRequestValidatorTests : EdiTestBase
     {
         // Arrange
         var request = new WholesaleServicesRequestBuilder()
-            .WithBusinessReason(DataHubNames.BusinessReason.Correction)
+            .WithBusinessReason(BusinessReason.Correction.Name)
             .WithSettlementVersion("invalid-settlement-version")
             .Build();
 

--- a/source/Edi.UnitTests/WholesaleServicesRequestHandlerTests.cs
+++ b/source/Edi.UnitTests/WholesaleServicesRequestHandlerTests.cs
@@ -120,6 +120,7 @@ public class WholesaleServicesRequestHandlerTests
         var serviceBusReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(
             properties: new Dictionary<string, object> { { "ReferenceId", expectedReferenceId } },
             body: new BinaryData(new WholesaleServicesRequestBuilder()
+                .WithResolution(Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Resolution.Monthly.Name)
                 .Build()
                 .ToByteArray()));
 

--- a/source/Edi.UnitTests/WholesaleServicesRequestHandlerTests.cs
+++ b/source/Edi.UnitTests/WholesaleServicesRequestHandlerTests.cs
@@ -120,7 +120,6 @@ public class WholesaleServicesRequestHandlerTests
         var serviceBusReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(
             properties: new Dictionary<string, object> { { "ReferenceId", expectedReferenceId } },
             body: new BinaryData(new WholesaleServicesRequestBuilder()
-                .WithResolution(DataHubNames.Resolution.Monthly)
                 .Build()
                 .ToByteArray()));
 
@@ -197,7 +196,7 @@ public class WholesaleServicesRequestHandlerTests
         var serviceBusReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(
             properties: new Dictionary<string, object> { { "ReferenceId", expectedReferenceId } },
             body: new BinaryData(new WholesaleServicesRequestBuilder()
-                .WithResolution(DataHubNames.Resolution.Monthly)
+                .WithResolution(Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Resolution.Monthly.Name)
                 .WithChargeTypes(chargeTypeInRequest)
                 .Build()
                 .ToByteArray()));

--- a/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
+++ b/source/IntegrationTests/Application/Transactions/AggregatedMeasureData/WhenAnAcceptedResultIsAvailableTests.cs
@@ -119,7 +119,7 @@ public class WhenAnAcceptedResultIsAvailableTests : TestBase
         };
         series.TimeSeriesPoints.AddRange(timeSeriesPoints.OrderBy(_ => Guid.NewGuid()));
 
-        if (aggregatedMeasureDataProcess.BusinessReason.Name == DataHubNames.BusinessReason.Correction)
+        if (aggregatedMeasureDataProcess.BusinessReason.Name == BusinessReason.Correction.Name)
         {
             switch (aggregatedMeasureDataProcess.SettlementVersion)
             {

--- a/source/IntegrationTests/Behaviours/AggregatedMeasureDataBehaviourTestBase.cs
+++ b/source/IntegrationTests/Behaviours/AggregatedMeasureDataBehaviourTestBase.cs
@@ -103,6 +103,11 @@ public abstract class AggregatedMeasureDataBehaviourTestBase : BehavioursTestBas
         await GivenProcessManagerResponseIsReceived(acceptedMessage);
     }
 
+    protected async Task GivenAggregatedMeasureDataRequestRejectedIsReceived(ServiceBusMessage rejectedMessage)
+    {
+        await GivenProcessManagerResponseIsReceived(rejectedMessage);
+    }
+
     protected async Task<string> GetGridAreaFromNotifyAggregatedMeasureDataDocument(Stream documentStream, DocumentFormat documentFormat)
     {
         documentStream.Position = 0;

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenAggregatedMeasureDataV2RequestTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenAggregatedMeasureDataV2RequestTests.cs
@@ -30,6 +30,7 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Extensions.Options;
 using NodaTime;
+using NodaTime.Text;
 using Xunit;
 using Xunit.Abstractions;
 using Period = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Period;
@@ -623,6 +624,119 @@ public class GivenAggregatedMeasureDataV2RequestTests : AggregatedMeasureDataBeh
         }
 
         gridAreas.Should().BeEquivalentTo("143", "512", "877");
+    }
+
+    [Theory]
+    [MemberData(nameof(DocumentFormatsWithAllActorRoleCombinations))]
+    public async Task
+        AndGiven_NoDataInGridArea_When_ActorPeeksAllMessages_Then_ReceivesOneRejectNotifyAggregatedMeasureDataDocumentWithCorrectContent(
+            ActorRole actorRole,
+            DocumentFormat incomingDocumentFormat,
+            DocumentFormat peekDocumentFormat)
+    {
+        /*
+         *  --- PART 1: Receive request and send message to Process Manager ---
+         */
+
+        // Arrange
+        var testDataDescription = GivenDatabricksResultDataForEnergyResultPerEnergySupplier();
+        var testMessageData = actorRole == ActorRole.EnergySupplier
+             ? testDataDescription.ExampleEnergySupplier
+             : testDataDescription.ExampleBalanceResponsible;
+
+        var senderSpy = CreateServiceBusSenderSpy(ServiceBusSenderNames.ProcessManagerTopic);
+        var energySupplierNumber = testMessageData.ExampleMessageData.EnergySupplier;
+        var balanceResponsibleParty = testMessageData.ExampleMessageData.BalanceResponsible;
+        var actor = (ActorNumber: testMessageData.ActorNumber, ActorRole: actorRole);
+
+        GivenNowIs(Instant.FromUtc(2024, 7, 1, 14, 57, 09));
+        GivenAuthenticatedActorIs(actor.ActorNumber, actor.ActorRole);
+        var transactionId = TransactionId.From("12356478912356478912356478912356478");
+
+        var gridAreaWithNoData = "000";
+
+        // Act
+        await GivenReceivedAggregatedMeasureDataRequest(
+            documentFormat: incomingDocumentFormat,
+            senderActorNumber: actor.ActorNumber,
+            senderActorRole: actor.ActorRole,
+            meteringPointType: testMessageData.ExampleMessageData.MeteringPointType,
+            settlementMethod: testMessageData.ExampleMessageData.SettlementMethod,
+            periodStart: (2022, 1, 1),
+            periodEnd: (2022, 2, 1),
+            energySupplier: energySupplierNumber,
+            balanceResponsibleParty: balanceResponsibleParty,
+            new (string? GridArea, TransactionId TransactionId)[]
+            {
+                (gridAreaWithNoData, transactionId),
+            });
+
+        // Assert
+        var message = ThenRequestCalculatedEnergyTimeSeriesInputV1ServiceBusMessageIsCorrect(
+            senderSpy,
+            new RequestCalculatedEnergyTimeSeriesInputV1AssertionInput(
+                transactionId,
+                actor.ActorNumber.Value,
+                actor.ActorRole.Name,
+                BusinessReason.BalanceFixing,
+                PeriodStart: CreateDateInstant(2022, 1, 1),
+                PeriodEnd: CreateDateInstant(2022, 2, 1),
+                energySupplierNumber!.Value,
+                balanceResponsibleParty!.Value,
+                new List<string> { gridAreaWithNoData },
+                SettlementMethod: testMessageData.ExampleMessageData.SettlementMethod,
+                MeteringPointType: testMessageData.ExampleMessageData.MeteringPointType,
+                SettlementVersion: null));
+
+        /*
+         *  --- PART 2: Receive data from Process Manager and create RSM document ---
+         */
+
+        // Arrange
+        var expectedErrorMessage = "Ingen data tilgængelig / No data available";
+        var expectedErrorCode = "E0H";
+
+        // Generate a mock ServiceBus Message with RequestCalculatedEnergyTimeSeriesAcceptedV1 response from Process Manager,
+        // based on the RequestCalculatedEnergyTimeSeriesInputV1
+        // It is very important that the generated data is correct,
+        // since (almost) all assertion after this point is based on this data
+        var requestCalculatedEnergyTimeSeriesInput = message.ParseInput<RequestCalculatedEnergyTimeSeriesInputV1>();
+        var requestCalculatedEnergyTimeSeriesRejected = AggregatedTimeSeriesResponseEventBuilder
+            .GenerateRejectedFrom(requestCalculatedEnergyTimeSeriesInput, expectedErrorMessage, expectedErrorCode);
+
+        await GivenAggregatedMeasureDataRequestRejectedIsReceived(
+            requestCalculatedEnergyTimeSeriesRejected);
+
+        // Act
+        var peekResults = await WhenActorPeeksAllMessages(
+            actor.ActorNumber,
+            actor.ActorRole,
+            peekDocumentFormat);
+
+        // Assert
+        PeekResultDto peekResult;
+        using (new AssertionScope())
+        {
+            peekResult = peekResults
+                .Should()
+                .ContainSingle("because there should be one message when requesting for one grid area")
+                .Subject;
+        }
+
+        peekResult.Bundle.Should().NotBeNull("because peek result should contain a document stream");
+
+        await ThenRejectRequestAggregatedMeasureDataDocumentIsCorrect(
+            peekResult.Bundle,
+            peekDocumentFormat,
+            new(
+                BusinessReason.BalanceFixing,
+                "5790001330552",
+                actor.ActorNumber.Value,
+                InstantPattern.General.Parse("2024-07-01T14:57:09Z").Value,
+                ReasonCode.FullyRejected.Code,
+                transactionId,
+                expectedErrorCode,
+                expectedErrorMessage));
     }
 
     public async Task InitializeAsync()

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenB2CWholesaleServicesRequestTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenB2CWholesaleServicesRequestTests.cs
@@ -113,7 +113,7 @@ public class GivenB2CWholesaleServicesRequestTests : WholesaleServicesBehaviourT
                 BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
-                    (DataHubNames.ChargeType.Tariff, null),
+                    (ChargeType.Tariff.Name, null),
                 },
                 new Period(CreateDateInstant(2024, 1, 1), CreateDateInstant(2024, 1, 31)),
                 null));

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenB2CWholesaleServicesRequestTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenB2CWholesaleServicesRequestTests.cs
@@ -110,7 +110,7 @@ public class GivenB2CWholesaleServicesRequestTests : WholesaleServicesBehaviourT
                 energySupplierNumber.Value,
                 null,
                 Resolution.Monthly.Name,
-                DataHubNames.BusinessReason.WholesaleFixing,
+                BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
                     (DataHubNames.ChargeType.Tariff, null),

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestTests.cs
@@ -138,7 +138,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                 chargeOwnerNumber.Value,
                 null,
                 BusinessReason.WholesaleFixing.Name,
-                new List<(string ChargeType, string? ChargeCode)> { (DataHubNames.ChargeType.Tariff, "25361478"), },
+                new List<(string ChargeType, string? ChargeCode)> { (ChargeType.Tariff.Name, "25361478"), },
                 new Period(CreateDateInstant(2024, 1, 1), CreateDateInstant(2024, 1, 31)),
                 null));
 
@@ -313,7 +313,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                 BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
-                    (DataHubNames.ChargeType.Tariff, "25361478"),
+                    (ChargeType.Tariff.Name, "25361478"),
                 },
                 Period: new Period(
                     CreateDateInstant(2024, 1, 1),
@@ -590,7 +590,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                     BusinessReason: BusinessReason.WholesaleFixing.Name,
                     ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                     {
-                        (DataHubNames.ChargeType.Tariff, "25361478"),
+                        (ChargeType.Tariff.Name, "25361478"),
                     },
                     Period: new Period(
                         CreateDateInstant(2024, 1, 1),
@@ -606,7 +606,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                     BusinessReason: BusinessReason.WholesaleFixing.Name,
                     ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                     {
-                        (DataHubNames.ChargeType.Tariff, "25361478"),
+                        (ChargeType.Tariff.Name, "25361478"),
                     },
                     Period: new Period(
                         CreateDateInstant(2024, 1, 1),
@@ -622,7 +622,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                     BusinessReason: BusinessReason.WholesaleFixing.Name,
                     ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                     {
-                        (DataHubNames.ChargeType.Tariff, "25361478"),
+                        (ChargeType.Tariff.Name, "25361478"),
                     },
                     Period: new Period(
                         CreateDateInstant(2024, 1, 1),
@@ -769,7 +769,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                 chargeOwnerNumber.Value,
                 null,
                 BusinessReason.WholesaleFixing.Name,
-                new List<(string ChargeType, string? ChargeCode)> { (DataHubNames.ChargeType.Tariff, "25361478"), },
+                new List<(string ChargeType, string? ChargeCode)> { (ChargeType.Tariff.Name, "25361478"), },
                 new Period(CreateDateInstant(2024, 1, 1), CreateDateInstant(2024, 1, 31)),
                 null));
 

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestTests.cs
@@ -137,7 +137,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                 energySupplierNumber.Value,
                 chargeOwnerNumber.Value,
                 null,
-                DataHubNames.BusinessReason.WholesaleFixing,
+                BusinessReason.WholesaleFixing.Name,
                 new List<(string ChargeType, string? ChargeCode)> { (DataHubNames.ChargeType.Tariff, "25361478"), },
                 new Period(CreateDateInstant(2024, 1, 1), CreateDateInstant(2024, 1, 31)),
                 null));
@@ -310,7 +310,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                 EnergySupplierId: energySupplierNumber.Value,
                 ChargeOwnerId: chargeOwnerNumber.Value,
                 Resolution: null,
-                BusinessReason: DataHubNames.BusinessReason.WholesaleFixing,
+                BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
                     (DataHubNames.ChargeType.Tariff, "25361478"),
@@ -449,7 +449,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                 EnergySupplierId: energySupplierOrNull?.Value,
                 ChargeOwnerId: chargeOwnerOrNull?.Value,
                 Resolution: null,
-                BusinessReason: DataHubNames.BusinessReason.WholesaleFixing,
+                BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: null,
                 Period: new Period(
                     CreateDateInstant(2024, 1, 1),
@@ -587,7 +587,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                     EnergySupplierId: energySupplierNumber.Value,
                     ChargeOwnerId: chargeOwnerNumber.Value,
                     Resolution: null,
-                    BusinessReason: DataHubNames.BusinessReason.WholesaleFixing,
+                    BusinessReason: BusinessReason.WholesaleFixing.Name,
                     ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                     {
                         (DataHubNames.ChargeType.Tariff, "25361478"),
@@ -603,7 +603,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                     EnergySupplierId: energySupplierNumber.Value,
                     ChargeOwnerId: chargeOwnerNumber.Value,
                     Resolution: null,
-                    BusinessReason: DataHubNames.BusinessReason.WholesaleFixing,
+                    BusinessReason: BusinessReason.WholesaleFixing.Name,
                     ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                     {
                         (DataHubNames.ChargeType.Tariff, "25361478"),
@@ -619,7 +619,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                     EnergySupplierId: energySupplierNumber.Value,
                     ChargeOwnerId: chargeOwnerNumber.Value,
                     Resolution: null,
-                    BusinessReason: DataHubNames.BusinessReason.WholesaleFixing,
+                    BusinessReason: BusinessReason.WholesaleFixing.Name,
                     ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                     {
                         (DataHubNames.ChargeType.Tariff, "25361478"),
@@ -768,7 +768,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                 energySupplierNumber.Value,
                 chargeOwnerNumber.Value,
                 null,
-                DataHubNames.BusinessReason.WholesaleFixing,
+                BusinessReason.WholesaleFixing.Name,
                 new List<(string ChargeType, string? ChargeCode)> { (DataHubNames.ChargeType.Tariff, "25361478"), },
                 new Period(CreateDateInstant(2024, 1, 1), CreateDateInstant(2024, 1, 31)),
                 null));
@@ -889,7 +889,7 @@ public class GivenWholesaleServicesRequestTests : WholesaleServicesBehaviourTest
                 energySupplierNumber.Value,
                 chargeOwnerNumber.Value,
                 Resolution.Monthly.Name,
-                DataHubNames.BusinessReason.WholesaleFixing,
+                BusinessReason.WholesaleFixing.Name,
                 null,
                 new Period(CreateDateInstant(2024, 1, 1), CreateDateInstant(2024, 1, 31)),
                 null));

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2Tests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2Tests.cs
@@ -586,7 +586,7 @@ public class GivenWholesaleServicesRequestV2Tests : WholesaleServicesBehaviourTe
                 chargeOwnerNumber.Value,
                 new List<string> { gridArea },
                 SettlementVersion: null,
-                new List<ChargeTypeInput> { new(DataHubNames.ChargeType.Tariff, "25361478") }));
+                new List<ChargeTypeInput> { new(ChargeType.Tariff.Name, "25361478") }));
 
         /*
          *  --- PART 2: Receive reject response from Process Manager and create RSM document ---

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2WithDelegationTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2WithDelegationTests.cs
@@ -498,7 +498,7 @@ public class GivenWholesaleServicesRequestV2WithDelegationTests : WholesaleServi
                 chargeOwnerNumber.Value,
                 new List<string> { gridAreaCode },
                 null,
-                new List<ChargeTypeInput> { new(DataHubNames.ChargeType.Tariff, "25361478"), }));
+                new List<ChargeTypeInput> { new(ChargeType.Tariff.Name, "25361478"), }));
 
         /*
          *  --- PART 2: Receive data from Process Manager and create RSM document ---
@@ -635,7 +635,7 @@ public class GivenWholesaleServicesRequestV2WithDelegationTests : WholesaleServi
                 chargeOwnerNumber.Value,
                 GridAreas: testDataDescription.GridAreaCodes,
                 null,
-                new List<ChargeTypeInput> { new(DataHubNames.ChargeType.Tariff, "25361478") }));
+                new List<ChargeTypeInput> { new(ChargeType.Tariff.Name, "25361478") }));
 
         /*
          *  --- PART 2: Receive data from Process Manager and create RSM document ---

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestWithDelegationTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestWithDelegationTests.cs
@@ -147,7 +147,7 @@ public class GivenWholesaleServicesRequestWithDelegationTests : WholesaleService
                 EnergySupplierId: energySupplierNumber.Value,
                 ChargeOwnerId: chargeOwnerNumber.Value,
                 Resolution: null,
-                BusinessReason: DataHubNames.BusinessReason.WholesaleFixing,
+                BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
                     (DataHubNames.ChargeType.Tariff, "25361478"),
@@ -298,7 +298,7 @@ public class GivenWholesaleServicesRequestWithDelegationTests : WholesaleService
                 EnergySupplierId: energySupplierNumber.Value,
                 ChargeOwnerId: chargeOwnerNumber.Value,
                 Resolution: null,
-                BusinessReason: DataHubNames.BusinessReason.WholesaleFixing,
+                BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
                     (DataHubNames.ChargeType.Tariff, "25361478"),
@@ -455,7 +455,7 @@ public class GivenWholesaleServicesRequestWithDelegationTests : WholesaleService
                 EnergySupplierId: energySupplierNumber.Value,
                 ChargeOwnerId: chargeOwnerNumber.Value,
                 Resolution: null,
-                BusinessReason: DataHubNames.BusinessReason.WholesaleFixing,
+                BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
                     (DataHubNames.ChargeType.Tariff, "25361478"),
@@ -598,7 +598,7 @@ public class GivenWholesaleServicesRequestWithDelegationTests : WholesaleService
                 EnergySupplierId: energySupplierNumber.Value,
                 ChargeOwnerId: chargeOwnerNumber.Value,
                 Resolution: null,
-                BusinessReason: DataHubNames.BusinessReason.WholesaleFixing,
+                BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
                     (DataHubNames.ChargeType.Tariff, "25361478"),
@@ -734,7 +734,7 @@ public class GivenWholesaleServicesRequestWithDelegationTests : WholesaleService
                 EnergySupplierId: energySupplierNumber.Value,
                 ChargeOwnerId: chargeOwnerNumber.Value,
                 Resolution: null,
-                BusinessReason: DataHubNames.BusinessReason.WholesaleFixing,
+                BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
                     (DataHubNames.ChargeType.Tariff, "25361478"),
@@ -887,7 +887,7 @@ public class GivenWholesaleServicesRequestWithDelegationTests : WholesaleService
                 EnergySupplierId: energySupplierNumber.Value,
                 ChargeOwnerId: chargeOwnerNumber.Value,
                 Resolution: null,
-                BusinessReason: DataHubNames.BusinessReason.WholesaleFixing,
+                BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
                     (DataHubNames.ChargeType.Tariff, "25361478"),

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestWithDelegationTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestWithDelegationTests.cs
@@ -150,7 +150,7 @@ public class GivenWholesaleServicesRequestWithDelegationTests : WholesaleService
                 BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
-                    (DataHubNames.ChargeType.Tariff, "25361478"),
+                    (ChargeType.Tariff.Name, "25361478"),
                 },
                 Period: new Period(
                     CreateDateInstant(2024, 1, 1),
@@ -301,7 +301,7 @@ public class GivenWholesaleServicesRequestWithDelegationTests : WholesaleService
                 BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
-                    (DataHubNames.ChargeType.Tariff, "25361478"),
+                    (ChargeType.Tariff.Name, "25361478"),
                 },
                 Period: new Period(
                     CreateDateInstant(2024, 1, 1),
@@ -458,7 +458,7 @@ public class GivenWholesaleServicesRequestWithDelegationTests : WholesaleService
                 BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
-                    (DataHubNames.ChargeType.Tariff, "25361478"),
+                    (ChargeType.Tariff.Name, "25361478"),
                 },
                 Period: new Period(
                     CreateDateInstant(2024, 1, 1),
@@ -601,7 +601,7 @@ public class GivenWholesaleServicesRequestWithDelegationTests : WholesaleService
                 BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
-                    (DataHubNames.ChargeType.Tariff, "25361478"),
+                    (ChargeType.Tariff.Name, "25361478"),
                 },
                 Period: new Period(
                     CreateDateInstant(2024, 1, 1),
@@ -737,7 +737,7 @@ public class GivenWholesaleServicesRequestWithDelegationTests : WholesaleService
                 BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
-                    (DataHubNames.ChargeType.Tariff, "25361478"),
+                    (ChargeType.Tariff.Name, "25361478"),
                 },
                 Period: new Period(
                     CreateDateInstant(2024, 1, 1),
@@ -890,7 +890,7 @@ public class GivenWholesaleServicesRequestWithDelegationTests : WholesaleService
                 BusinessReason: BusinessReason.WholesaleFixing.Name,
                 ChargeTypes: new List<(string ChargeType, string? ChargeCode)>
                 {
-                    (DataHubNames.ChargeType.Tariff, "25361478"),
+                    (ChargeType.Tariff.Name, "25361478"),
                 },
                 Period: new Period(
                     CreateDateInstant(2024, 1, 1),

--- a/source/IntegrationTests/EventBuilders/AggregatedTimeSeriesResponseEventBuilder.cs
+++ b/source/IntegrationTests/EventBuilders/AggregatedTimeSeriesResponseEventBuilder.cs
@@ -15,6 +15,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Edi.Requests;
 using Energinet.DataHub.Edi.Responses;
 using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
@@ -34,6 +35,8 @@ using PMMeteringPointType = Energinet.DataHub.ProcessManager.Components.Abstract
 using PMSettlementMethod = Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects.SettlementMethod;
 using PMSettlementVersion = Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects.SettlementVersion;
 using PMTypes = Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
+using Resolution = Energinet.DataHub.Edi.Responses.Resolution;
+using SettlementVersion = Energinet.DataHub.Edi.Responses.SettlementVersion;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.EventBuilders;
 
@@ -77,7 +80,7 @@ internal static class AggregatedTimeSeriesResponseEventBuilder
                     TimeSeriesPoints = { points },
                 };
 
-                if (request.BusinessReason == DataHubNames.BusinessReason.Correction)
+                if (request.BusinessReason == BusinessReason.Correction.Name)
                 {
                     series.SettlementVersion = request.SettlementVersion switch
                     {

--- a/source/IntegrationTests/EventBuilders/WholesaleServicesResponseEventBuilder.cs
+++ b/source/IntegrationTests/EventBuilders/WholesaleServicesResponseEventBuilder.cs
@@ -15,6 +15,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.Edi.Requests;
 using Energinet.DataHub.Edi.Responses;
 using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
@@ -91,7 +92,7 @@ public static class WholesaleServicesResponseEventBuilder
                                 StartOfPeriod = periodStart.ToTimestamp(), EndOfPeriod = periodEnd.ToTimestamp(),
                             },
                             Resolution = resolution,
-                            CalculationType = request.BusinessReason == DataHubNames.BusinessReason.WholesaleFixing
+                            CalculationType = request.BusinessReason == BusinessReason.WholesaleFixing.Name
                                 ? WholesaleServicesRequestSeries.Types.CalculationType.WholesaleFixing
                                 : throw new NotImplementedException(
                                     "Builder only supports WholesaleFixing, not corrections"),
@@ -131,7 +132,7 @@ public static class WholesaleServicesResponseEventBuilder
                             EndOfPeriod = periodEnd.ToTimestamp(),
                         },
                         Resolution = WholesaleServicesRequestSeries.Types.Resolution.Monthly,
-                        CalculationType = request.BusinessReason == DataHubNames.BusinessReason.WholesaleFixing
+                        CalculationType = request.BusinessReason == BusinessReason.WholesaleFixing.Name
                             ? WholesaleServicesRequestSeries.Types.CalculationType.WholesaleFixing
                             : throw new NotImplementedException("Builder only supports WholesaleFixing, not corrections"),
                         ChargeOwnerId = request.HasChargeOwnerId ? request.ChargeOwnerId : defaultChargeOwnerId!,

--- a/source/IntegrationTests/EventBuilders/WholesaleServicesResponseEventBuilder.cs
+++ b/source/IntegrationTests/EventBuilders/WholesaleServicesResponseEventBuilder.cs
@@ -67,7 +67,7 @@ public static class WholesaleServicesResponseEventBuilder
         // If no charge types are specified, add some default charge types representing the different charges an actor can have.
         var chargeTypes = request.ChargeTypes.ToList();
         if (chargeTypes.Count == 0)
-            chargeTypes.Add(new ChargeType { ChargeCode = "12345678", ChargeType_ = DataHubNames.ChargeType.Tariff });
+            chargeTypes.Add(new ChargeType { ChargeCode = "12345678", ChargeType_ = BuildingBlocks.Domain.Models.ChargeType.Tariff.Name });
 
         var periodStart = InstantPattern.General.Parse(request.PeriodStart).Value;
         var periodEnd = InstantPattern.General.Parse(request.PeriodEnd).Value;

--- a/source/IntegrationTests/EventBuilders/WholesaleServicesResponseEventBuilder.cs
+++ b/source/IntegrationTests/EventBuilders/WholesaleServicesResponseEventBuilder.cs
@@ -34,6 +34,7 @@ using PMBusinessReason = Energinet.DataHub.ProcessManager.Components.Abstraction
 using PMChargeType = Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects.ChargeType;
 using PMResolution = Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects.Resolution;
 using PMSettlementVersion = Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects.SettlementVersion;
+using Resolution = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Resolution;
 
 namespace Energinet.DataHub.EDI.IntegrationTests.EventBuilders;
 
@@ -78,7 +79,7 @@ public static class WholesaleServicesResponseEventBuilder
                 var series = chargeTypes.Select(
                     ct =>
                     {
-                        var resolution = request.Resolution == DataHubNames.Resolution.Monthly
+                        var resolution = request.Resolution == Resolution.Monthly.Name
                             ? WholesaleServicesRequestSeries.Types.Resolution.Monthly
                             : WholesaleServicesRequestSeries.Types.Resolution.Hour;
 
@@ -120,7 +121,7 @@ public static class WholesaleServicesResponseEventBuilder
                     }).ToList();
 
                 // When the resolution is monthly and no charge types are specified, series should contain a total monthly amount result.
-                if (request.Resolution == DataHubNames.Resolution.Monthly
+                if (request.Resolution == Resolution.Monthly.Name
                     && request.ChargeTypes.Count == 0)
                 {
                     var totalMonthlyAmountSeries = new WholesaleServicesRequestSeries()

--- a/source/OutgoingMessages.Infrastructure/Databricks/CalculationResults/Mappers/RequestedCalculationTypeMapper.cs
+++ b/source/OutgoingMessages.Infrastructure/Databricks/CalculationResults/Mappers/RequestedCalculationTypeMapper.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.Request;
 
@@ -22,20 +23,20 @@ public static class RequestedCalculationTypeMapper
 {
     public static CalculationType ToRequestedCalculationType(string businessReason, string? settlementVersion)
     {
-        if (businessReason != DataHubNames.BusinessReason.Correction && settlementVersion != null)
+        if (businessReason != BusinessReason.Correction.Name && settlementVersion != null)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(settlementVersion),
                 settlementVersion,
-                $"Value must be null when {nameof(businessReason)} is not {nameof(DataHubNames.BusinessReason.Correction)}.");
+                $"Value must be null when {nameof(businessReason)} is not {nameof(BusinessReason.Correction)}.");
         }
 
         return businessReason switch
         {
-            DataHubNames.BusinessReason.BalanceFixing => CalculationType.BalanceFixing,
-            DataHubNames.BusinessReason.PreliminaryAggregation => CalculationType.Aggregation,
-            DataHubNames.BusinessReason.WholesaleFixing => CalculationType.WholesaleFixing,
-            DataHubNames.BusinessReason.Correction => settlementVersion switch
+            _ when businessReason == BusinessReason.BalanceFixing.Name => CalculationType.BalanceFixing,
+            _ when businessReason == BusinessReason.PreliminaryAggregation.Name => CalculationType.Aggregation,
+            _ when businessReason == BusinessReason.WholesaleFixing.Name => CalculationType.WholesaleFixing,
+            _ when businessReason == BusinessReason.Correction.Name => settlementVersion switch
             {
                 DataHubNames.SettlementVersion.FirstCorrection => CalculationType.FirstCorrectionSettlement,
                 DataHubNames.SettlementVersion.SecondCorrection => CalculationType.SecondCorrectionSettlement,

--- a/source/OutgoingMessages.Infrastructure/Databricks/CalculationResults/Mappers/TimeSeriesTypeMapper.cs
+++ b/source/OutgoingMessages.Infrastructure/Databricks/CalculationResults/Mappers/TimeSeriesTypeMapper.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.CalculationResults.Request;
 
 namespace Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.CalculationResults.Mappers;
@@ -23,9 +24,9 @@ public static class TimeSeriesTypeMapper
     {
         return meteringPointType switch
         {
-            DataHubNames.MeteringPointType.Production => TimeSeriesType.Production,
-            DataHubNames.MeteringPointType.Exchange => TimeSeriesType.NetExchangePerGa,
-            DataHubNames.MeteringPointType.Consumption => settlementMethod switch
+            _ when meteringPointType == MeteringPointType.Production.Name => TimeSeriesType.Production,
+            _ when meteringPointType == MeteringPointType.Exchange.Name => TimeSeriesType.NetExchangePerGa,
+            _ when meteringPointType == MeteringPointType.Consumption.Name => settlementMethod switch
             {
                 DataHubNames.SettlementMethod.NonProfiled => TimeSeriesType.NonProfiledConsumption,
                 DataHubNames.SettlementMethod.Flex => TimeSeriesType.FlexConsumption,

--- a/source/Tests/Infrastructure/OutgoingMessages/NotifyWholesaleServices/NotifyWholesaleServicesDocumentWriterTests.cs
+++ b/source/Tests/Infrastructure/OutgoingMessages/NotifyWholesaleServices/NotifyWholesaleServicesDocumentWriterTests.cs
@@ -146,7 +146,7 @@ public class NotifyWholesaleServicesDocumentWriterTests(DocumentValidationFixtur
             SettlementMethod: null,
             OriginalTransactionIdReference: null);
         var header = new OutgoingMessageHeader(
-            DataHubNames.BusinessReason.WholesaleFixing,
+            BusinessReason.WholesaleFixing.Name,
             SampleData.SenderId.Value,
             ActorRole.EnergySupplier.Code,
             SampleData.ReceiverId.Value,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
This pull request includes a series of changes aimed at replacing hardcoded string constants with properties from the `BusinessReason`, `MeteringPointType`, `Resolution`, `MeasurementUnit` and `ChargeType `. This refactoring simplifies the codebase and ensures consistency across the application. The most important changes include modifying various methods and classes to use the new properties and removing obsolete constants from the `DataHubNames` class.

Refactoring to use properties from `BusinessReason` and `MeteringPointType`:

* [`source/B2BApi/Functions/EnqueueMessages/BRS_026/EnqueueHandler_Brs_026_V1.cs`](diffhunk://#diff-f185f02595a6de8aea97ef89ca35e56e051da2a84a0eac513e3ffbfee2804c02L194-R207): Updated the `MapCalculationType` and `MapTimeSeriesType` methods to use `BusinessReason` and `MeteringPointType` properties instead of hardcoded string constants. [[1]](diffhunk://#diff-f185f02595a6de8aea97ef89ca35e56e051da2a84a0eac513e3ffbfee2804c02L194-R207) [[2]](diffhunk://#diff-f185f02595a6de8aea97ef89ca35e56e051da2a84a0eac513e3ffbfee2804c02L229-R231)
* [`source/Edi.UnitTests/Builders/AggregatedTimeSeriesRequestBuilder.cs`](diffhunk://#diff-5e61fa907a436608c408f02a27a52b5f26db4391c97a5615d58147d7a672cbecR16): Changed the initialization of `_meteringPointType` and `_businessReason` to use the corresponding properties. [[1]](diffhunk://#diff-5e61fa907a436608c408f02a27a52b5f26db4391c97a5615d58147d7a672cbecR16) [[2]](diffhunk://#diff-5e61fa907a436608c408f02a27a52b5f26db4391c97a5615d58147d7a672cbecL25-R26) [[3]](diffhunk://#diff-5e61fa907a436608c408f02a27a52b5f26db4391c97a5615d58147d7a672cbecL44-R45)
* [`source/Edi.UnitTests/Builders/WholesaleServicesRequestBuilder.cs`](diffhunk://#diff-488eceacea008288ae6af1832880622a37deea950ab4a351469fd1ed9c3358b7L27-R28): Modified the `_businessReason` initialization to use the `BusinessReason` property.

Removal of obsolete constants:

* [`source/BuildingBlocks.Domain/DataHub/DataHubNames.cs`](diffhunk://#diff-3938680b9347397e1176c869992147a4371b709beb880bac30da88237f0c2ee9L30-L78): Removed obsolete nested classes and their constants, which are now replaced by properties from other classes.

Unit tests and test data updates:

* [`source/Edi.UnitTests/Factories/AggregatedTimeSeries/AggregatedTimeSeriesRequestFactoryTests.cs`](diffhunk://#diff-6e36294f3bf2e245492e5c2b9142b13f094e04a2f25a6348694b1f2aa99be3ebR16): Updated test methods to use the new properties and adjusted the `CreateRequest` method accordingly. [[1]](diffhunk://#diff-6e36294f3bf2e245492e5c2b9142b13f094e04a2f25a6348694b1f2aa99be3ebR16) [[2]](diffhunk://#diff-6e36294f3bf2e245492e5c2b9142b13f094e04a2f25a6348694b1f2aa99be3ebL38-R39) [[3]](diffhunk://#diff-6e36294f3bf2e245492e5c2b9142b13f094e04a2f25a6348694b1f2aa99be3ebL62-R64) [[4]](diffhunk://#diff-6e36294f3bf2e245492e5c2b9142b13f094e04a2f25a6348694b1f2aa99be3ebL86-R89) [[5]](diffhunk://#diff-6e36294f3bf2e245492e5c2b9142b13f094e04a2f25a6348694b1f2aa99be3ebL237-R240) [[6]](diffhunk://#diff-6e36294f3bf2e245492e5c2b9142b13f094e04a2f25a6348694b1f2aa99be3ebL250-R253)
* [`source/Edi.UnitTests/Mappers/ChargeTypeMapperTests.cs`](diffhunk://#diff-5dd7d8e7ca785ccc57222ada4adab4e255bbbd52b0d36aa2ce8be18d71fd9bb9L15-R15): Refactored to use `MemberData` for test data and replaced constants with properties. [[1]](diffhunk://#diff-5dd7d8e7ca785ccc57222ada4adab4e255bbbd52b0d36aa2ce8be18d71fd9bb9L15-R15) [[2]](diffhunk://#diff-5dd7d8e7ca785ccc57222ada4adab4e255bbbd52b0d36aa2ce8be18d71fd9bb9R24-R32)
* [`source/Edi.UnitTests/Mappers/RequestedCalculationTypeMapperTests.cs`](diffhunk://#diff-2f96cce4a916c78004e65c63eac6d5265a83b757d6a2354e110ffe4ecccb8a05R16): Added `MemberData` for valid and invalid business reasons and settlement versions, and replaced constants with properties. [[1]](diffhunk://#diff-2f96cce4a916c78004e65c63eac6d5265a83b757d6a2354e110ffe4ecccb8a05R16) [[2]](diffhunk://#diff-2f96cce4a916c78004e65c63eac6d5265a83b757d6a2354e110ffe4ecccb8a05R26-R53) [[3]](diffhunk://#diff-2f96cce4a916c78004e65c63eac6d5265a83b757d6a2354e110ffe4ecccb8a05L43-R64)
* [`source/Edi.UnitTests/Mappers/ResolutionMapperTests.cs`](diffhunk://#diff-baaad56810c9fa725daf86aa470268ea913061a9e68555b01ec8f9d2a1f187bfR16): Updated to use `MemberData` for valid resolutions and replaced constants with properties. [[1]](diffhunk://#diff-baaad56810c9fa725daf86aa470268ea913061a9e68555b01ec8f9d2a1f187bfR16) [[2]](diffhunk://#diff-baaad56810c9fa725daf86aa470268ea913061a9e68555b01ec8f9d2a1f187bfR25-R33)
* [`source/Edi.UnitTests/Validators/AggregatedTimeSeriesRequest/AggregatedTimeSeriesRequestValidatorTests.cs`](diffhunk://#diff-3533f37e2a936821a1f0c0b106f12c337847183e264c892e80593832bd9833dfR16): Included the new `Models` namespace for updated property references.
## References
https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/495
## Checklist
- [x] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003) https://github.com/Energinet-DataHub/dh3-environments/actions/runs/13324532113
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task