### PR TITLE
fix: Always write RSM-012 quantity decimal with periods for ebIX

### DIFF
--- a/source/OutgoingMessages.Domain/DocumentWriters/RSM012/MeteredDataForMeteringPointEbixDocumentWriter.cs
+++ b/source/OutgoingMessages.Domain/DocumentWriters/RSM012/MeteredDataForMeteringPointEbixDocumentWriter.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Globalization;
 using System.Xml;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.OutgoingMessages.Domain.DocumentWriters.Formats;
@@ -125,7 +126,7 @@ public class MeteredDataForMeteringPointEbixDocumentWriter(IMessageRecordParser 
                         DocumentDetails.Prefix,
                         "EnergyQuantity",
                         null,
-                        energyObservation.Quantity.Value.ToString())
+                        energyObservation.Quantity.Value.ToString(NumberFormatInfo.InvariantInfo))
                     .ConfigureAwait(false);
 
                     if (energyObservation.Quality is not null)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Use `NumberFormatInfo.InvariantInfo` to always write the ebIX energy quantity with periods for decimals.

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task