### PR TITLE
test: Fix BRS-021 subsystem tests

### DIFF
--- a/source/SubsystemTests/Drivers/EdiDriver.cs
+++ b/source/SubsystemTests/Drivers/EdiDriver.cs
@@ -101,7 +101,7 @@ internal sealed class EdiDriver
         if (peekResponse.StatusCode == HttpStatusCode.OK)
         {
             await DequeueAsync(GetMessageId(peekResponse)).ConfigureAwait(false);
-            await EmptyQueueAsync().ConfigureAwait(false);
+            await EmptyQueueAsync(messageCategory).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

`EmptyQueueAsync()` would only peek/dequeue one measurements message, and then afterwards dequeue other aggregations (because the `messageCategory` defaults to `Aggregations` and wasn't provided in the recursive method call).

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task