### PR TITLE
chore: Disable extensive logging from EF Core

### DIFF
--- a/source/B2BApi.AppTests/Fixtures/B2BApiAppFixture.cs
+++ b/source/B2BApi.AppTests/Fixtures/B2BApiAppFixture.cs
@@ -419,6 +419,10 @@ public class B2BApiAppFixture : IAsyncLifetime
         appHostSettings.ProcessEnvironmentVariables.Add(
             "Logging__LogLevel__Default",
             "Information");
+        // => Disable extensive logging from EF Core
+        appHostSettings.ProcessEnvironmentVariables.Add(
+            "Logging__LogLevel__Microsoft.EntityFrameworkCore",
+            "Warning");
         // => Disable extensive logging when using Azure Storage
         appHostSettings.ProcessEnvironmentVariables.Add(
             "Logging__LogLevel__Azure.Core",

--- a/source/B2BApi.AppTests/Functions/EnqueueMessages/BRS_021/EnqueueBrs21ForwardMeteredDataMessagesTests.cs
+++ b/source/B2BApi.AppTests/Functions/EnqueueMessages/BRS_021/EnqueueBrs21ForwardMeteredDataMessagesTests.cs
@@ -24,12 +24,15 @@ using Energinet.DataHub.EDI.B2BApi.Functions.EnqueueMessages.BRS_021;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Tests.Logging;
 using Energinet.DataHub.EDI.IntegrationTests.Infrastructure.Authentication.MarketActors;
+using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.DataAccess;
 using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
 using Energinet.DataHub.ProcessManager.Shared.Extensions;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
 using PMCoreValueTypes = Energinet.DataHub.ProcessManager.Abstractions.Core.ValueObjects;
@@ -69,8 +72,9 @@ public class EnqueueBrs21ForwardMeteredDataMessagesTests : IAsyncLifetime
 
         // Arrange
         // => Given enqueue BRS-021 service bus message
+        var eventId = BuildingBlocks.Domain.Models.EventId.From(Guid.NewGuid());
         var enqueueMessagesData = new ForwardMeteredDataRejectedV1(
-            "EventId",
+            eventId.Value,
             PMValueTypes.BusinessReason.PeriodicMetering,
             new MarketActorRecipientV1(PMCoreValueTypes.ActorNumber.Create("1111111111111"), PMCoreValueTypes.ActorRole.GridAccessProvider),
             Guid.NewGuid(),
@@ -126,8 +130,14 @@ public class EnqueueBrs21ForwardMeteredDataMessagesTests : IAsyncLifetime
 
         hostLog.Should().ContainMatch("*Executing 'Functions.EnqueueTrigger_Brs_021_Forward_Metered_Data_V1'*");
         hostLog.Should().ContainMatch("*Received enqueue rejected message(s) for BRS 021*");
-        hostLog.Should().ContainMatch("*INSERT INTO [dbo].[OutgoingMessages]*");
         hostLog.Should().ContainMatch("*Executed 'Functions.EnqueueTrigger_Brs_021_Forward_Metered_Data_V1' (Succeeded,*");
+
+        // Verify that outgoing messages were enqueued
+        await using var dbContext = _fixture.DatabaseManager.CreateDbContext<ActorMessageQueueContext>();
+        var enqueuedOutgoingMessages = await dbContext.OutgoingMessages
+            .Where(om => om.EventId == eventId)
+            .ToListAsync();
+        enqueuedOutgoingMessages.Should().HaveCount(1);
 
         var actorClientId = Guid.NewGuid().ToString();
         await _fixture.DatabaseManager.AddActorAsync(ActorNumber.Create("1111111111111"), actorClientId);


### PR DESCRIPTION
## Description

The log output from tests running in CI and locally are very extensive, which makes it harder to find what we need, and slow to load in GitHub.

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task