### PR TITLE
fix: rename peek measurement messages flag

### DIFF
--- a/source/B2BApi.AppTests/Functions/EnqueueMessages/BRS_021/EnqueueBrs21CalculationMessagesTests.cs
+++ b/source/B2BApi.AppTests/Functions/EnqueueMessages/BRS_021/EnqueueBrs21CalculationMessagesTests.cs
@@ -79,7 +79,7 @@ public class EnqueueBrs21CalculationMessagesTests : IAsyncLifetime
     {
         _fixture.EnsureAppHostUsesFeatureFlagValue(
         [
-            new(FeatureFlagName.Brs021PeekMessages, true),
+            new(FeatureFlagName.PeekMeasurementMessages, true),
             new(FeatureFlagName.PM25CIM, true),
         ]);
 

--- a/source/B2BApi.AppTests/Functions/EnqueueMessages/BRS_021/EnqueueBrs21ForwardMeteredDataMessagesTests.cs
+++ b/source/B2BApi.AppTests/Functions/EnqueueMessages/BRS_021/EnqueueBrs21ForwardMeteredDataMessagesTests.cs
@@ -87,7 +87,7 @@ public class EnqueueBrs21ForwardMeteredDataMessagesTests : IAsyncLifetime
     {
         _fixture.EnsureAppHostUsesFeatureFlagValue(
         [
-            new(FeatureFlagName.Brs021PeekMessages, true),
+            new(FeatureFlagName.PeekMeasurementMessages, true),
             new(FeatureFlagName.PM25CIM, true),
         ]);
 
@@ -244,7 +244,7 @@ public class EnqueueBrs21ForwardMeteredDataMessagesTests : IAsyncLifetime
     {
         _fixture.EnsureAppHostUsesFeatureFlagValue(
         [
-            new(FeatureFlagName.Brs021PeekMessages, true),
+            new(FeatureFlagName.PeekMeasurementMessages, true),
             new(FeatureFlagName.PM25CIM, true),
         ]);
 

--- a/source/BuildingBlocks.Infrastructure/FeatureFlag/FeatureFlagName.cs
+++ b/source/BuildingBlocks.Infrastructure/FeatureFlag/FeatureFlagName.cs
@@ -42,5 +42,5 @@ public static class FeatureFlagName
     /// <summary>
     /// Whether to allow actors to peek measurements messages.
     /// </summary>
-    public const string Brs021PeekMessages = "BRS021-PEEK-MESSAGES";
+    public const string PeekMeasurementMessages = "PEEK-MEASUREMENT-MESSAGES";
 }

--- a/source/BuildingBlocks.Infrastructure/FeatureFlag/MicrosoftFeatureFlagManager.cs
+++ b/source/BuildingBlocks.Infrastructure/FeatureFlag/MicrosoftFeatureFlagManager.cs
@@ -34,7 +34,7 @@ public class MicrosoftFeatureFlagManager(
 
     public Task<bool> ReceiveForwardMeteredDataInEbixAsync() => IsEnabledAsync(FeatureFlagName.PM25Ebix);
 
-    public Task<bool> UsePeekForwardMeteredDataMessagesAsync() => IsEnabledAsync(FeatureFlagName.Brs021PeekMessages);
+    public Task<bool> UsePeekForwardMeteredDataMessagesAsync() => IsEnabledAsync(FeatureFlagName.PeekMeasurementMessages);
 
     protected Task<bool> IsEnabledAsync(string featureFlagName)
     {

--- a/source/BuildingBlocks.Tests/TestDoubles/FeatureFlagManagerStub.cs
+++ b/source/BuildingBlocks.Tests/TestDoubles/FeatureFlagManagerStub.cs
@@ -29,7 +29,7 @@ public class FeatureFlagManagerStub : IFeatureFlagManager
         { FeatureFlagName.UsePeekMessages, true },
         { FeatureFlagName.PM25CIM, true },
         { FeatureFlagName.PM25Ebix, true },
-        { FeatureFlagName.Brs021PeekMessages, true },
+        { FeatureFlagName.PeekMeasurementMessages, true },
     };
 
     public void SetFeatureFlag(string featureFlagName, bool value)
@@ -39,7 +39,7 @@ public class FeatureFlagManagerStub : IFeatureFlagManager
 
     public Task<bool> UsePeekMessagesAsync() => Task.FromResult(_featureFlagDictionary[FeatureFlagName.UsePeekMessages]);
 
-    public Task<bool> UsePeekForwardMeteredDataMessagesAsync() => Task.FromResult(_featureFlagDictionary[FeatureFlagName.Brs021PeekMessages]);
+    public Task<bool> UsePeekForwardMeteredDataMessagesAsync() => Task.FromResult(_featureFlagDictionary[FeatureFlagName.PeekMeasurementMessages]);
 
     public Task<bool> ReceiveForwardMeteredDataInCimAsync() => Task.FromResult(_featureFlagDictionary[FeatureFlagName.PM25CIM]);
 

--- a/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenAPeekIsRequestedTests.cs
+++ b/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenAPeekIsRequestedTests.cs
@@ -368,7 +368,7 @@ public class WhenAPeekIsRequestedTests : OutgoingMessagesTestBase
     public async Task Given_EnqueuedRsm012_AndGiven_DisallowedPeekingRsm012_When_MessagesArePeekedInAnyFormat_Then_PeekReturnsNothing(DocumentFormat documentFormat)
     {
         // Arrange / Given
-        FeatureFlagManagerStub.SetFeatureFlag(FeatureFlagName.Brs021PeekMessages, false);
+        FeatureFlagManagerStub.SetFeatureFlag(FeatureFlagName.PeekMeasurementMessages, false);
 
         var receiver = new Actor(ActorNumber.Create("1234567890123"), ActorRole.EnergySupplier);
         var bundledMessage = new AcceptedForwardMeteredDataMessageDtoBuilder()
@@ -397,7 +397,7 @@ public class WhenAPeekIsRequestedTests : OutgoingMessagesTestBase
     public async Task Given_EnqueuedRsm012_AndGiven_AllowedPeekingRsm012_When_MessagesArePeekedInAnyFormat_Then_PeekReturnsDocument(DocumentFormat documentFormat)
     {
         // Arrange / Given
-        FeatureFlagManagerStub.SetFeatureFlag(FeatureFlagName.Brs021PeekMessages, true);
+        FeatureFlagManagerStub.SetFeatureFlag(FeatureFlagName.PeekMeasurementMessages, true);
 
         var receiver = new Actor(ActorNumber.Create("1234567890123"), ActorRole.EnergySupplier);
         var bundledMessage = new AcceptedForwardMeteredDataMessageDtoBuilder()


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Imødekomme renaming I dette pr: https://github.com/Energinet-DataHub/dh3-infrastructure/pull/3568


## Må ikke merges før
- [x] Infra er deployed
- [x] Nyt flag er enabled på forventet miljøer. I dette tilfælde:
  - [x] Dev001
  - [x] Dev002
  - [x] Test001
  - [x] Preprod001

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [ ] Reference to the task