### PR TITLE
test: Mock dependencies when running subsystem tests

### DIFF
--- a/source/ArchitectureTests/RegistrationTests.cs
+++ b/source/ArchitectureTests/RegistrationTests.cs
@@ -55,7 +55,7 @@ public class RegistrationTests
 
     public RegistrationTests()
     {
-        Environment.SetEnvironmentVariable($"{IncomingMessagesQueueOptions.SectionName}__{nameof(IncomingMessagesQueueOptions.QueueName)}", "FakeQueueNameIncoming");
+        Environment.SetEnvironmentVariable($"{IncomingMessagesOptions.SectionName}__{nameof(IncomingMessagesOptions.QueueName)}", "FakeQueueNameIncoming");
         Environment.SetEnvironmentVariable("DB_CONNECTION_STRING", TestEnvironment.CreateConnectionString());
         // The following declaration slows down the test execution, since creating a new Uri is a heavy operation
         Environment.SetEnvironmentVariable(

--- a/source/B2BApi.AppTests/Fixtures/B2BApiAppFixture.cs
+++ b/source/B2BApi.AppTests/Fixtures/B2BApiAppFixture.cs
@@ -239,7 +239,7 @@ public class B2BApiAppFixture : IAsyncLifetime
         await ServiceBusResourceProvider
             .BuildQueue("incoming-messages")
             .Do(queue => appHostSettings.ProcessEnvironmentVariables
-                .Add($"{IncomingMessagesQueueOptions.SectionName}__{nameof(IncomingMessagesQueueOptions.QueueName)}", queue.Name))
+                .Add($"{IncomingMessagesOptions.SectionName}__{nameof(IncomingMessagesOptions.QueueName)}", queue.Name))
             .CreateAsync();
         LogStopwatch(stopwatch, "ServiceBusQueue (incoming-messages)");
 

--- a/source/B2CWebApi.AppTests/Fixture/B2CWebApiFixture.cs
+++ b/source/B2CWebApi.AppTests/Fixture/B2CWebApiFixture.cs
@@ -146,7 +146,7 @@ public class B2CWebApiFixture : IAsyncLifetime
             { $"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.NotifyTopicName)}", processManagerNotifyTopicName },
             { $"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataStartTopicName)}", processManagerStartTopicName }, // TODO: Do we need a separate topic for tests as well?
             { $"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.Brs021ForwardMeteredDataNotifyTopicName)}", processManagerNotifyTopicName }, // TODO: Do we need a separate topic for tests as well?
-            { $"{IncomingMessagesQueueOptions.SectionName}:{nameof(IncomingMessagesQueueOptions.QueueName)}", incomingMessagesQueueName },
+            { $"{IncomingMessagesOptions.SectionName}:{nameof(IncomingMessagesOptions.QueueName)}", incomingMessagesQueueName },
             { "OrchestrationsStorageAccountConnectionString", AzuriteManager.FullConnectionString },
             { "OrchestrationsTaskHubName", "EdiTest01" },
             // Feature Management => Azure App Configuration settings

--- a/source/BuildingBlocks.Domain/Extensions/TestMessageIdExtensions.cs
+++ b/source/BuildingBlocks.Domain/Extensions/TestMessageIdExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Extensions;
+
+public static class TestMessageIdExtensions
+{
+    public const string TestUuidPrefix = "test__";
+
+    /// <summary>
+    /// Converts the guid to a shorter version, prefixed with the <see cref="TestUuidPrefix"/>.
+    /// See <see cref="ToShortUuid"/> for details on how the conversion is done.
+    /// </summary>
+    /// <returns>A string prefixed with <see cref="TestUuidPrefix"/>, that isn't longer than the default Guid length.</returns>
+    public static string ToTestMessageUuid(this Guid guid)
+    {
+        return $"{TestUuidPrefix}{guid.ToShortUuid()}";
+    }
+
+    public static bool IsTestUuid(this string messageId)
+    {
+        return messageId.StartsWith(TestUuidPrefix);
+    }
+
+    /// <summary>
+    /// Convert a guid to a shorter version, while still being unique.
+    /// <remarks>
+    /// Converts the Guid to a base64 string, and replaces special characters.
+    /// See: https://stackoverflow.com/questions/9278909/net-short-unique-identifier
+    /// </remarks>
+    /// <returns>A string with 22 characters, that preserves the uniqueness of the Guid</returns>
+    /// </summary>
+    private static string ToShortUuid(this Guid guid)
+    {
+        return Convert.ToBase64String(guid.ToByteArray())[0..^2] // remove trailing == padding
+            .Replace('+', '-') // escape special character
+            .Replace('/', '_'); // escape special character
+    }
+}

--- a/source/IncomingMessages.Infrastructure/Configuration/Options/IncomingMessagesOptions.cs
+++ b/source/IncomingMessages.Infrastructure/Configuration/Options/IncomingMessagesOptions.cs
@@ -16,10 +16,17 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Configuration.Options;
 
-public class IncomingMessagesQueueOptions
+public class IncomingMessagesOptions
 {
     public const string SectionName = "IncomingMessages";
 
     [Required]
     public string QueueName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Allow using mock dependencies for tests. This is used by our subsystem tests, to avoid polluting other subsystems,
+    /// and thus must only be enabled in environments where subsystem tests are executed.
+    /// </summary>
+    [Required]
+    public bool AllowMockDependenciesForTests { get; set; } = false;
 }

--- a/source/IncomingMessages.Infrastructure/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
+++ b/source/IncomingMessages.Infrastructure/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
@@ -86,14 +86,14 @@ public static class IncomingMessagesExtensions
 
         // => Service Bus
         services
-            .AddOptions<IncomingMessagesQueueOptions>()
-            .BindConfiguration(IncomingMessagesQueueOptions.SectionName)
+            .AddOptions<IncomingMessagesOptions>()
+            .BindConfiguration(IncomingMessagesOptions.SectionName)
             .ValidateDataAnnotations();
 
         var incomingMessagesQueueOptions =
             configuration
-                .GetRequiredSection(IncomingMessagesQueueOptions.SectionName)
-                .Get<IncomingMessagesQueueOptions>()
+                .GetRequiredSection(IncomingMessagesOptions.SectionName)
+                .Get<IncomingMessagesOptions>()
             ?? throw new InvalidOperationException("Missing Incoming Messages configuration.");
 
         services.AddAzureClients(builder =>
@@ -113,12 +113,12 @@ public static class IncomingMessagesExtensions
             .AddHealthChecks()
             .AddAzureServiceBusQueue(
                 sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
-                sp => sp.GetRequiredService<IOptions<IncomingMessagesQueueOptions>>().Value.QueueName,
+                sp => sp.GetRequiredService<IOptions<IncomingMessagesOptions>>().Value.QueueName,
                 _ => defaultAzureCredential,
                 name: incomingMessagesQueueOptions.QueueName)
             .AddServiceBusQueueDeadLetter(
                 sp => sp.GetRequiredService<IOptions<ServiceBusNamespaceOptions>>().Value.FullyQualifiedNamespace,
-                sp => sp.GetRequiredService<IOptions<IncomingMessagesQueueOptions>>().Value.QueueName,
+                sp => sp.GetRequiredService<IOptions<IncomingMessagesOptions>>().Value.QueueName,
                 _ => defaultAzureCredential,
                 "Dead-letter (incoming messages)",
                 [HealthChecksConstants.StatusHealthCheckTag])

--- a/source/IncomingMessages.Infrastructure/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
+++ b/source/IncomingMessages.Infrastructure/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
@@ -170,7 +170,7 @@ public static class IncomingMessagesExtensions
          */
         services.AddTransient<IRequestProcessOrchestrationStarter, RequestProcessOrchestrationStarter>();
         services.AddTransient<ForwardMeteredDataOrchestrationStarter>();
-        services.AddTransient<IProcessManagerClientFactory, ProcessManagerClientFactory>();
+        services.AddTransient<IProcessManagerMessageClientFactory, ProcessManagerMessageClientFactory>();
         services.AddProcessManagerMessageClient();
 
         return services;

--- a/source/IncomingMessages.Infrastructure/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
+++ b/source/IncomingMessages.Infrastructure/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
@@ -170,6 +170,7 @@ public static class IncomingMessagesExtensions
          */
         services.AddTransient<IRequestProcessOrchestrationStarter, RequestProcessOrchestrationStarter>();
         services.AddTransient<ForwardMeteredDataOrchestrationStarter>();
+        services.AddTransient<IProcessManagerClientFactory, ProcessManagerClientFactory>();
         services.AddProcessManagerMessageClient();
 
         return services;

--- a/source/IncomingMessages.Infrastructure/IncomingMessagePublisher.cs
+++ b/source/IncomingMessages.Infrastructure/IncomingMessagePublisher.cs
@@ -32,7 +32,7 @@ public class IncomingMessagePublisher
 
     public IncomingMessagePublisher(
         AuthenticatedActor authenticatedActor,
-        IOptions<IncomingMessagesQueueOptions> options,
+        IOptions<IncomingMessagesOptions> options,
         IAzureClientFactory<ServiceBusSender> senderFactory,
         IRequestProcessOrchestrationStarter requestProcessOrchestrationStarter,
         ForwardMeteredDataOrchestrationStarter forwardMeteredDataOrchestrationStarter)

--- a/source/IncomingMessages.Infrastructure/ProcessManager/ForwardMeteredDataOrchestrationStarter.cs
+++ b/source/IncomingMessages.Infrastructure/ProcessManager/ForwardMeteredDataOrchestrationStarter.cs
@@ -26,10 +26,10 @@ namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.ProcessManager;
     "SA1118:Parameter should not span multiple lines",
     Justification = "Needed for inline ebix exception")]
 public class ForwardMeteredDataOrchestrationStarter(
-    IProcessManagerClientFactory processManagerClientFactory,
+    IProcessManagerMessageClientFactory processManagerMessageClientFactory,
     AuthenticatedActor authenticatedActor)
 {
-    private readonly IProcessManagerClientFactory _processManagerClientFactory = processManagerClientFactory;
+    private readonly IProcessManagerMessageClientFactory _processManagerMessageClientFactory = processManagerMessageClientFactory;
     private readonly AuthenticatedActor _authenticatedActor = authenticatedActor;
 
     public async Task StartForwardMeteredDataOrchestrationAsync(
@@ -37,7 +37,7 @@ public class ForwardMeteredDataOrchestrationStarter(
         CancellationToken cancellationToken)
     {
         var actorIdentityDto = GetAuthenticatedActorIdentityDto(meteredDataForMeteringPointMessageBase.MessageId);
-        var processManagerMessageClient = _processManagerClientFactory.CreateMessageClient(meteredDataForMeteringPointMessageBase.MessageId);
+        var processManagerMessageClient = _processManagerMessageClientFactory.CreateMessageClient(meteredDataForMeteringPointMessageBase.MessageId);
 
         var startProcessTasks = new List<Task>();
         foreach (var transaction in meteredDataForMeteringPointMessageBase.Series

--- a/source/IncomingMessages.Infrastructure/ProcessManager/IProcessManagerClientFactory.cs
+++ b/source/IncomingMessages.Infrastructure/ProcessManager/IProcessManagerClientFactory.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Extensions;
+using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Configuration.Options;
+using Energinet.DataHub.ProcessManager.Client;
+
+namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.ProcessManager;
+
+public interface IProcessManagerClientFactory
+{
+    /// <summary>
+    /// Create a process manager message client.
+    /// <remarks>
+    /// If <see cref="IncomingMessagesOptions.AllowMockDependenciesForTests"/> is true, and the
+    /// given <paramref name="actorMessageId"/> is a test id, a mock client will be returned. See
+    /// <see cref="TestMessageIdExtensions"/> for more information about test id's.
+    /// </remarks>
+    /// </summary>
+    /// <param name="actorMessageId">The id of the actor message. If it is a test id, a mock will be returned.</param>
+    IProcessManagerMessageClient CreateMessageClient(string actorMessageId);
+}

--- a/source/IncomingMessages.Infrastructure/ProcessManager/IProcessManagerClientFactory.cs
+++ b/source/IncomingMessages.Infrastructure/ProcessManager/IProcessManagerClientFactory.cs
@@ -22,12 +22,12 @@ public interface IProcessManagerClientFactory
 {
     /// <summary>
     /// Create a process manager message client.
+    /// </summary>
     /// <remarks>
     /// If <see cref="IncomingMessagesOptions.AllowMockDependenciesForTests"/> is true, and the
     /// given <paramref name="actorMessageId"/> is a test id, a mock client will be returned. See
     /// <see cref="TestMessageIdExtensions"/> for more information about test id's.
     /// </remarks>
-    /// </summary>
     /// <param name="actorMessageId">The id of the actor message. If it is a test id, a mock will be returned.</param>
     IProcessManagerMessageClient CreateMessageClient(string actorMessageId);
 }

--- a/source/IncomingMessages.Infrastructure/ProcessManager/IProcessManagerMessageClientFactory.cs
+++ b/source/IncomingMessages.Infrastructure/ProcessManager/IProcessManagerMessageClientFactory.cs
@@ -18,7 +18,7 @@ using Energinet.DataHub.ProcessManager.Client;
 
 namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.ProcessManager;
 
-public interface IProcessManagerClientFactory
+public interface IProcessManagerMessageClientFactory
 {
     /// <summary>
     /// Create a process manager message client.

--- a/source/IncomingMessages.Infrastructure/ProcessManager/ProcessManagerClientFactory.cs
+++ b/source/IncomingMessages.Infrastructure/ProcessManager/ProcessManagerClientFactory.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Extensions;
+using Energinet.DataHub.EDI.IncomingMessages.Infrastructure.Configuration.Options;
+using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
+using Energinet.DataHub.ProcessManager.Client;
+using Microsoft.Extensions.Options;
+
+namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.ProcessManager;
+
+/// <summary>
+/// Create process manager clients. Can return a mock client if
+/// <see cref="IncomingMessagesOptions.AllowMockDependenciesForTests"/> is true.
+/// </summary>
+public class ProcessManagerClientFactory(
+    IOptions<IncomingMessagesOptions> options,
+    IProcessManagerMessageClient processManagerMessageClient) : IProcessManagerClientFactory
+{
+    private readonly IncomingMessagesOptions _options = options.Value;
+    private readonly IProcessManagerMessageClient _processManagerMessageClient = processManagerMessageClient;
+
+    /// <inheritdoc />
+    public IProcessManagerMessageClient CreateMessageClient(string actorMessageId)
+    {
+        if (!_options.AllowMockDependenciesForTests)
+            return _processManagerMessageClient;
+
+        var isTestMessage = actorMessageId.IsTestUuid();
+
+        return isTestMessage
+            ? new ProcessManagerMessageClientMock()
+            : _processManagerMessageClient;
+    }
+
+    /// <summary>
+    /// A mock implementation of <see cref="IProcessManagerMessageClient"/> that does nothing.
+    /// </summary>
+    private class ProcessManagerMessageClientMock : IProcessManagerMessageClient
+    {
+        public Task StartNewOrchestrationInstanceAsync<TInputParameterDto>(
+            StartOrchestrationInstanceMessageCommand<TInputParameterDto> command,
+            CancellationToken cancellationToken)
+                where TInputParameterDto : class, IInputParameterDto
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task NotifyOrchestrationInstanceAsync(
+            NotifyOrchestrationInstanceEvent notifyEvent,
+            CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task NotifyOrchestrationInstanceAsync<TNotifyDataDto>(
+            NotifyOrchestrationInstanceEvent<TNotifyDataDto> notifyEvent,
+            CancellationToken cancellationToken)
+                where TNotifyDataDto : class, INotifyDataDto
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/source/IncomingMessages.Infrastructure/ProcessManager/ProcessManagerMessageClientFactory.cs
+++ b/source/IncomingMessages.Infrastructure/ProcessManager/ProcessManagerMessageClientFactory.cs
@@ -24,9 +24,9 @@ namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.ProcessManager;
 /// Create process manager clients. Can return a mock client if
 /// <see cref="IncomingMessagesOptions.AllowMockDependenciesForTests"/> is true.
 /// </summary>
-public class ProcessManagerClientFactory(
+public class ProcessManagerMessageClientFactory(
     IOptions<IncomingMessagesOptions> options,
-    IProcessManagerMessageClient processManagerMessageClient) : IProcessManagerClientFactory
+    IProcessManagerMessageClient processManagerMessageClient) : IProcessManagerMessageClientFactory
 {
     private readonly IncomingMessagesOptions _options = options.Value;
     private readonly IProcessManagerMessageClient _processManagerMessageClient = processManagerMessageClient;

--- a/source/IncomingMessages.Infrastructure/ProcessManager/ProcessManagerMessageClientFactory.cs
+++ b/source/IncomingMessages.Infrastructure/ProcessManager/ProcessManagerMessageClientFactory.cs
@@ -24,7 +24,7 @@ namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.ProcessManager;
 /// Create process manager clients. Can return a mock client if
 /// <see cref="IncomingMessagesOptions.AllowMockDependenciesForTests"/> is true.
 /// </summary>
-public class ProcessManagerMessageClientFactory(
+internal class ProcessManagerMessageClientFactory(
     IOptions<IncomingMessagesOptions> options,
     IProcessManagerMessageClient processManagerMessageClient) : IProcessManagerMessageClientFactory
 {

--- a/source/IncomingMessages.Infrastructure/ProcessManager/RequestProcessOrchestrationStarter.cs
+++ b/source/IncomingMessages.Infrastructure/ProcessManager/RequestProcessOrchestrationStarter.cs
@@ -22,10 +22,10 @@ using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS
 namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.ProcessManager;
 
 public class RequestProcessOrchestrationStarter(
-    IProcessManagerClientFactory processManagerClientFactory,
+    IProcessManagerMessageClientFactory processManagerMessageClientFactory,
     AuthenticatedActor authenticatedActor) : IRequestProcessOrchestrationStarter
 {
-    private readonly IProcessManagerClientFactory _processManagerClientFactory = processManagerClientFactory;
+    private readonly IProcessManagerMessageClientFactory _processManagerMessageClientFactory = processManagerMessageClientFactory;
     private readonly AuthenticatedActor _authenticatedActor = authenticatedActor;
 
     public async Task StartRequestWholesaleServicesOrchestrationAsync(
@@ -33,7 +33,7 @@ public class RequestProcessOrchestrationStarter(
         CancellationToken cancellationToken)
     {
         var actorIdentity = GetAuthenticatedActorIdentityDto(initializeProcessDto.MessageId);
-        var processManagerMessageClient = _processManagerClientFactory.CreateMessageClient(initializeProcessDto.MessageId);
+        var processManagerMessageClient = _processManagerMessageClientFactory.CreateMessageClient(initializeProcessDto.MessageId);
 
         var startProcessTasks = new List<Task>();
         foreach (var transaction in initializeProcessDto.Series)
@@ -92,7 +92,7 @@ public class RequestProcessOrchestrationStarter(
         CancellationToken cancellationToken)
     {
         var actorIdentity = GetAuthenticatedActorIdentityDto(initializeProcessDto.MessageId);
-        var processManagerMessageClient = _processManagerClientFactory.CreateMessageClient(initializeProcessDto.MessageId);
+        var processManagerMessageClient = _processManagerMessageClientFactory.CreateMessageClient(initializeProcessDto.MessageId);
 
         var startProcessTasks = new List<Task>();
         foreach (var transaction in initializeProcessDto.Series)

--- a/source/IncomingMessages.Infrastructure/ProcessManager/RequestProcessOrchestrationStarter.cs
+++ b/source/IncomingMessages.Infrastructure/ProcessManager/RequestProcessOrchestrationStarter.cs
@@ -16,17 +16,16 @@ using Energinet.DataHub.EDI.BuildingBlocks.Domain.Authentication;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model.OrchestrationInstance;
-using Energinet.DataHub.ProcessManager.Client;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_026.V1.Model;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.BRS_028.V1.Model;
 
 namespace Energinet.DataHub.EDI.IncomingMessages.Infrastructure.ProcessManager;
 
 public class RequestProcessOrchestrationStarter(
-    IProcessManagerMessageClient processManagerMessageClient,
+    IProcessManagerClientFactory processManagerClientFactory,
     AuthenticatedActor authenticatedActor) : IRequestProcessOrchestrationStarter
 {
-    private readonly IProcessManagerMessageClient _processManagerMessageClient = processManagerMessageClient;
+    private readonly IProcessManagerClientFactory _processManagerClientFactory = processManagerClientFactory;
     private readonly AuthenticatedActor _authenticatedActor = authenticatedActor;
 
     public async Task StartRequestWholesaleServicesOrchestrationAsync(
@@ -34,6 +33,7 @@ public class RequestProcessOrchestrationStarter(
         CancellationToken cancellationToken)
     {
         var actorIdentity = GetAuthenticatedActorIdentityDto(initializeProcessDto.MessageId);
+        var processManagerMessageClient = _processManagerClientFactory.CreateMessageClient(initializeProcessDto.MessageId);
 
         var startProcessTasks = new List<Task>();
         foreach (var transaction in initializeProcessDto.Series)
@@ -80,7 +80,7 @@ public class RequestProcessOrchestrationStarter(
                 idempotencyKey: CreateIdempotencyKey(transaction.Id, transaction.RequestedByActor));
 
             // TODO: Handle resiliency. Could use something like Polly to retry if failing?
-            var startProcessTask = _processManagerMessageClient.StartNewOrchestrationInstanceAsync(startCommand, cancellationToken);
+            var startProcessTask = processManagerMessageClient.StartNewOrchestrationInstanceAsync(startCommand, cancellationToken);
             startProcessTasks.Add(startProcessTask);
         }
 
@@ -92,6 +92,7 @@ public class RequestProcessOrchestrationStarter(
         CancellationToken cancellationToken)
     {
         var actorIdentity = GetAuthenticatedActorIdentityDto(initializeProcessDto.MessageId);
+        var processManagerMessageClient = _processManagerClientFactory.CreateMessageClient(initializeProcessDto.MessageId);
 
         var startProcessTasks = new List<Task>();
         foreach (var transaction in initializeProcessDto.Series)
@@ -129,7 +130,7 @@ public class RequestProcessOrchestrationStarter(
                 idempotencyKey: CreateIdempotencyKey(transaction.Id.Value, transaction.RequestedByActor));
 
             // TODO: Handle resiliency. Could use something like Polly to retry if failing?
-            var startProcessTask = _processManagerMessageClient.StartNewOrchestrationInstanceAsync(startCommand, cancellationToken);
+            var startProcessTask = processManagerMessageClient.StartNewOrchestrationInstanceAsync(startCommand, cancellationToken);
             startProcessTasks.Add(startProcessTask);
         }
 

--- a/source/IncomingMessages.IntegrationTests/IncomingMessagesTestBase.cs
+++ b/source/IncomingMessages.IntegrationTests/IncomingMessagesTestBase.cs
@@ -196,7 +196,7 @@ public class IncomingMessagesTestBase : IDisposable
                     // ServiceBus
                     [$"{ServiceBusNamespaceOptions.SectionName}:{nameof(ServiceBusNamespaceOptions.FullyQualifiedNamespace)}"] =
                         "Fake",
-                    [$"{IncomingMessagesQueueOptions.SectionName}:{nameof(IncomingMessagesQueueOptions.QueueName)}"] =
+                    [$"{IncomingMessagesOptions.SectionName}:{nameof(IncomingMessagesOptions.QueueName)}"] =
                         "Fake",
                     [$"{ProcessManagerServiceBusClientOptions.SectionName}:{nameof(ProcessManagerServiceBusClientOptions.StartTopicName)}"] =
                         "Fake",

--- a/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
+++ b/source/IntegrationTests/Behaviours/BehavioursTestBase.cs
@@ -413,7 +413,7 @@ public class BehavioursTestBase : IDisposable
                 {
                     // ServiceBus
                     [$"{ServiceBusNamespaceOptions.SectionName}:{nameof(ServiceBusNamespaceOptions.FullyQualifiedNamespace)}"] = MockServiceBusName,
-                    [$"{IncomingMessagesQueueOptions.SectionName}:{nameof(IncomingMessagesQueueOptions.QueueName)}"] = MockServiceBusName,
+                    [$"{IncomingMessagesOptions.SectionName}:{nameof(IncomingMessagesOptions.QueueName)}"] = MockServiceBusName,
                     [$"{IntegrationEventsOptions.SectionName}:{nameof(IntegrationEventsOptions.TopicName)}"] = "NotEmpty",
                     [$"{IntegrationEventsOptions.SectionName}:{nameof(IntegrationEventsOptions.SubscriptionName)}"] = "NotEmpty",
 

--- a/source/IntegrationTests/TestBase.cs
+++ b/source/IntegrationTests/TestBase.cs
@@ -228,7 +228,7 @@ public class TestBase : IDisposable
                 {
                     // ServiceBus
                     [$"{ServiceBusNamespaceOptions.SectionName}:{nameof(ServiceBusNamespaceOptions.FullyQualifiedNamespace)}"] = "Fake",
-                    [$"{IncomingMessagesQueueOptions.SectionName}:{nameof(IncomingMessagesQueueOptions.QueueName)}"] = "Fake",
+                    [$"{IncomingMessagesOptions.SectionName}:{nameof(IncomingMessagesOptions.QueueName)}"] = "Fake",
                     [$"{IntegrationEventsOptions.SectionName}:{nameof(IntegrationEventsOptions.TopicName)}"] = "NotEmpty",
                     [$"{IntegrationEventsOptions.SectionName}:{nameof(IntegrationEventsOptions.SubscriptionName)}"] = "NotEmpty",
 

--- a/source/SubsystemTests/Drivers/EdiDriver.cs
+++ b/source/SubsystemTests/Drivers/EdiDriver.cs
@@ -102,7 +102,7 @@ internal sealed class EdiDriver
         if (peekResponse.StatusCode == HttpStatusCode.OK)
         {
             await DequeueAsync(GetMessageId(peekResponse)).ConfigureAwait(false);
-            await EmptyQueueAsync().ConfigureAwait(false);
+            await EmptyQueueAsync(messageCategory).ConfigureAwait(false);
         }
     }
 

--- a/source/SubsystemTests/Drivers/MessageFactories/EnqueueBrs021ForwardMeteredDataFactory.cs
+++ b/source/SubsystemTests/Drivers/MessageFactories/EnqueueBrs021ForwardMeteredDataFactory.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Azure.Messaging.ServiceBus;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Extensions;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
@@ -90,7 +91,7 @@ public class EnqueueBrs021ForwardMeteredDataFactory
     {
         var rejected = new ForwardMeteredDataRejectedV1(
             OriginalActorMessageId: originalActorMessageId,
-            OriginalTransactionId: Guid.NewGuid().ToString(),
+            OriginalTransactionId: Guid.NewGuid().ToTestMessageUuid(),
             ForwardedForActorRole: actor.ActorRole.ToProcessManagerActorRole(),
             BusinessReason: BusinessReason.PeriodicMetering,
             ValidationErrors:

--- a/source/SubsystemTests/Drivers/MessageFactories/EnqueueBrs026MessageFactory.cs
+++ b/source/SubsystemTests/Drivers/MessageFactories/EnqueueBrs026MessageFactory.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Azure.Messaging.ServiceBus;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Extensions;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
@@ -35,8 +36,8 @@ public static class EnqueueBrs026MessageFactory
         var energySupplier = actor.ActorRole == ActorRole.EnergySupplier ? actor.ActorNumber.ToProcessManagerActorNumber() : null;
 
         var accepted = new RequestCalculatedEnergyTimeSeriesAcceptedV1(
-            OriginalActorMessageId: Guid.NewGuid().ToString(),
-            OriginalTransactionId: Guid.NewGuid().ToString(),
+            OriginalActorMessageId: Guid.NewGuid().ToTestMessageUuid(),
+            OriginalTransactionId: Guid.NewGuid().ToTestMessageUuid(),
             RequestedForActorNumber: actor.ActorNumber.ToProcessManagerActorNumber(),
             RequestedForActorRole: actor.ActorRole.ToProcessManagerActorRole(),
             RequestedByActorNumber: actor.ActorNumber.ToProcessManagerActorNumber(),
@@ -57,11 +58,11 @@ public static class EnqueueBrs026MessageFactory
     public static ServiceBusMessage CreateReject(
         Actor actor)
     {
-        var actorMessageId = Guid.NewGuid().ToString();
+        var actorMessageId = Guid.NewGuid().ToTestMessageUuid();
         var rejected = new RequestCalculatedEnergyTimeSeriesRejectedV1(
             OriginalMessageId: actorMessageId,
             OriginalActorMessageId: actorMessageId,
-            OriginalTransactionId: Guid.NewGuid().ToString(),
+            OriginalTransactionId: Guid.NewGuid().ToTestMessageUuid(),
             RequestedForActorNumber: actor.ActorNumber.ToProcessManagerActorNumber(),
             RequestedForActorRole: actor.ActorRole.ToProcessManagerActorRole(),
             RequestedByActorNumber: actor.ActorNumber.ToProcessManagerActorNumber(),

--- a/source/SubsystemTests/Drivers/MessageFactories/EnqueueBrs028MessageFactory.cs
+++ b/source/SubsystemTests/Drivers/MessageFactories/EnqueueBrs028MessageFactory.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Azure.Messaging.ServiceBus;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Extensions;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.ProcessManager.Abstractions.Api.Model;
 using Energinet.DataHub.ProcessManager.Abstractions.Contracts;
@@ -35,8 +36,8 @@ public class EnqueueBrs028MessageFactory
         var energySupplier = actor.ActorRole == ActorRole.EnergySupplier ? actor.ActorNumber.ToProcessManagerActorNumber() : null;
 
         var accepted = new RequestCalculatedWholesaleServicesAcceptedV1(
-            OriginalActorMessageId: Guid.NewGuid().ToString(),
-            OriginalTransactionId: Guid.NewGuid().ToString(),
+            OriginalActorMessageId: Guid.NewGuid().ToTestMessageUuid(),
+            OriginalTransactionId: Guid.NewGuid().ToTestMessageUuid(),
             RequestedForActorNumber: actor.ActorNumber.ToProcessManagerActorNumber(),
             RequestedForActorRole: actor.ActorRole.ToProcessManagerActorRole(),
             RequestedByActorNumber: actor.ActorNumber.ToProcessManagerActorNumber(),
@@ -56,11 +57,11 @@ public class EnqueueBrs028MessageFactory
 
     public static ServiceBusMessage CreateReject(Actor actor)
     {
-        var actorMessageId = Guid.NewGuid().ToString();
+        var actorMessageId = Guid.NewGuid().ToTestMessageUuid();
         var reject = new RequestCalculatedWholesaleServicesRejectedV1(
             OriginalMessageId: actorMessageId,
             OriginalActorMessageId: actorMessageId,
-            OriginalTransactionId: Guid.NewGuid().ToString(),
+            OriginalTransactionId: Guid.NewGuid().ToTestMessageUuid(),
             RequestedForActorNumber: actor.ActorNumber.ToProcessManagerActorNumber(),
             RequestedForActorRole: actor.ActorRole.ToProcessManagerActorRole(),
             RequestedByActorNumber: actor.ActorNumber.ToProcessManagerActorNumber(),

--- a/source/SubsystemTests/Dsl/AggregatedMeasureDataRequestDsl.cs
+++ b/source/SubsystemTests/Dsl/AggregatedMeasureDataRequestDsl.cs
@@ -43,7 +43,7 @@ public sealed class AggregatedMeasureDataRequestDsl
         return _ediDriver.RequestAggregatedMeasureDataXmlAsync(payload);
     }
 
-    internal async Task<Guid> Request(CancellationToken cancellationToken)
+    internal async Task<string> Request(CancellationToken cancellationToken)
     {
         await _ediDriver.EmptyQueueAsync().ConfigureAwait(false);
         return await _ediDriver

--- a/source/SubsystemTests/Dsl/ForwardMeteredDataDsl.cs
+++ b/source/SubsystemTests/Dsl/ForwardMeteredDataDsl.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Extensions;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.SubsystemTests.Drivers;
 using Energinet.DataHub.EDI.SubsystemTests.Drivers.Ebix;
@@ -74,7 +75,7 @@ internal sealed class ForwardMeteredDataDsl(
             actor: actor,
             start: Instant.FromUtc(2024, 12, 31, 23, 00, 00),
             end: Instant.FromUtc(2025, 01, 31, 23, 00, 00),
-            originalActorMessageId: Guid.NewGuid().ToString(),
+            originalActorMessageId: Guid.NewGuid().ToTestMessageUuid(),
             eventId: Guid.NewGuid());
     }
 
@@ -99,7 +100,7 @@ internal sealed class ForwardMeteredDataDsl(
         await _ediDriver.EmptyQueueAsync(messageCategory: MessageCategory.MeasureData);
         await _processManagerDriver.PublishBrs021ForwardMeteredDataRejectedAsync(
             actor: actor,
-            originalActorMessageId: Guid.NewGuid().ToString(),
+            originalActorMessageId: Guid.NewGuid().ToTestMessageUuid(),
             eventId: Guid.NewGuid(),
             validationError: SubsystemTestValidationError,
             meteringPointId: meteringPointId);

--- a/source/SubsystemTests/Dsl/WholesaleSettlementRequestDsl.cs
+++ b/source/SubsystemTests/Dsl/WholesaleSettlementRequestDsl.cs
@@ -41,7 +41,7 @@ public sealed class WholesaleSettlementRequestDsl
         _processManagerDriver = processManagerDriver;
     }
 
-    internal async Task<Guid> Request(CancellationToken cancellationToken)
+    internal async Task<string> Request(CancellationToken cancellationToken)
     {
         await _ediDriver.EmptyQueueAsync().ConfigureAwait(false);
 

--- a/source/SubsystemTests/Tests/ArchivedMessages/WhenArchivedMessageIsRequestedTests.cs
+++ b/source/SubsystemTests/Tests/ArchivedMessages/WhenArchivedMessageIsRequestedTests.cs
@@ -90,7 +90,7 @@ public sealed class WhenArchivedMessageIsRequestedTests : BaseTestClass
         await _archivedMessages.ConfirmArchivedMessageSearchAuditLogExistsForMessageId(messageId, createdAfter);
     }
 
-    [Fact(Skip = "The outgoing message created from this test is interfering with other subsystem tests.")]
+    [Fact]
     public async Task B2C_actor_can_get_the_send_forward_metering_point_archived_message()
     {
         var meteringPointId = MeteringPointId.From("9999999999");

--- a/source/Tests/Infrastructure/IncomingMessages/RequestProcessOrchestrationStarterTests.cs
+++ b/source/Tests/Infrastructure/IncomingMessages/RequestProcessOrchestrationStarterTests.cs
@@ -97,7 +97,7 @@ public class RequestProcessOrchestrationStarterTests
                     It.IsAny<CancellationToken>()))
             .Callback((StartOrchestrationInstanceMessageCommand<RequestCalculatedWholesaleServicesInputV1> command, CancellationToken _) => actualCommand = command);
 
-        var processManagerClientFactory = new Mock<IProcessManagerClientFactory>();
+        var processManagerClientFactory = new Mock<IProcessManagerMessageClientFactory>();
         processManagerClientFactory
             .Setup(c => c.CreateMessageClient(It.IsAny<string>()))
             .Returns(processManagerClient.Object);
@@ -223,7 +223,7 @@ public class RequestProcessOrchestrationStarterTests
                     It.IsAny<CancellationToken>()))
             .Callback((StartOrchestrationInstanceMessageCommand<RequestCalculatedEnergyTimeSeriesInputV1> command, CancellationToken _) => actualCommand = command);
 
-        var processManagerClientFactory = new Mock<IProcessManagerClientFactory>();
+        var processManagerClientFactory = new Mock<IProcessManagerMessageClientFactory>();
         processManagerClientFactory
             .Setup(c => c.CreateMessageClient(It.IsAny<string>()))
             .Returns(processManagerClient.Object);
@@ -357,7 +357,7 @@ public class RequestProcessOrchestrationStarterTests
                     It.IsAny<ForwardMeteredDataCommandV1>(),
                     It.IsAny<CancellationToken>()))
             .Callback((StartOrchestrationInstanceMessageCommand<ForwardMeteredDataInputV1> command, CancellationToken _) => actualCommand = command);
-        var processManagerClientFactory = new Mock<IProcessManagerClientFactory>();
+        var processManagerClientFactory = new Mock<IProcessManagerMessageClientFactory>();
         processManagerClientFactory
             .Setup(c => c.CreateMessageClient(It.IsAny<string>()))
             .Returns(processManagerClient.Object);

--- a/source/Tests/Infrastructure/IncomingMessages/RequestProcessOrchestrationStarterTests.cs
+++ b/source/Tests/Infrastructure/IncomingMessages/RequestProcessOrchestrationStarterTests.cs
@@ -97,6 +97,11 @@ public class RequestProcessOrchestrationStarterTests
                     It.IsAny<CancellationToken>()))
             .Callback((StartOrchestrationInstanceMessageCommand<RequestCalculatedWholesaleServicesInputV1> command, CancellationToken _) => actualCommand = command);
 
+        var processManagerClientFactory = new Mock<IProcessManagerClientFactory>();
+        processManagerClientFactory
+            .Setup(c => c.CreateMessageClient(It.IsAny<string>()))
+            .Returns(processManagerClient.Object);
+
         // => Setup authenticated actor
         var expectedActor = new Actor(ActorNumber.Create("1234567890123"), ActorRole.GridAccessProvider);
         var authenticatedActor = new AuthenticatedActor();
@@ -108,7 +113,7 @@ public class RequestProcessOrchestrationStarterTests
             Guid.NewGuid()));
 
         var sut = new RequestProcessOrchestrationStarter(
-            processManagerClient.Object,
+            processManagerClientFactory.Object,
             authenticatedActor);
 
         // Act
@@ -218,8 +223,12 @@ public class RequestProcessOrchestrationStarterTests
                     It.IsAny<CancellationToken>()))
             .Callback((StartOrchestrationInstanceMessageCommand<RequestCalculatedEnergyTimeSeriesInputV1> command, CancellationToken _) => actualCommand = command);
 
-        // => Setup authenticated actor
+        var processManagerClientFactory = new Mock<IProcessManagerClientFactory>();
+        processManagerClientFactory
+            .Setup(c => c.CreateMessageClient(It.IsAny<string>()))
+            .Returns(processManagerClient.Object);
 
+        // => Setup authenticated actor
         var expectedActor = new Actor(ActorNumber.Create("1234567890123"), ActorRole.EnergySupplier);
         var authenticatedActor = new AuthenticatedActor();
         authenticatedActor.SetAuthenticatedActor(new ActorIdentity(
@@ -230,7 +239,7 @@ public class RequestProcessOrchestrationStarterTests
             Guid.NewGuid()));
 
         var sut = new RequestProcessOrchestrationStarter(
-            processManagerClient.Object,
+            processManagerClientFactory.Object,
             authenticatedActor);
 
         // Act
@@ -348,6 +357,10 @@ public class RequestProcessOrchestrationStarterTests
                     It.IsAny<ForwardMeteredDataCommandV1>(),
                     It.IsAny<CancellationToken>()))
             .Callback((StartOrchestrationInstanceMessageCommand<ForwardMeteredDataInputV1> command, CancellationToken _) => actualCommand = command);
+        var processManagerClientFactory = new Mock<IProcessManagerClientFactory>();
+        processManagerClientFactory
+            .Setup(c => c.CreateMessageClient(It.IsAny<string>()))
+            .Returns(processManagerClient.Object);
 
         // => Setup authenticated actor
         var expectedActor = new Actor(ActorNumber.Create("1111111111111"), ActorRole.GridAccessProvider);
@@ -360,7 +373,7 @@ public class RequestProcessOrchestrationStarterTests
             Guid.NewGuid()));
 
         var sut = new ForwardMeteredDataOrchestrationStarter(
-            processManagerClient.Object,
+            processManagerClientFactory.Object,
             authenticatedActor);
 
         // Act


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

This PR updates test dependencies to use special test UUIDs and improves testability by mocking dependencies in subsystem tests. Key changes include:

- Replacing Guid.ToString() calls with Guid.ToTestMessageUuid() for consistent test message identifiers.
- Changing return types from Guid to string for test methods where message identifiers are returned.
- Renaming and updating configuration options from IncomingMessagesQueueOptions to IncomingMessagesOptions and adding a new ProcessManagerClientFactory to support mock dependencies.

## References

- Infrastructure PR: https://github.com/Energinet-DataHub/dh3-infrastructure/pull/3564
- D002 run: https://github.com/Energinet-DataHub/dh3-environments/actions/runs/14910113600/job/41882830343
- https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/740

## Checklist
- [x] Should the change be behind a feature flag?
- [x] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [x] Has it been considered whether data is being delivered to the wrong actor?
- [x] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task