### PR TITLE
fix: set max request body size mb in b2b app

### DIFF
--- a/source/B2BApi/HostFactory.cs
+++ b/source/B2BApi/HostFactory.cs
@@ -31,7 +31,9 @@ using Energinet.DataHub.EDI.IntegrationEvents.Infrastructure.Extensions.Dependen
 using Energinet.DataHub.EDI.MasterData.Infrastructure.Extensions.DependencyInjection;
 using Energinet.DataHub.EDI.Outbox.Infrastructure;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using OutboxContext = Energinet.DataHub.EDI.Outbox.Infrastructure.OutboxContext;
@@ -126,7 +128,13 @@ public static class HostFactory
                         .AddOutboxRetention()
 
                         // Enqueue messages from PM (using Edi Topic)
-                        .AddEnqueueActorMessagesFromProcessManager(defaultAzureCredential);
+                        .AddEnqueueActorMessagesFromProcessManager(defaultAzureCredential)
+
+                        // Configure Kestrel options
+                        .Configure<KestrelServerOptions>(options =>
+                        {
+                            options.Limits.MaxRequestBodySize = 50 * 1024 * 1024; // 50mb
+                        });
                 })
             .ConfigureLogging(
                 (hostingContext, logging) =>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
fix: Request body too large. The max request body size is 30000000 bytes.


<!--EndFragment-->
</body>
</html>
## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task