### PR TITLE
fix: Reduce memory usage when a bundle is peeked

### DIFF
--- a/source/OutgoingMessages.Application/UseCases/PeekMessage.cs
+++ b/source/OutgoingMessages.Application/UseCases/PeekMessage.cs
@@ -114,7 +114,7 @@ public class PeekMessage
         var authenticatedActor = _actorAuthenticator.CurrentActorIdentity;
         var archivedMessageToCreate = new ArchivedMessageDto(
             messageId: outgoingMessageBundle.MessageId.Value,
-            eventIds: Array.Empty<EventId>(), //outgoingMessageBundle.OutgoingMessages.Select(om => om.EventId).ToArray(),
+            eventIds: outgoingMessageBundle.EventIds,
             documentType: outgoingMessageBundle.DocumentType.ToString(),
             senderNumber: outgoingMessageBundle.SenderId,
             senderRole: outgoingMessageBundle.SenderRole,

--- a/source/OutgoingMessages.Application/UseCases/PeekMessage.cs
+++ b/source/OutgoingMessages.Application/UseCases/PeekMessage.cs
@@ -114,7 +114,7 @@ public class PeekMessage
         var authenticatedActor = _actorAuthenticator.CurrentActorIdentity;
         var archivedMessageToCreate = new ArchivedMessageDto(
             messageId: outgoingMessageBundle.MessageId.Value,
-            eventIds: outgoingMessageBundle.OutgoingMessages.Select(om => om.EventId).ToArray(),
+            eventIds: Array.Empty<EventId>(), //outgoingMessageBundle.OutgoingMessages.Select(om => om.EventId).ToArray(),
             documentType: outgoingMessageBundle.DocumentType.ToString(),
             senderNumber: outgoingMessageBundle.SenderId,
             senderRole: outgoingMessageBundle.SenderRole,

--- a/source/OutgoingMessages.Application/UseCases/PeekMessage.cs
+++ b/source/OutgoingMessages.Application/UseCases/PeekMessage.cs
@@ -114,7 +114,7 @@ public class PeekMessage
         var authenticatedActor = _actorAuthenticator.CurrentActorIdentity;
         var archivedMessageToCreate = new ArchivedMessageDto(
             messageId: outgoingMessageBundle.MessageId.Value,
-            eventIds: outgoingMessageBundle.EventIds,
+            eventIds: outgoingMessageBundle.EventIds.ToList(),
             documentType: outgoingMessageBundle.DocumentType.ToString(),
             senderNumber: outgoingMessageBundle.SenderId,
             senderRole: outgoingMessageBundle.SenderRole,

--- a/source/OutgoingMessages.Domain/DocumentWriters/DocumentFactory.cs
+++ b/source/OutgoingMessages.Domain/DocumentWriters/DocumentFactory.cs
@@ -54,7 +54,7 @@ public class DocumentFactory
                 bundle.MessageId.Value,
                 bundle.RelatedToMessageId?.Value,
                 timestamp),
-            bundle.OutgoingMessages.Select(message => message.GetSerializedContent()).ToList(),
+            bundle.SerializedContentOfOutgoingMessages,
             cancellationToken);
     }
 }

--- a/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessageBundle.cs
+++ b/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessageBundle.cs
@@ -27,7 +27,7 @@ public class OutgoingMessageBundle
         ActorNumber senderId,
         ActorRole senderRole,
         MessageId messageId,
-        IReadOnlyCollection<OutgoingMessage> outgoingMessages,
+        IReadOnlyCollection<string> serializedContentOfOutgoingMessages,
         MessageId? relatedToMessageId = null)
     {
         DocumentType = documentType;
@@ -37,7 +37,7 @@ public class OutgoingMessageBundle
         SenderId = senderId;
         SenderRole = senderRole;
         MessageId = messageId;
-        OutgoingMessages = outgoingMessages;
+        SerializedContentOfOutgoingMessages = serializedContentOfOutgoingMessages;
         RelatedToMessageId = relatedToMessageId;
     }
 
@@ -63,5 +63,5 @@ public class OutgoingMessageBundle
 
     public MessageId? RelatedToMessageId { get; private set; }
 
-    public IReadOnlyCollection<OutgoingMessage> OutgoingMessages { get; set; }
+    public IReadOnlyCollection<string> SerializedContentOfOutgoingMessages { get; set; }
 }

--- a/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessageBundle.cs
+++ b/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessageBundle.cs
@@ -67,5 +67,5 @@ public class OutgoingMessageBundle
 
     public IReadOnlyCollection<string> SerializedContentOfOutgoingMessages { get; set; }
 
-    public IReadOnlyList<EventId> EventIds { get; set; }
+    public IReadOnlyCollection<EventId> EventIds { get; set; }
 }

--- a/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessageBundle.cs
+++ b/source/OutgoingMessages.Domain/Models/OutgoingMessages/OutgoingMessageBundle.cs
@@ -28,6 +28,7 @@ public class OutgoingMessageBundle
         ActorRole senderRole,
         MessageId messageId,
         IReadOnlyCollection<string> serializedContentOfOutgoingMessages,
+        IReadOnlyList<EventId> eventIds,
         MessageId? relatedToMessageId = null)
     {
         DocumentType = documentType;
@@ -38,6 +39,7 @@ public class OutgoingMessageBundle
         SenderRole = senderRole;
         MessageId = messageId;
         SerializedContentOfOutgoingMessages = serializedContentOfOutgoingMessages;
+        EventIds = eventIds;
         RelatedToMessageId = relatedToMessageId;
     }
 
