### PR TITLE
fix: number of enqueued rsm021 query (load test)

### DIFF
--- a/source/SubsystemTests/Drivers/EdiDatabaseDriver.cs
+++ b/source/SubsystemTests/Drivers/EdiDatabaseDriver.cs
@@ -186,7 +186,7 @@ internal sealed class EdiDatabaseDriver
                  JOIN Bundles b ON om.AssignedBundleId = b.Id
                  WHERE b.[DequeuedAt] IS NULL
                  AND om.[RelatedToMessageId] like 'perf_test_%'
-                 AND b.[DocumentType] = 'NotifyValidatedMeasureData'
+                 AND b.[DocumentTypeInBundle] = 'NotifyValidatedMeasureData'
                  """);
 
         return enqueuedMessagesCount;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
Fix query to fetch number of enqueued outgoing messages after a load test. 

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [x] Is there time to monitor state of the release to Production?
- [x] Reference to the task => https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/726