### PR TITLE
test: OwnedRestriction for Metering point messages

### DIFF
--- a/source/ArchivedMessages.IntegrationTests/ArchivedMessagesWithOwnedRestrictionTests.cs
+++ b/source/ArchivedMessages.IntegrationTests/ArchivedMessagesWithOwnedRestrictionTests.cs
@@ -149,6 +149,7 @@ public class ArchivedMessagesWithOwnedRestrictionTests : IAsyncLifetime
 
         // This messages owned by the authenticated actor
         await _fixture.CreateArchivedMessageAsync(
+            timestamp: Instant.FromUtc(2025, 01, 02, 0, 0),
             documentType: DocumentType.NotifyValidatedMeasureData,
             meteringPointIds: new List<MeteringPointId>()
             {
@@ -157,6 +158,7 @@ public class ArchivedMessagesWithOwnedRestrictionTests : IAsyncLifetime
             receiverNumber: _authenticatedActor.ActorNumber.Value,
             receiverRole: _authenticatedActor.ActorRole);
         await _fixture.CreateArchivedMessageAsync(
+            timestamp: Instant.FromUtc(2025, 01, 02, 0, 0),
             documentType: DocumentType.NotifyValidatedMeasureData,
             meteringPointIds: new List<MeteringPointId>()
             {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task