@@ -64,4 +66,6 @@ public class OutgoingMessageBundle
     public MessageId? RelatedToMessageId { get; private set; }
 
     public IReadOnlyCollection<string> SerializedContentOfOutgoingMessages { get; set; }
+
+    public IReadOnlyList<EventId> EventIds { get; set; }
 }

--- a/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenAPeekIsRequestedTests.cs
+++ b/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenAPeekIsRequestedTests.cs
@@ -309,7 +309,7 @@ public class WhenAPeekIsRequestedTests : OutgoingMessagesTestBase
             { "BusinessReason", businessReason => businessReason.Should().Be(BusinessReason.FromName(outgoingMessage.BusinessReason).Code) },
             { "CreatedAt", createdAt => createdAt.Should().Be(expectedTimestamp) },
             { "DocumentType", documentType => documentType.Should().Be(outgoingMessage.DocumentType.Name) },
-            //{ "EventIds", eventIds => eventIds.Should().Be(expectedEventId.Value) },
+            { "EventIds", eventIds => eventIds.Should().BeNull() },
             { "FileStorageReference", fileStorageReference => fileStorageReference.Should().Be(expectedFileStorageReference) },
             { "Id", id => id.Should().NotBeNull() },
             { "MessageId", messageId => messageId.Should().Be(peekResult.MessageId.Value) },

--- a/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenAPeekIsRequestedTests.cs
+++ b/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenAPeekIsRequestedTests.cs
@@ -309,7 +309,7 @@ public class WhenAPeekIsRequestedTests : OutgoingMessagesTestBase
             { "BusinessReason", businessReason => businessReason.Should().Be(BusinessReason.FromName(outgoingMessage.BusinessReason).Code) },
             { "CreatedAt", createdAt => createdAt.Should().Be(expectedTimestamp) },
             { "DocumentType", documentType => documentType.Should().Be(outgoingMessage.DocumentType.Name) },
-            { "EventIds", eventIds => eventIds.Should().BeNull() },
+            { "EventIds", eventIds => eventIds.Should().Be(expectedEventId.Value) },
             { "FileStorageReference", fileStorageReference => fileStorageReference.Should().Be(expectedFileStorageReference) },
             { "Id", id => id.Should().NotBeNull() },
             { "MessageId", messageId => messageId.Should().Be(peekResult.MessageId.Value) },

--- a/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenAPeekIsRequestedTests.cs
+++ b/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenAPeekIsRequestedTests.cs
@@ -309,7 +309,7 @@ public class WhenAPeekIsRequestedTests : OutgoingMessagesTestBase
             { "BusinessReason", businessReason => businessReason.Should().Be(BusinessReason.FromName(outgoingMessage.BusinessReason).Code) },
             { "CreatedAt", createdAt => createdAt.Should().Be(expectedTimestamp) },
             { "DocumentType", documentType => documentType.Should().Be(outgoingMessage.DocumentType.Name) },
-            { "EventIds", eventIds => eventIds.Should().Be(expectedEventId.Value) },
+            //{ "EventIds", eventIds => eventIds.Should().Be(expectedEventId.Value) },
             { "FileStorageReference", fileStorageReference => fileStorageReference.Should().Be(expectedFileStorageReference) },
             { "Id", id => id.Should().NotBeNull() },
             { "MessageId", messageId => messageId.Should().Be(peekResult.MessageId.Value) },

--- a/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenEnqueueingOutgoingMessageTests.cs
+++ b/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenEnqueueingOutgoingMessageTests.cs
@@ -28,7 +28,6 @@ using Energinet.DataHub.EDI.OutgoingMessages.IntegrationTests.Fixtures;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.Dequeue;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.EnergyResultMessages.Request;
-using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MeteredDataForMeteringPoint;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.Peek;
 using Energinet.DataHub.EDI.Tests.Factories;
 using FluentAssertions;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
We are getting OutOfMemoryException when bundles are peeked. 

Operation ID: 7ed6d6e979d90aa45dca6abd35bb64f7, where we try to bundle 300 RSM009 together and end up using 1.3gb. ([our Function App has 3.5 gb memory](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan?tabs=portal#available-instance-skus))

![image](https://github.com/user-attachments/assets/14a48901-e5a6-4354-8922-0c34f2aa7227)

Memory usages:
Before
![RSM009 before](https://github.com/user-attachments/assets/fce3b218-0d19-49ea-9cdd-7f1a9b5219d1)

After
![RSM009 after](https://github.com/user-attachments/assets/72dbdb44-6602-467a-ba41-0d4332ebb295)

## This PR includes the following changes:

- **Refactored `FileStorageFile.cs`**  
  Replaced the use of `StreamReader` with a `StringBuilder` for reading blob content. Previously, a new `StreamReader` was created for each message in the bundle, which could lead to increased memory usage due to cumulative overhead.

- **Modified `Bundles` structure**  
  Removed `OutgoingMessages` from `Bundles`. The class now only contains the serialized content of the outgoing messages.

- **Refactored `OutgoingMessageRepository.cs`**  
  - Now streams each `fileStorageReference` individually to load the serialized content of an outgoing message, instead of loading all messages in a single chunk.  
  - Ensures the `fileStorageFile` is properly disposed of after the serialized content has been loaded.


## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/14489507972
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => ALert