### PR TITLE
fix: Make `OriginalTransactionId` optional in `ForwardMeteredDataInputV1`

### DIFF
--- a/source/B2BApi/Functions/EnqueueMessages/BRS_021/EnqueueHandler_Brs_021_ForwardMeteredData_V1.cs
+++ b/source/B2BApi/Functions/EnqueueMessages/BRS_021/EnqueueHandler_Brs_021_ForwardMeteredData_V1.cs
@@ -12,21 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Interfaces;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MeteredDataForMeteringPoint;
-using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 using Energinet.DataHub.ProcessManager.Client;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_021.ForwardMeteredData.V1.Model;
 using Microsoft.Extensions.Logging;
-using NodaTime;
 using NodaTime.Extensions;
 using Polly;
 using EventId = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.EventId;
 
 namespace Energinet.DataHub.EDI.B2BApi.Functions.EnqueueMessages.BRS_021;
 
+[SuppressMessage(
+    "StyleCop.CSharp.ReadabilityRules",
+    "SA1118:Parameter should not span multiple lines",
+    Justification = "Readability")]
 public sealed class EnqueueHandler_Brs_021_ForwardMeteredData_V1(
     IOutgoingMessagesClient outgoingMessagesClient,
     IProcessManagerMessageClient processManagerMessageClient,
@@ -67,7 +70,9 @@ public sealed class EnqueueHandler_Brs_021_ForwardMeteredData_V1(
                         TransactionId: TransactionId.New(),
                         MarketEvaluationPointNumber: acceptedData.MeteringPointId,
                         MarketEvaluationPointType: MeteringPointType.FromName(acceptedData.MeteringPointType.Name),
-                        OriginalTransactionIdReferenceId: TransactionId.From(acceptedData.OriginalTransactionId),
+                        OriginalTransactionIdReferenceId: acceptedData.OriginalTransactionId is not null
+                            ? TransactionId.From(acceptedData.OriginalTransactionId)
+                            : null,
                         Product: acceptedData.ProductNumber,
                         QuantityMeasureUnit: MeasurementUnit.FromName(receivers.MeasureUnit.Name),
                         RegistrationDateTime: acceptedData.RegistrationDateTime.ToInstant(),

--- a/source/BuildingBlocks.Domain/BuildingBlocks.Domain.csproj
+++ b/source/BuildingBlocks.Domain/BuildingBlocks.Domain.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Energinet.DataHub.EDI.BuildingBlocks.Domain</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.ProcessManager.Components.Abstractions" Version="1.3.7" />
+      <PackageReference Include="Energinet.DataHub.ProcessManager.Components.Abstractions" Version="1.3.8"/>
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/IncomingMessages.Infrastructure/IncomingMessages.Infrastructure.csproj
+++ b/source/IncomingMessages.Infrastructure/IncomingMessages.Infrastructure.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="AdaskoTheBeAsT.Dapper.NodaTime" Version="5.0.0" />
     <PackageReference Include="Energinet.DataHub.ProcessManager.Client" Version="2.1.1" />
-    <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="1.11.2" />
+      <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="1.14.0-alpha-166"/>
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.2">

--- a/source/IntegrationTests/IntegrationTests.csproj
+++ b/source/IntegrationTests/IntegrationTests.csproj
@@ -24,7 +24,7 @@ limitations under the License.
     <ItemGroup>
         <PackageReference Include="CsvHelper" Version="33.0.1" />
         <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.2.1"/>
-        <PackageReference Include="Energinet.DataHub.ProcessManager.Abstractions" Version="2.1.1" />
+        <PackageReference Include="Energinet.DataHub.ProcessManager.Abstractions" Version="2.1.2"/>
         <PackageReference Include="FluentAssertions" Version="7.0.0" />
         <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
             <PrivateAssets>all</PrivateAssets>

--- a/source/OutgoingMessages.Infrastructure/OutgoingMessages.Infrastructure.csproj
+++ b/source/OutgoingMessages.Infrastructure/OutgoingMessages.Infrastructure.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Core.Databricks.SqlStatementExecution" Version="12.0.2"/>
-    <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="1.11.2" />
+      <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="1.14.0-alpha-166"/>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.13" />

--- a/source/SubsystemTests/SubsystemTests.csproj
+++ b/source/SubsystemTests/SubsystemTests.csproj
@@ -83,7 +83,7 @@
         <PackageReference Include="Energinet.DataHub.Core.DurableFunctionApp.TestCommon" Version="7.2.1"/>
         <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.2.1"/>
         <PackageReference Include="Energinet.DataHub.ProcessManager.Client" Version="2.1.1" />
-        <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="1.11.2" />
+        <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="1.14.0-alpha-166"/>
         <PackageReference Include="FluentAssertions" Version="7.0.0" />
         <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
           <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION


<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task