### PR TITLE
refac: Rename TimeSeries to MeasureData

### DIFF
--- a/source/B2BApi/OutgoingMessages/PeekRequestListener.cs
+++ b/source/B2BApi/OutgoingMessages/PeekRequestListener.cs
@@ -103,7 +103,9 @@ public class PeekRequestListener
         }
 
         var parsedMessageCategory = messageCategory != null && desiredDocumentFormat != DocumentFormat.Ebix
-            ? EnumerationType.FromName<MessageCategory>(messageCategory)
+            ? messageCategory.Equals("timeseries", StringComparison.InvariantCultureIgnoreCase)
+                ? MessageCategory.MeasureData
+                : EnumerationType.FromName<MessageCategory>(messageCategory)
             : MessageCategory.None;
 
         if (parsedMessageCategory == MessageCategory.MeasureData && !await _featureFlagManager.UsePeekTimeSeriesMessagesAsync().ConfigureAwait(false))

--- a/source/B2BApi/OutgoingMessages/PeekRequestListener.cs
+++ b/source/B2BApi/OutgoingMessages/PeekRequestListener.cs
@@ -106,7 +106,7 @@ public class PeekRequestListener
             ? EnumerationType.FromName<MessageCategory>(messageCategory)
             : MessageCategory.None;
 
-        if (parsedMessageCategory == MessageCategory.TimeSeries && !await _featureFlagManager.UsePeekTimeSeriesMessagesAsync().ConfigureAwait(false))
+        if (parsedMessageCategory == MessageCategory.MeasureData && !await _featureFlagManager.UsePeekTimeSeriesMessagesAsync().ConfigureAwait(false))
         {
             var noContentResponse = HttpResponseData.CreateResponse(request);
             noContentResponse.Headers.Add("Content-Type", $"{desiredDocumentFormat.GetContentType()}; charset=utf-8");

--- a/source/BuildingBlocks.Domain/Models/DocumentType.cs
+++ b/source/BuildingBlocks.Domain/Models/DocumentType.cs
@@ -20,8 +20,8 @@ public class DocumentType : EnumerationType
     public static readonly DocumentType RejectRequestAggregatedMeasureData = new(nameof(RejectRequestAggregatedMeasureData), MessageCategory.Aggregations);
     public static readonly DocumentType NotifyWholesaleServices = new(nameof(NotifyWholesaleServices), MessageCategory.Aggregations);
     public static readonly DocumentType RejectRequestWholesaleSettlement = new(nameof(RejectRequestWholesaleSettlement), MessageCategory.Aggregations);
-    public static readonly DocumentType NotifyValidatedMeasureData = new(nameof(NotifyValidatedMeasureData), MessageCategory.TimeSeries);
-    public static readonly DocumentType Acknowledgement = new(nameof(Acknowledgement), MessageCategory.TimeSeries);
+    public static readonly DocumentType NotifyValidatedMeasureData = new(nameof(NotifyValidatedMeasureData), MessageCategory.MeasureData);
+    public static readonly DocumentType Acknowledgement = new(nameof(Acknowledgement), MessageCategory.MeasureData);
 
     private DocumentType(string name, MessageCategory category)
         : base(name)

--- a/source/BuildingBlocks.Domain/Models/MessageCategory.cs
+++ b/source/BuildingBlocks.Domain/Models/MessageCategory.cs
@@ -18,7 +18,7 @@ public class MessageCategory : EnumerationType
 {
     public static readonly MessageCategory None = new(nameof(None));
     public static readonly MessageCategory Aggregations = new(nameof(Aggregations));
-    public static readonly MessageCategory TimeSeries = new(nameof(TimeSeries));
+    public static readonly MessageCategory MeasureData = new(nameof(MeasureData));
 
     // Message category can not be peeked
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Rename `TimeSeries` category to `MeasureData`.

## References

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/585

- d002 deploy without infra: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/13761276193
- d002 deploy with infra: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/13761308079 (https://github.com/Energinet-DataHub/dh3-infrastructure/pull/3105)

## Checklist
- [x] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task