### PR TITLE
fix: issue where quality code is send instead of name to PM

### DIFF
--- a/source/IntegrationTests/Behaviours/IncomingRequests/GivenMeteredDataForMeteringPointV2Tests.cs
+++ b/source/IntegrationTests/Behaviours/IncomingRequests/GivenMeteredDataForMeteringPointV2Tests.cs
@@ -107,7 +107,7 @@ public sealed class GivenMeteredDataForMeteringPointV2Tests(
                     .Select(eo => new EnergyObservation(
                         eo.Position.ToString(),
                         eo.Quantity.HasValue ? eo.Quantity.Value.ToString(CultureInfo.InvariantCulture) : null,
-                        eo.QualityName))
+                        eo.QualityName != null ? Quality.TryGetNameFromCode(eo.QualityName!, fallbackValue: eo.QualityName) : null))
                     .ToList()));
 
         /*

--- a/source/IntegrationTests/EventBuilders/MeteredDataForMeteringPointEventBuilder.cs
+++ b/source/IntegrationTests/EventBuilders/MeteredDataForMeteringPointEventBuilder.cs
@@ -65,7 +65,7 @@ public static class MeteredDataForMeteringPointEventBuilder
             .Select(eo => new AcceptedEnergyObservation(
                 int.Parse(eo.Position!),
                 eo.EnergyQuantity != null ? decimal.Parse(eo.EnergyQuantity.TrimEnd('M'), CultureInfo.InvariantCulture) : null,
-                eo.QuantityQuality != null ? PMQuality.FromName(Quality.FromCode(eo.QuantityQuality).Name) : null))
+                eo.QuantityQuality != null ? PMQuality.FromName(eo.QuantityQuality) : null))
             .ToList();
 
         var marketActorRecipients = new List<MarketActorRecipientV1>

--- a/source/Tests/Infrastructure/IncomingMessages/RequestProcessOrchestrationStarterTests.cs
+++ b/source/Tests/Infrastructure/IncomingMessages/RequestProcessOrchestrationStarterTests.cs
@@ -293,7 +293,7 @@ public class RequestProcessOrchestrationStarterTests
         const string expectedRegistrationDateFrom = "2023-04-30T22:00:00Z";
         const string expectedPosition = "1";
         const string expectedEnergyQuantity = "1001";
-        const string expectedQuantityQuality = "A03";
+        var expectedQuantityQuality = Quality.Estimated.Name;
 
         var meteringPointType = expectedMeteringPointType is not null
             ? MeteringPointType.FromCode(expectedMeteringPointType)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
We should not send the quality code for brs021, but instead translate it to a quality name.

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/13788752669
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task