### PR TITLE
fix: where grid operator received not tax charges from syo

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -105,13 +105,25 @@ jobs:
 
           - name: Integration tests - Behaviours - IncomingRequests V2
             paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
-            filter: (DisplayName~IntegrationTests.Behaviours)&(DisplayName~Behaviours.IncomingRequests)&(DisplayName~V2)&(DisplayName!~WholesaleServices)
+            filter: (DisplayName~IntegrationTests.Behaviours)&(DisplayName~Behaviours.IncomingRequests)&(DisplayName~V2)&(DisplayName!~WholesaleServices)&(DisplayName!~WithDelegation)
+            use_azure_functions_tools: true
+            contentroot_variable_name: empty # Means skip
+
+          - name: Integration tests - Behaviours - IncomingRequests V2 with Delegation
+            paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
+            filter: (DisplayName~IntegrationTests.Behaviours)&(DisplayName~Behaviours.IncomingRequests)&(DisplayName~V2)&(DisplayName!~WholesaleServices)&(DisplayName~WithDelegation)
             use_azure_functions_tools: true
             contentroot_variable_name: empty # Means skip
 
           - name: Integration tests - Behaviours - IncomingRequests V2 WholesaleServices
             paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
-            filter: (DisplayName~IntegrationTests.Behaviours)&(DisplayName~Behaviours.IncomingRequests)&(DisplayName~V2)&(DisplayName~WholesaleServices)
+            filter: (DisplayName~IntegrationTests.Behaviours)&(DisplayName~Behaviours.IncomingRequests)&(DisplayName~V2)&(DisplayName~WholesaleServices)&(DisplayName!~WithDelegation)
+            use_azure_functions_tools: true
+            contentroot_variable_name: empty # Means skip
+
+          - name: Integration tests - Behaviours - IncomingRequests V2 WholesaleServices with Delegation
+            paths: \source\IntegrationTests\bin\Release\net8.0\Energinet.DataHub.EDI.IntegrationTests.dll
+            filter: (DisplayName~IntegrationTests.Behaviours)&(DisplayName~Behaviours.IncomingRequests)&(DisplayName~V2)&(DisplayName~WholesaleServices)&(DisplayName~WithDelegation)
             use_azure_functions_tools: true
             contentroot_variable_name: empty # Means skip
 

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2Tests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2Tests.cs
@@ -479,7 +479,9 @@ public class GivenWholesaleServicesRequestV2Tests : WholesaleServicesBehaviourTe
             peekDocumentFormat);
 
         // Assert
