### PR TITLE
fix: duplicated with key argument exception in ebix schema provider

### DIFF
--- a/source/IncomingMessages.Domain/Schemas/Ebix/EbixSchemaProvider.cs
+++ b/source/IncomingMessages.Domain/Schemas/Ebix/EbixSchemaProvider.cs
@@ -57,14 +57,13 @@ public class EbixSchemaProvider : SchemaProvider, ISchemaProvider<XmlSchema>
 
         // Ensure that only backslashes are used in paths
         location = location.Replace("/", "\\", StringComparison.InvariantCulture);
-        XmlSchema? cached;
-        if (_schemaCache.TryGetValue(location, out cached))
+        if (_schemaCache.TryGetValue(location, out var cached))
             return (T)(object)cached;
 
         using var reader = new XmlTextReader(location);
         var xmlSchema = XmlSchema.Read(reader, null) ?? throw new XmlSchemaException($"Could not read schema at {location}");
 
-        _schemaCache.Add(location, xmlSchema);
+        _schemaCache.TryAdd(location, xmlSchema);
 
         // Extract path of the current XSD as includes are relative to this
         var pathElements = location.Split('\\').ToList();


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
There is a race condition when multiple requests try to store any ebix schema in a cache simultaneously. The first one wins and the second fails. 

Now we are trying to add the loaded schema without throwing exceptions when the second request is trying to update the cache with the loaded schema

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/14031363515
- [x] Is there time to monitor state of the release to Production?
- [ ] Reference to the task