### PR TITLE
fix: UnparsableValueException when receiving rsm012 with invalid registeredAt value

### DIFF
--- a/source/IncomingMessages.Infrastructure/ProcessManager/ForwardMeteredDataOrchestrationStarter.cs
+++ b/source/IncomingMessages.Infrastructure/ProcessManager/ForwardMeteredDataOrchestrationStarter.cs
@@ -19,7 +19,6 @@ using Energinet.DataHub.EDI.IncomingMessages.Domain.Messages;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
 using Energinet.DataHub.ProcessManager.Client;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
-using NodaTime.Text;
 
 namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.ProcessManager;
 

--- a/source/IncomingMessages.Infrastructure/ProcessManager/ForwardMeteredDataOrchestrationStarter.cs
+++ b/source/IncomingMessages.Infrastructure/ProcessManager/ForwardMeteredDataOrchestrationStarter.cs
@@ -54,8 +54,6 @@ public class ForwardMeteredDataOrchestrationStarter(IProcessManagerMessageClient
                 ? Resolution.TryGetNameFromCode(transaction.Resolution, fallbackValue: transaction.Resolution)
                 : null;
 
-            var registeredAt = InstantPattern.General.Parse(transaction.RegisteredAt).Value.ToString();
-
             var businessReason = BusinessReason
                 .TryGetNameFromCode(
                     meteredDataForMeteringPointMessageBase.BusinessReason,
@@ -78,10 +76,7 @@ public class ForwardMeteredDataOrchestrationStarter(IProcessManagerMessageClient
                         MeteringPointType: meteringPointType,
                         ProductNumber: transaction.ProductNumber,
                         MeasureUnit: productUnitType,
-                        RegistrationDateTime: registeredAt
-                                              ?? throw new ArgumentNullException(
-                                                  nameof(transaction.RegisteredAt),
-                                                  "RegistrationDateTime is only allowed to be null in Ebix."),
+                        RegistrationDateTime: transaction.RegisteredAt,
                         Resolution: resolution,
                         StartDateTime: transaction.StartDateTime,
                         EndDateTime: transaction.EndDateTime,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
We should not parse the registeredAt to an Instant in the sync process. This should be done in the async flow in Process Manager. 

Fix: NodaTime.Text.UnparsableValueException Operation ID: 4d18c42a1a33849ce18eac0ba3a47409
## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task