### PR TITLE
test: count enqueued outgoing message from perf test

### DIFF
--- a/source/SubsystemTests/Drivers/EdiDatabaseDriver.cs
+++ b/source/SubsystemTests/Drivers/EdiDatabaseDriver.cs
@@ -72,7 +72,9 @@ internal sealed class EdiDatabaseDriver
     /// <summary>
     /// Mark bundles from load test as dequeued from a month ago to ensure that they are cleaned up by the retention service
     /// </summary>
-    internal async Task MarkBundlesFromLoadTestAsDequeuedAMonthAgoAsync(CancellationToken cancellationToken)
+    internal async Task MarkBundlesFromLoadTestAsDequeuedAMonthAgoAsync(
+        string relatedToMessageIdPrefix,
+        CancellationToken cancellationToken)
     {
         await using var connection = new SqlConnection(_connectionString);
 
@@ -89,7 +91,7 @@ internal sealed class EdiDatabaseDriver
                                 AND om.RelatedToMessageId like @RelatedToMessageIdPrefix
                         )
                 """;
-            updateBundles.Parameters.AddWithValue("RelatedToMessageIdPrefix", "perf_test_%");
+            updateBundles.Parameters.AddWithValue("RelatedToMessageIdPrefix", relatedToMessageIdPrefix + "%");
 
             updateBundles.Connection = connection;
             updateBundles.CommandTimeout = (int)TimeSpan.FromMinutes(4).TotalSeconds;

--- a/source/SubsystemTests/LoadTest/ForwardMeteredData.cs
+++ b/source/SubsystemTests/LoadTest/ForwardMeteredData.cs
@@ -67,6 +67,6 @@ public sealed class ForwardMeteredData : IClassFixture<LoadTestFixture>
 
     private async Task CleanUp()
     {
-        await _ediDatabaseDriver.MarkBundlesFromLoadTestAsDequeuedAMonthAgoAsync("perf_test_", CancellationToken.None);
+        await _ediDatabaseDriver.MarkBundlesFromLoadTestAsDequeuedAMonthAgoAsync(CancellationToken.None);
     }
 }

--- a/source/SubsystemTests/LoadTest/ForwardMeteredData.cs
+++ b/source/SubsystemTests/LoadTest/ForwardMeteredData.cs
@@ -67,6 +67,6 @@ public sealed class ForwardMeteredData : IClassFixture<LoadTestFixture>
 
     private async Task CleanUp()
     {
-        await _ediDatabaseDriver.MarkBundlesFromLoadTestAsDequeuedAMonthAgoAsync(CancellationToken.None);
+        await _ediDatabaseDriver.MarkBundlesFromLoadTestAsDequeuedAMonthAgoAsync("perf_test_", CancellationToken.None);
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Ensure we count and clean up correctly after perf test. 

Counts all outgoing messages with "perf_test" message id prefix in not-dequeued bundles
And cleans up by dequeueing all bundles that contain messages from the performance test. 

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/725