### PR TITLE
Test: Ensure archived messages are saved in expected table

### DIFF
--- a/source/ArchivedMessages.IntegrationTests/Fixture/ArchivedMessagesFixture.cs
+++ b/source/ArchivedMessages.IntegrationTests/Fixture/ArchivedMessagesFixture.cs
@@ -205,6 +205,19 @@ public class ArchivedMessagesFixture : IDisposable, IAsyncLifetime
         return archivedMessages.ToList().AsReadOnly();
     }
 
+    public async Task<int> GetNumberOfCreatedMessagesInDatabase()
+    {
+        var connectionFactory = Services.GetService<IDatabaseConnectionFactory>()!;
+        using var connection = await connectionFactory.GetConnectionAndOpenAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var rowCount =
+            await connection.QuerySingleAsync<int>(
+                    "SELECT COUNT(*) FROM dbo.[ArchivedMessages]")
+                .ConfigureAwait(false);
+
+        return rowCount;
+    }
+
     public async Task<IReadOnlyCollection<MeteringPointArchivedMessageFromDb>> GetAllMeteringPointMessagesInDatabase()
     {
         var connectionFactory = Services.GetService<IDatabaseConnectionFactory>()!;

--- a/source/ArchivedMessages.IntegrationTests/WhenArchivedMessageIsCreatedTests.cs
+++ b/source/ArchivedMessages.IntegrationTests/WhenArchivedMessageIsCreatedTests.cs
@@ -94,6 +94,27 @@ public class WhenArchivedMessageIsCreatedTests : IAsyncLifetime
         Assert.NotNull(result);
     }
 
+    [Theory]
+    [MemberData(nameof(GetDocumentTypes))]
+    public async Task Given_DocumentType_When_Created_Then_StoredInExpectedDatabase(DocumentType documentType)
+    {
+        await CreateArchivedMessageAsync(documentType: documentType);
+
+        var numberOfArchivedMeteringPointMessages = await _fixture.GetNumberOfCreatedMeteringPointMessages();
+        var numberOfArchivedMessages = await _fixture.GetNumberOfCreatedMessagesInDatabase();
+
+        if (MeteringPointDocumentTypes.Contains(documentType))
+        {
+            numberOfArchivedMeteringPointMessages.Should().Be(1);
+            numberOfArchivedMessages.Should().Be(0);
+        }
+        else
+        {
+            numberOfArchivedMeteringPointMessages.Should().Be(0);
+            numberOfArchivedMessages.Should().Be(1);
+        }
+    }
+
     [Fact]
     public async Task Given_ArchivedDocument_When_Created_Then_RetrievedWithCorrectContent()
     {

--- a/source/ArchivedMessages.IntegrationTests/WhenArchivedMessageIsCreatedTests.cs
+++ b/source/ArchivedMessages.IntegrationTests/WhenArchivedMessageIsCreatedTests.cs
@@ -96,7 +96,7 @@ public class WhenArchivedMessageIsCreatedTests : IAsyncLifetime
 
     [Theory]
     [MemberData(nameof(GetDocumentTypes))]
-    public async Task Given_DocumentType_When_Created_Then_StoredInExpectedDatabase(DocumentType documentType)
+    public async Task Given_DocumentType_When_Created_Then_StoredInExpectedTable(DocumentType documentType)
     {
         await CreateArchivedMessageAsync(documentType: documentType);
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-aggregations) before we can accept your contribution. --->

<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
As of right now, we do not have a test which ensures that all the archived messages are stored in the expected table.
This pr introduces such a test

## References

## Checklist
- [ ] Should the change be behind a feature flag?
- [ ] Can the feature be meaningfully disabled or circumvented if there are issues (e.g., database-breaking changes)?
- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Subsystem test executed (dev_002/dev_003)
- [ ] Is there time to monitor state of the release to Production?
- [ ] Reference to the task