-        var acceptedChargeCodes = new List<string>() { "40000", "41000", "45013", "EA-001" };
+        var acceptedChargeCodes = actorRole != ActorRole.SystemOperator
+         ? new List<string>() { "EA-001" }
+         : new List<string>() { "40000", "41000", "45013" };
         var acceptedResolutions = new List<Resolution>() { Resolution.Daily, Resolution.Hourly };
         using (new AssertionScope())
         {

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2Tests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2Tests.cs
@@ -116,7 +116,7 @@ public class GivenWholesaleServicesRequestV2Tests : WholesaleServicesBehaviourTe
 
         var senderSpy = CreateServiceBusSenderSpy(ServiceBusSenderNames.ProcessManagerTopic);
         var energySupplierNumber = ActorNumber.Create("5790001662233");
-        var chargeOwnerNumber = actorRole == ActorRole.SystemOperator ? ActorNumber.Create("5790000432752") : ActorNumber.Create("8500000000502");
+        var chargeOwnerNumber = actorRole == ActorRole.SystemOperator ? ActorNumber.Create(DataHubDetails.SystemOperatorActorNumber.Value) : ActorNumber.Create("8500000000502");
         var gridOperatorNumber = ActorNumber.Create("4444444444444");
         var actor = (ActorNumber: actorRole == ActorRole.EnergySupplier
             ? energySupplierNumber
@@ -251,7 +251,7 @@ public class GivenWholesaleServicesRequestV2Tests : WholesaleServicesBehaviourTe
 
         var senderSpy = CreateServiceBusSenderSpy(ServiceBusSenderNames.ProcessManagerTopic);
         var energySupplierNumber = ActorNumber.Create("5790001662233");
-        var chargeOwnerNumber = actorRole == ActorRole.SystemOperator ? ActorNumber.Create("5790000432752") : ActorNumber.Create("8500000000502");
+        var chargeOwnerNumber = actorRole == ActorRole.SystemOperator ? ActorNumber.Create(DataHubDetails.SystemOperatorActorNumber.Value) : ActorNumber.Create("8500000000502");
         var actor = (ActorNumber: actorRole == ActorRole.EnergySupplier
             ? energySupplierNumber
             : chargeOwnerNumber, ActorRole: actorRole);
@@ -403,7 +403,7 @@ public class GivenWholesaleServicesRequestV2Tests : WholesaleServicesBehaviourTe
             ? ActorNumber.Create("5790001662233")
             : null;
         var chargeOwnerOrNull = actorRole == ActorRole.SystemOperator
-            ? ActorNumber.Create("5790000432752")
+            ? ActorNumber.Create(DataHubDetails.SystemOperatorActorNumber.Value)
             : null;
         var gridOperatorNumber = ActorNumber.Create("4444444444444");
         var actor = (ActorNumber: energySupplierOrNull != null
@@ -464,7 +464,7 @@ public class GivenWholesaleServicesRequestV2Tests : WholesaleServicesBehaviourTe
         // It is very important that the generated data is correct,
         // since (almost) all assertion after this point is based on this data
         var defaultGridAreas = gridAreaOrNull == null ? testDataDescription.GridAreaCodes : null;
-        var defaultChargeOwner = chargeOwnerOrNull == null ? "5790000432752" : null;
+        var defaultChargeOwner = chargeOwnerOrNull == null ? DataHubDetails.SystemOperatorActorNumber.Value : null;
         var defaultEnergySupplier = energySupplierOrNull == null ? "5790001662233" : null;
         var requestCalculatedWholesaleServicesInputV1 = message.ParseInput<RequestCalculatedWholesaleServicesInputV1>();
         var requestCalculatedWholesaleServicesAccepted = WholesaleServicesResponseEventBuilder
@@ -516,7 +516,7 @@ public class GivenWholesaleServicesRequestV2Tests : WholesaleServicesBehaviourTe
                     ReceiverRole: actor.ActorRole,
                     SenderId: DataHubDetails.DataHubActorNumber.Value, // Sender is always DataHub
                     SenderRole: ActorRole.MeteredDataAdministrator,
-                    ChargeTypeOwner: chargeOwnerOrNull?.Value ?? "5790000432752",
+                    ChargeTypeOwner: chargeOwnerOrNull?.Value ?? DataHubDetails.SystemOperatorActorNumber.Value,
                     ChargeCode: peekResultChargeCode,
                     ChargeType: ChargeType.Tariff,
                     Currency: Currency.DanishCrowns,
@@ -674,7 +674,7 @@ public class GivenWholesaleServicesRequestV2Tests : WholesaleServicesBehaviourTe
         var senderSpy = CreateServiceBusSenderSpy(ServiceBusSenderNames.ProcessManagerTopic);
         var energySupplierNumber = ActorNumber.Create("5790001662233");
         var chargeOwnerNumber = actorRole == ActorRole.SystemOperator
-                                ? ActorNumber.Create("5790000432752")
+                                ? ActorNumber.Create(DataHubDetails.SystemOperatorActorNumber.Value)
                                 : actorRole == ActorRole.GridAccessProvider
                                     ? ActorNumber.Create("8500000000502") : null;
         var gridOperatorNumber = ActorNumber.Create("4444444444444");

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2Tests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2Tests.cs
@@ -747,10 +747,8 @@ public class GivenWholesaleServicesRequestV2Tests : WholesaleServicesBehaviourTe
 
         // Assert
         var expectedResultsNumber = actorRole == ActorRole.EnergySupplier
-                ? 8 // 7 for each charge type (monthly) and 1 for charge owner (total amount)
-                : actorRole == ActorRole.GridAccessProvider
-                    ? 4 // 3 for each charge type (monthly) and 1 for charge owner (total amount)
-                    : 5; // 3 for each charge type (monthly) and 2 for charge owner (total amount)
+            ? 8 // 7 for each charge type (monthly) and 1 for charge owner (total amount)
+            : 4; // 3 for each charge type (monthly) and 1 for charge owner (total amount)
         using (new AssertionScope())
         {
            peekResults

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2WithDelegationTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2WithDelegationTests.cs
@@ -276,7 +276,7 @@ public class GivenWholesaleServicesRequestV2WithDelegationTests : WholesaleServi
         var senderSpy = CreateServiceBusSenderSpy(ServiceBusSenderNames.ProcessManagerTopic);
         var energySupplierNumber = ActorNumber.Create("5790001662233");
         var chargeOwnerNumber = delegatedFromRole == ActorRole.SystemOperator
-            ? ActorNumber.Create("5790000432752")
+            ? ActorNumber.Create(DataHubDetails.SystemOperatorActorNumber.Value)
             : ActorNumber.Create("8500000000502");
         var gridOperatorNumber = ActorNumber.Create("4444444444444");
 
@@ -580,7 +580,7 @@ public class GivenWholesaleServicesRequestV2WithDelegationTests : WholesaleServi
 
         var senderSpy = CreateServiceBusSenderSpy(ServiceBusSenderNames.ProcessManagerTopic);
         var energySupplierNumber = ActorNumber.Create("5790001662233");
-        var chargeOwnerNumber = ActorNumber.Create("5790000432752");
+        var chargeOwnerNumber = ActorNumber.Create(DataHubDetails.SystemOperatorActorNumber.Value);
         var gridOperatorNumber = ActorNumber.Create("4444444444444");
         var transactionId = TransactionId.From("12356478912356478912356478912356478");
 
@@ -723,7 +723,7 @@ public class GivenWholesaleServicesRequestV2WithDelegationTests : WholesaleServi
         var senderSpy = CreateServiceBusSenderSpy(ServiceBusSenderNames.ProcessManagerTopic);
         var energySupplierNumber = ActorNumber.Create("5790001662233");
         var chargeOwnerNumber = delegatedFromRole == ActorRole.SystemOperator
-            ? ActorNumber.Create("5790000432752")
+            ? ActorNumber.Create(DataHubDetails.SystemOperatorActorNumber.Value)
             : ActorNumber.Create("8500000000502");
         var gridOperatorNumber = ActorNumber.Create("4444444444444");
 

--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2WithDelegationTests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenWholesaleServicesRequestV2WithDelegationTests.cs
@@ -269,13 +269,15 @@ public class GivenWholesaleServicesRequestV2WithDelegationTests : WholesaleServi
 
         // Arrange
         var testDataDescription = GivenDatabricksResultDataForWholesaleResultAmountPerChargeInTwoGridAreas();
-        var exampleWholesaleResultMessageForActor = delegatedToRole == ActorRole.EnergySupplier
+        var exampleWholesaleResultMessageForActor = delegatedFromRole == ActorRole.EnergySupplier
             ? testDataDescription.ExampleWholesaleResultMessageDataForEnergySupplier
             : testDataDescription.ExampleWholesaleResultMessageDataForSystemOperator;
 
         var senderSpy = CreateServiceBusSenderSpy(ServiceBusSenderNames.ProcessManagerTopic);
         var energySupplierNumber = ActorNumber.Create("5790001662233");
-        var chargeOwnerNumber = ActorNumber.Create("5790000432752");
+        var chargeOwnerNumber = delegatedFromRole == ActorRole.SystemOperator
+            ? ActorNumber.Create("5790000432752")
+            : ActorNumber.Create("8500000000502");
         var gridOperatorNumber = ActorNumber.Create("4444444444444");
 
         var delegatedToActor = (ActorNumber: ActorNumber.Create("2222222222222"), ActorRole: delegatedToRole);
@@ -701,7 +703,12 @@ public class GivenWholesaleServicesRequestV2WithDelegationTests : WholesaleServi
     /// </summary>
     [Theory]
     [MemberData(nameof(DocumentFormatsWithRoleCombinationsForNullGridArea))] // Grid operator can't make request without grid area
-    public async Task AndGiven_OriginalActorRequestsOwnDataWithDataInTwoGridAreas_When_OriginalActorPeeksAllMessages_Then_OriginalActorReceivesTwoNotifyWholesaleServicesDocumentWithCorrectContent(DocumentFormat incomingDocumentFormat, DocumentFormat peekDocumentFormat, ActorRole delegatedFromRole, ActorRole delegatedToRole)
+    public async Task
+        AndGiven_OriginalActorRequestsOwnDataWithDataInTwoGridAreas_When_OriginalActorPeeksAllMessages_Then_OriginalActorReceivesTwoNotifyWholesaleServicesDocumentWithCorrectContent(
+            DocumentFormat incomingDocumentFormat,
+            DocumentFormat peekDocumentFormat,
+            ActorRole delegatedFromRole,
+            ActorRole delegatedToRole)
     {
         /*
          *  --- PART 1: Receive request and send message to Process Manager ---
@@ -709,13 +716,15 @@ public class GivenWholesaleServicesRequestV2WithDelegationTests : WholesaleServi
 
         // Arrange
         var testDataDescription = GivenDatabricksResultDataForWholesaleResultAmountPerChargeInTwoGridAreas();
-        var exampleWholesaleResultMessageForActor = delegatedToRole == ActorRole.EnergySupplier
+        var exampleWholesaleResultMessageForActor = delegatedFromRole == ActorRole.EnergySupplier
             ? testDataDescription.ExampleWholesaleResultMessageDataForEnergySupplier
             : testDataDescription.ExampleWholesaleResultMessageDataForSystemOperator;
 
         var senderSpy = CreateServiceBusSenderSpy(ServiceBusSenderNames.ProcessManagerTopic);
         var energySupplierNumber = ActorNumber.Create("5790001662233");
-        var chargeOwnerNumber = ActorNumber.Create("5790000432752");
+        var chargeOwnerNumber = delegatedFromRole == ActorRole.SystemOperator
+            ? ActorNumber.Create("5790000432752")
+            : ActorNumber.Create("8500000000502");
         var gridOperatorNumber = ActorNumber.Create("4444444444444");
 
         var delegatedToActor = (ActorNumber: ActorNumber.Create("2222222222222"), ActorRole: delegatedToRole);

--- a/source/IntegrationTests/CalculationResults/RequestCalculationResult/WholesaleServicesQueriesCsvTests.cs
+++ b/source/IntegrationTests/CalculationResults/RequestCalculationResult/WholesaleServicesQueriesCsvTests.cs
@@ -226,12 +226,12 @@ public class WholesaleServicesQueriesCsvTests
                 AmountType: AmountType.MonthlyAmountPerCharge,
                 GridAreaCodes: ["804"],
                 EnergySupplierId: "5790001687137",
-                ChargeOwnerId: "5790000432752",
-                ChargeTypes: [("EA-003", ChargeType.Tariff)],
+                ChargeOwnerId: "8100000000047",
+                ChargeTypes: [("4300", ChargeType.Tariff)],
                 CalculationType: null, // This is how we denote 'latest correction'
                 Period: totalPeriod,
                 RequestedForEnergySupplier: isEnergySupplier,
-                RequestedForActorNumber: isEnergySupplier ? "5790001687137" : "5790000432752");
+                RequestedForActorNumber: isEnergySupplier ? "5790001687137" : "8100000000047");
 
             // Act
             var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -242,7 +242,41 @@ public class WholesaleServicesQueriesCsvTests
                     ats.CalculationType, ats.Version, ats.TimeSeriesPoints.Count))
                 .Should()
                 .BeEquivalentTo([
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "EA-003", AmountType.MonthlyAmountPerCharge, Resolution.Month, (MeteringPointType?)null, (SettlementMethod?)null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                    ("804", "5790001687137", "8100000000047", ChargeType.Tariff, "4300", AmountType.MonthlyAmountPerCharge, Resolution.Month, (MeteringPointType?)null, (SettlementMethod?)null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                ]);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Given_AllQueryParametersAssignedValuesAsSyoWithLatestCorrection_When_Queried_Then_LatestCorrectionReturned(
+            bool isChargerOwner)
+        {
+            var totalPeriod = new OutgoingMessages.Interfaces.Models.CalculationResults.Period(
+                Instant.FromUtc(2021, 12, 31, 23, 0),
+                Instant.FromUtc(2022, 1, 31, 23, 0));
+
+            var parameters = new WholesaleServicesQueryParameters(
+                AmountType: AmountType.MonthlyAmountPerCharge,
+                GridAreaCodes: ["804"],
+                EnergySupplierId: "5790001687137",
+                ChargeOwnerId: isChargerOwner ? "5790000432752" : "8100000000047",
+                ChargeTypes: [("40000", ChargeType.Tariff)],
+                CalculationType: null, // This is how we denote 'latest correction'
+                Period: totalPeriod,
+                RequestedForEnergySupplier: false,
+                RequestedForActorNumber: "5790000432752");
+
+            // Act
+            var actual = await Sut.GetAsync(parameters).ToListAsync();
+
+            using var assertionScope = new AssertionScope();
+            actual.Select(ats => (ats.GridArea, ats.EnergySupplierId, ats.ChargeOwnerId, ats.ChargeType, ats.ChargeCode,
+                    ats.AmountType, ats.Resolution, ats.MeteringPointType, ats.SettlementMethod,
+                    ats.CalculationType, ats.Version, ats.TimeSeriesPoints.Count))
+                .Should()
+                .BeEquivalentTo([
+                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "40000", AmountType.MonthlyAmountPerCharge, Resolution.Month, (MeteringPointType?)null, (SettlementMethod?)null, CalculationType.ThirdCorrectionSettlement, 2, 1),
                 ]);
         }
 
@@ -321,11 +355,8 @@ public class WholesaleServicesQueriesCsvTests
                 ]);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task Given_ChargeOwnerForSpecificGridAreaAndLatestCorrection_When_Queried_Then_LatestCorrectionReturned(
-            bool isEnergySupplier)
+        [Fact]
+        public async Task Given_ChargeOwnerForSpecificGridAreaAndLatestCorrection_When_Queried_Then_LatestCorrectionReturned()
         {
             var totalPeriod = new OutgoingMessages.Interfaces.Models.CalculationResults.Period(
                 Instant.FromUtc(2021, 12, 31, 23, 0),
@@ -342,8 +373,8 @@ public class WholesaleServicesQueriesCsvTests
                 ChargeTypes: [],
                 CalculationType: null,
                 Period: totalPeriod,
-                RequestedForEnergySupplier: isEnergySupplier,
-                RequestedForActorNumber: isEnergySupplier ? "5790001687137" : "5790000432752");
+                RequestedForEnergySupplier: true,
+                RequestedForActorNumber: "5790001687137");
 
             // Act
             var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -352,41 +383,45 @@ public class WholesaleServicesQueriesCsvTests
                     ats.CalculationType, ats.Version, ats.TimeSeriesPoints.Count))
                 .Should()
                 .BeEquivalentTo([
-                    ("584", "5790000701278", "5790000432752", ChargeType.Tariff, "45013", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
-                    ("584", "5790000701278", "5790000432752", ChargeType.Tariff, "41000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
-                    ("584", "5790000701278", "5790000432752", ChargeType.Tariff, "42000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
-                    ("584", "5790000701278", "5790000432752", ChargeType.Tariff, "40000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
                     ("584", "5790000701278", "5790000432752", ChargeType.Tariff, "EA-001", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
-
-                    ("584", "5790001095390", "5790000432752", ChargeType.Tariff, "41000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
-                    ("584", "5790001095390", "5790000432752", ChargeType.Tariff, "42000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
-                    ("584", "5790001095390", "5790000432752", ChargeType.Tariff, "45013", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
-                    ("584", "5790001095390", "5790000432752", ChargeType.Tariff, "40000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
                     ("584", "5790001095390", "5790000432752", ChargeType.Tariff, "EA-001", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
-                    ("584", "5790001095390", "5790000432752", ChargeType.Tariff, "42030", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.OwnProduction, null, CalculationType.SecondCorrectionSettlement, 3, 31),
-
                     ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "EA-001", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.Flex, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "40000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.Flex, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "41000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.Flex, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "45013", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.Flex, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "42000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.Flex, CalculationType.ThirdCorrectionSettlement, 2, 31),
                     ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "EA-002", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.Flex, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "41000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "45013", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "40000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.ThirdCorrectionSettlement, 2, 31),
                     ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "EA-001", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.ThirdCorrectionSettlement, 2, 31),
                     ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "EA-002", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "42000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "41000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.ConsumptionFromGrid, (SettlementMethod?)null, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "EA-003", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.ElectricalHeating, null, CalculationType.ThirdCorrectionSettlement, 2, 31),
+                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "EA-003", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.ElectricalHeating, (SettlementMethod?)null, CalculationType.ThirdCorrectionSettlement, 2, 31),
                     ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "EA-001", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.ElectricalHeating, null, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "41000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.NetConsumption, null, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "40000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.NetConsumption, null, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "42000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.NetConsumption, null, CalculationType.ThirdCorrectionSettlement, 2, 31),
                     ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "EA-001", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.NetConsumption, null, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "40010", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Production, null, CalculationType.ThirdCorrectionSettlement, 2, 31),
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "45012", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Production, null, CalculationType.ThirdCorrectionSettlement, 2, 31),
                 ]);
+        }
+
+        [Fact]
+        public async Task
+            Given_GridAreaOwnerRequestsAmountPerChargeWithChargeOwner_WhenChargeIsNotTaxAndChargeOwnerIsSyo_Then_NoDataReturned()
+        {
+            var gridAreaOwnerAsRequester = "8100000000007";
+            var syoChargeOwner = "5790000432752";
+            var period = new OutgoingMessages.Interfaces.Models.CalculationResults.Period(
+                Instant.FromUtc(2021, 12, 31, 23, 0),
+                Instant.FromUtc(2022, 1, 31, 23, 0));
+
+            var parameters = new WholesaleServicesQueryParameters(
+                AmountType: AmountType.AmountPerCharge,
+                GridAreaCodes: ["804"],
+                EnergySupplierId: null,
+                ChargeOwnerId: syoChargeOwner,
+                ChargeTypes: [("40000", ChargeType.Tariff)],
+                CalculationType: null, // This is how we denote 'latest correction'
+                Period: period,
+                RequestedForEnergySupplier: false,
+                RequestedForActorNumber: gridAreaOwnerAsRequester);
+
+            // Act
+            var actual = await Sut.GetAsync(parameters).ToListAsync();
+
+            using var assertionScope = new AssertionScope();
+            // New charge owner receives all grid area owner charges
+            actual.Should().BeEmpty("No data should be returned when the charge owner is the system operator");
         }
 
         [Fact]
@@ -517,12 +552,12 @@ public class WholesaleServicesQueriesCsvTests
                 AmountType: AmountType.AmountPerCharge,
                 GridAreaCodes: ["804"],
                 EnergySupplierId: "5790001687137",
-                ChargeOwnerId: "5790000432752",
-                ChargeTypes: [("EA-001", ChargeType.Tariff)],
+                ChargeOwnerId: "8100000000047",
+                ChargeTypes: [("4310", ChargeType.Subscription)],
                 CalculationType: CalculationType.SecondCorrectionSettlement,
                 Period: totalPeriod,
                 RequestedForEnergySupplier: isEnergySupplier,
-                RequestedForActorNumber: isEnergySupplier ? "5790001687137" : "5790000432752");
+                RequestedForActorNumber: isEnergySupplier ? "5790001687137" : "8100000000047");
 
             // Act
             var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -534,7 +569,54 @@ public class WholesaleServicesQueriesCsvTests
                 .BeEquivalentTo([
                     (MeteringPointType.Consumption, SettlementMethod.Flex, Instant.FromUtc(2022, 1, 15, 23, 0), Instant.FromUtc(2022, 1, 31, 23, 0), 16),
                     (MeteringPointType.Consumption, SettlementMethod.NonProfiled, Instant.FromUtc(2022, 1, 15, 23, 0), Instant.FromUtc(2022, 1, 31, 23, 0), 16),
-                    (MeteringPointType.ElectricalHeating, (SettlementMethod?)null, Instant.FromUtc(2022, 1, 15, 23, 0), Instant.FromUtc(2022, 1, 31, 23, 0), 16),
+                    (MeteringPointType.ConsumptionFromGrid, (SettlementMethod?)null, Instant.FromUtc(2022, 1, 15, 23, 0), Instant.FromUtc(2022, 1, 31, 23, 0), 16),
+                    (MeteringPointType.SupplyToGrid, null, Instant.FromUtc(2022, 1, 15, 23, 0), Instant.FromUtc(2022, 1, 31, 23, 0), 16),
+                    (MeteringPointType.Production, null, Instant.FromUtc(2022, 1, 15, 23, 0), Instant.FromUtc(2022, 1, 31, 23, 0), 16),
+                ]);
+        }
+
+        [Fact]
+        public async Task Given_EnergySupplierOnlyHaveDataForHalfOfThePeriodAndIsSyo_Then_DataReturnedWithModifiedPeriod()
+        {
+            /*
+             Business case example:
+             When a new Energy Supplier is being made responsible for a metering point in the middle of the month,
+             and they do not yet have a metering point in the grid area from the beginning of the month.
+             The result is that the Energy Supplier will only have results for the last half of the month.
+            */
+
+            await ClearAndAddDatabricksDataAsync(_fixture, _testOutputHelper);
+            await RemoveDataForEnergySupplierInTimespan(
+                _fixture,
+                _testOutputHelper,
+                "5790001687137",
+                Instant.FromUtc(2022, 1, 15, 0, 0),
+                null);
+
+            var totalPeriod = new OutgoingMessages.Interfaces.Models.CalculationResults.Period(
+                Instant.FromUtc(2021, 12, 31, 23, 0),
+                Instant.FromUtc(2022, 1, 31, 23, 0));
+
+            var parameters = new WholesaleServicesQueryParameters(
+                AmountType: AmountType.AmountPerCharge,
+                GridAreaCodes: ["804"],
+                EnergySupplierId: "5790001687137",
+                ChargeOwnerId: "5790000432752",
+                ChargeTypes: [("40000", ChargeType.Tariff)],
+                CalculationType: CalculationType.SecondCorrectionSettlement,
+                Period: totalPeriod,
+                RequestedForEnergySupplier: false,
+                RequestedForActorNumber: "5790000432752");
+
+            // Act
+            var actual = await Sut.GetAsync(parameters).ToListAsync();
+            using var assertionScope = new AssertionScope();
+            actual.Select(ats => (ats.MeteringPointType, ats.SettlementMethod, ats.Period.Start,
+                    ats.Period.End, ats.TimeSeriesPoints.Count))
+                .Should()
+                .BeEquivalentTo([
+                    (MeteringPointType.Consumption, SettlementMethod.Flex, Instant.FromUtc(2022, 1, 15, 23, 0), Instant.FromUtc(2022, 1, 31, 23, 0), 16),
+                    (MeteringPointType.Consumption, SettlementMethod.NonProfiled, Instant.FromUtc(2022, 1, 15, 23, 0), Instant.FromUtc(2022, 1, 31, 23, 0), 16),
                     (MeteringPointType.NetConsumption, (SettlementMethod?)null, Instant.FromUtc(2022, 1, 15, 23, 0), Instant.FromUtc(2022, 1, 31, 23, 0), 16),
                 ]);
         }
@@ -653,41 +735,37 @@ public class WholesaleServicesQueriesCsvTests
         [InlineData(true)]
         [InlineData(false)]
         public async Task
-            Given_EnergySupplierAndChargeOwnerWithLatestCorrectionButOnlyOneGridAreaWithCorrectionData_When_Queried_Then_DataReturnedForGridArea(
+            Given_EnergySupplierAndChargeOwnerWithLatestCorrectionButOnlyOneGridAreaWithCorrectionData_Then_DataReturnedForGridArea(
                 bool isEnergySupplier)
         {
             await ClearAndAddDatabricksDataAsync(_fixture, _testOutputHelper);
             await RemoveDataForCorrections(_fixture, _testOutputHelper, ["804", "543"]);
-
             var totalPeriod = new OutgoingMessages.Interfaces.Models.CalculationResults.Period(
                 Instant.FromUtc(2021, 12, 31, 23, 0),
                 Instant.FromUtc(2022, 1, 31, 23, 0));
-
             var parameters = new WholesaleServicesQueryParameters(
                 AmountType: AmountType.AmountPerCharge,
                 GridAreaCodes: ["543", "584"],
                 EnergySupplierId: "5790000701278",
-                ChargeOwnerId: "5790000432752",
+                ChargeOwnerId: "5790001089023",
                 ChargeTypes: [],
                 CalculationType: null,
                 Period: totalPeriod,
                 RequestedForEnergySupplier: isEnergySupplier,
-                RequestedForActorNumber: isEnergySupplier ? "5790000701278" : "5790000432752");
+                RequestedForActorNumber: isEnergySupplier ? "5790000701278" : "5790001089023");
 
             // Act
             var actual = await Sut.GetAsync(parameters).ToListAsync();
-
             using var assertionScope = new AssertionScope();
             actual.Select(ats => (ats.GridArea, ats.EnergySupplierId, ats.ChargeOwnerId, ats.ChargeType, ats.ChargeCode,
                     ats.AmountType, ats.Resolution, ats.MeteringPointType, ats.SettlementMethod,
                     ats.CalculationType, ats.Version, ats.TimeSeriesPoints.Count))
                 .Should()
                 .BeEquivalentTo([
-                    ("584", "5790000701278", "5790000432752", ChargeType.Tariff, "EA-001", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
-                    ("584", "5790000701278", "5790000432752", ChargeType.Tariff, "40000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
-                    ("584", "5790000701278", "5790000432752", ChargeType.Tariff, "41000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
-                    ("584", "5790000701278", "5790000432752", ChargeType.Tariff, "45013", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
-                    ("584", "5790000701278", "5790000432752", ChargeType.Tariff, "42000", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
+                    ("584", "5790000701278", "5790001089023", ChargeType.Subscription, "AB15001", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
+                    ("584", "5790000701278", "5790001089023", ChargeType.Tariff, "NT15001", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
+                    ("584", "5790000701278", "5790001089023", ChargeType.Tariff, "NT15003", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
+                    ("584", "5790000701278", "5790001089023", ChargeType.Tariff, "NT15004", AmountType.AmountPerCharge, Resolution.Day, MeteringPointType.Consumption, SettlementMethod.NonProfiled, CalculationType.SecondCorrectionSettlement, 3, 31),
                 ]);
         }
     }

--- a/source/IntegrationTests/CalculationResults/RequestCalculationResult/WholesaleServicesQueriesCsvTests.cs
+++ b/source/IntegrationTests/CalculationResults/RequestCalculationResult/WholesaleServicesQueriesCsvTests.cs
@@ -397,7 +397,7 @@ public class WholesaleServicesQueriesCsvTests
 
         [Fact]
         public async Task
-            Given_GridAreaOwnerRequestsAmountPerChargeWithChargeOwner_WhenChargeIsNotTaxAndChargeOwnerIsSyo_Then_NoDataReturned()
+            Given_GridAreaOwnerRequestsAmountPerChargeWithChargeOwner_When_ChargeIsNotTaxAndChargeOwnerIsSyo_Then_NoDataReturned()
         {
             var gridAreaOwnerAsRequester = "8100000000007";
             var syoChargeOwner = "5790000432752";
@@ -576,7 +576,7 @@ public class WholesaleServicesQueriesCsvTests
         }
 
         [Fact]
-        public async Task Given_EnergySupplierOnlyHaveDataForHalfOfThePeriodAndIsSyo_Then_DataReturnedWithModifiedPeriod()
+        public async Task Given_EnergySupplierOnlyHaveDataForHalfOfThePeriodAndIsSyo_When_Queried_Then_DataReturnedWithModifiedPeriod()
         {
             /*
              Business case example:
@@ -735,7 +735,7 @@ public class WholesaleServicesQueriesCsvTests
         [InlineData(true)]
         [InlineData(false)]
         public async Task
-            Given_EnergySupplierAndChargeOwnerWithLatestCorrectionButOnlyOneGridAreaWithCorrectionData_Then_DataReturnedForGridArea(
+            Given_EnergySupplierAndChargeOwnerWithLatestCorrectionButOnlyOneGridAreaWithCorrectionData_When_Queried_Then_DataReturnedForGridArea(
                 bool isEnergySupplier)
         {
             await ClearAndAddDatabricksDataAsync(_fixture, _testOutputHelper);

--- a/source/IntegrationTests/CalculationResults/RequestCalculationResult/WholesaleServicesQueriesCsvTests.cs
+++ b/source/IntegrationTests/CalculationResults/RequestCalculationResult/WholesaleServicesQueriesCsvTests.cs
@@ -16,6 +16,7 @@ using AutoFixture;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution;
 using Energinet.DataHub.Core.Databricks.SqlStatementExecution.Formats;
 using Energinet.DataHub.Core.TestCommon;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
 using Energinet.DataHub.EDI.IntegrationTests.CalculationResults.Fixtures;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.CalculationResults;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Databricks.CalculationResults.DeltaTableConstants;
@@ -260,12 +261,12 @@ public class WholesaleServicesQueriesCsvTests
                 AmountType: AmountType.MonthlyAmountPerCharge,
                 GridAreaCodes: ["804"],
                 EnergySupplierId: "5790001687137",
-                ChargeOwnerId: isChargerOwner ? "5790000432752" : "8100000000047",
+                ChargeOwnerId: isChargerOwner ? DataHubDetails.SystemOperatorActorNumber.Value : "8100000000047",
                 ChargeTypes: [("40000", ChargeType.Tariff)],
                 CalculationType: null, // This is how we denote 'latest correction'
                 Period: totalPeriod,
                 RequestedForEnergySupplier: false,
-                RequestedForActorNumber: "5790000432752");
+                RequestedForActorNumber: DataHubDetails.SystemOperatorActorNumber.Value);
 
             // Act
             var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -276,7 +277,7 @@ public class WholesaleServicesQueriesCsvTests
                     ats.CalculationType, ats.Version, ats.TimeSeriesPoints.Count))
                 .Should()
                 .BeEquivalentTo([
-                    ("804", "5790001687137", "5790000432752", ChargeType.Tariff, "40000", AmountType.MonthlyAmountPerCharge, Resolution.Month, (MeteringPointType?)null, (SettlementMethod?)null, CalculationType.ThirdCorrectionSettlement, 2, 1),
+                    ("804", "5790001687137", DataHubDetails.SystemOperatorActorNumber.Value, ChargeType.Tariff, "40000", AmountType.MonthlyAmountPerCharge, Resolution.Month, (MeteringPointType?)null, (SettlementMethod?)null, CalculationType.ThirdCorrectionSettlement, 2, 1),
                 ]);
         }
 
@@ -292,7 +293,7 @@ public class WholesaleServicesQueriesCsvTests
                 AmountType: AmountType.AmountPerCharge,
                 GridAreaCodes: ["804"],
                 EnergySupplierId: "5790001687137",
-                ChargeOwnerId: "5790000432752",
+                ChargeOwnerId: DataHubDetails.SystemOperatorActorNumber.Value,
                 ChargeTypes: [("EA-003", ChargeType.Tariff)],
                 CalculationType: null, // This is how we denote 'latest correction'
                 Period: totalPeriod,
@@ -315,7 +316,7 @@ public class WholesaleServicesQueriesCsvTests
                 AmountType: AmountType.MonthlyAmountPerCharge,
                 GridAreaCodes: ["804"],
                 EnergySupplierId: "5790001687137",
-                ChargeOwnerId: "5790000432752",
+                ChargeOwnerId: DataHubDetails.SystemOperatorActorNumber.Value,
                 ChargeTypes: [("EA-003", ChargeType.Tariff)],
                 CalculationType: null, // This is how we denote 'latest correction'
                 Period: totalPeriod,
@@ -337,7 +338,7 @@ public class WholesaleServicesQueriesCsvTests
                 AmountType: AmountType.AmountPerCharge,
                 GridAreaCodes: ["804"],
                 EnergySupplierId: "5790001687137",
-                ChargeOwnerId: "5790000432752",
+                ChargeOwnerId: DataHubDetails.SystemOperatorActorNumber.Value,
                 ChargeTypes: [],
                 CalculationType: null, // This is how we denote 'latest correction'
                 Period: totalPeriod,
@@ -369,7 +370,7 @@ public class WholesaleServicesQueriesCsvTests
                 AmountType: AmountType.AmountPerCharge,
                 GridAreaCodes: ["804", "584"],
                 EnergySupplierId: null,
-                ChargeOwnerId: "5790000432752",
+                ChargeOwnerId: DataHubDetails.SystemOperatorActorNumber.Value,
                 ChargeTypes: [],
                 CalculationType: null,
                 Period: totalPeriod,
@@ -400,7 +401,7 @@ public class WholesaleServicesQueriesCsvTests
             Given_GridAreaOwnerRequestsAmountPerChargeWithChargeOwner_When_ChargeIsNotTaxAndChargeOwnerIsSyo_Then_NoDataReturned()
         {
             var gridAreaOwnerAsRequester = "8100000000007";
-            var syoChargeOwner = "5790000432752";
+            var syoChargeOwner = DataHubDetails.SystemOperatorActorNumber.Value;
             var period = new OutgoingMessages.Interfaces.Models.CalculationResults.Period(
                 Instant.FromUtc(2021, 12, 31, 23, 0),
                 Instant.FromUtc(2022, 1, 31, 23, 0));
@@ -440,7 +441,7 @@ public class WholesaleServicesQueriesCsvTests
                 CalculationType: CalculationType.SecondCorrectionSettlement,
                 Period: totalPeriod,
                 false,
-                "5790000432752");
+                DataHubDetails.SystemOperatorActorNumber.Value);
 
             // Act
             var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -601,12 +602,12 @@ public class WholesaleServicesQueriesCsvTests
                 AmountType: AmountType.AmountPerCharge,
                 GridAreaCodes: ["804"],
                 EnergySupplierId: "5790001687137",
-                ChargeOwnerId: "5790000432752",
+                ChargeOwnerId: DataHubDetails.SystemOperatorActorNumber.Value,
                 ChargeTypes: [("40000", ChargeType.Tariff)],
                 CalculationType: CalculationType.SecondCorrectionSettlement,
                 Period: totalPeriod,
                 RequestedForEnergySupplier: false,
-                RequestedForActorNumber: "5790000432752");
+                RequestedForActorNumber: DataHubDetails.SystemOperatorActorNumber.Value);
 
             // Act
             var actual = await Sut.GetAsync(parameters).ToListAsync();
@@ -640,7 +641,7 @@ public class WholesaleServicesQueriesCsvTests
                 AmountType: AmountType.AmountPerCharge,
                 GridAreaCodes: ["804"],
                 EnergySupplierId: "5790001687137",
-                ChargeOwnerId: "5790000432752",
+                ChargeOwnerId: DataHubDetails.SystemOperatorActorNumber.Value,
                 ChargeTypes: [("EA-001", ChargeType.Tariff)],
                 CalculationType: CalculationType.SecondCorrectionSettlement,
                 Period: totalPeriod,
@@ -722,7 +723,7 @@ public class WholesaleServicesQueriesCsvTests
                 CalculationType: null,
                 Period: totalPeriod,
                 RequestedForEnergySupplier: false,
-                RequestedForActorNumber: "5790000432752");
+                RequestedForActorNumber: DataHubDetails.SystemOperatorActorNumber.Value);
 
             // Act
             var actual = await Sut.GetAsync(parameters).ToListAsync();

--- a/source/OutgoingMessages.Infrastructure/Databricks/CalculationResults/Statements/WholesaleServicesQuerySnippetProvider.cs
+++ b/source/OutgoingMessages.Infrastructure/Databricks/CalculationResults/Statements/WholesaleServicesQuerySnippetProvider.cs
@@ -160,9 +160,32 @@ public sealed class WholesaleServicesQuerySnippetProvider(
 
         if (_queryParameters.ChargeOwnerId is not null)
         {
-            sql += $"""
-                    AND {table}.{DatabricksContract.GetChargeOwnerIdColumnName()} = '{_queryParameters.ChargeOwnerId}'
-                    """;
+            if (_queryParameters is { RequestedForActorNumber: SystemOperatorActorNumber })
+            {
+                sql += $"""
+                            AND (
+                               {table}.{DatabricksContract.GetChargeOwnerIdColumnName()} = '{SystemOperatorActorNumber}'
+                                 AND {table}.{DatabricksContract.GetIsTaxColumnName()} = false
+                            )
+                        """;
+            }
+            else if (_queryParameters is { ChargeOwnerId: SystemOperatorActorNumber })
+            {
+                sql += $"""
+                            AND (
+                               {table}.{DatabricksContract.GetChargeOwnerIdColumnName()} = '{SystemOperatorActorNumber}'
+                                 AND {table}.{DatabricksContract.GetIsTaxColumnName()} = true
+                            )
+                        """;
+            }
+            else
+            {
+                sql += $"""
+                            AND (
+                               {table}.{DatabricksContract.GetChargeOwnerIdColumnName()} = '{_queryParameters.ChargeOwnerId}' 
+                            )
+                        """;
+            }
         }
 
         if (_queryParameters is { RequestedForEnergySupplier: false, ChargeOwnerId: null })


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

This PR fix incident: INC0429484, where the grid operator could get not tax charges from SYO.

The wholesale query has been updated to ensure only taxes are queried for grid operators + spilt the integration tests into multiple runs. 

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/13308989120
- [ ] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/internal-repo/1573