### PR TITLE
fix: Set Missing Measurements Log external id from input

### DIFF
--- a/source/B2BApi/Functions/EnqueueMessages/BRS_045/EnqueueHandler_Brs_045_MissingMeasurementsLog.cs
+++ b/source/B2BApi/Functions/EnqueueMessages/BRS_045/EnqueueHandler_Brs_045_MissingMeasurementsLog.cs
@@ -53,9 +53,8 @@ public class EnqueueHandler_Brs_045_MissingMeasurementsLog(
     {
         return new MissingMeasurementMessageDto(
             eventId: EventId.From(Guid.CreateVersion7()),
-            externalId: ExternalId.HashValuesWithMaxLength(
-                orchestrationInstanceId.ToString("N"),
-                data.MeteringPointId),
+            orchestrationInstanceId: orchestrationInstanceId,
+            meteringPointId: data.MeteringPointId,
             receiver: new Actor(
                 ActorNumber.Create(data.GridAccessProvider.Value),
                 ActorRole.MeteredDataResponsible),

--- a/source/B2BApi/Functions/EnqueueMessages/BRS_045/EnqueueHandler_Brs_045_MissingMeasurementsLog.cs
+++ b/source/B2BApi/Functions/EnqueueMessages/BRS_045/EnqueueHandler_Brs_045_MissingMeasurementsLog.cs
@@ -54,7 +54,6 @@ public class EnqueueHandler_Brs_045_MissingMeasurementsLog(
         return new MissingMeasurementMessageDto(
             eventId: EventId.From(Guid.CreateVersion7()),
             orchestrationInstanceId: orchestrationInstanceId,
-            meteringPointId: data.MeteringPointId,
             receiver: new Actor(
                 ActorNumber.Create(data.GridAccessProvider.Value),
                 ActorRole.MeteredDataResponsible),

--- a/source/BuildingBlocks.Domain/Models/ExternalId.cs
+++ b/source/BuildingBlocks.Domain/Models/ExternalId.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json.Serialization;
 
 namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
@@ -25,9 +27,19 @@ namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 [Serializable]
 public record ExternalId
 {
+    private const int MaxLength = 36;
+
     [JsonConstructor]
     public ExternalId(string value)
     {
+        if (value.Length > MaxLength)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                value,
+                $"ExternalId must be {MaxLength} characters or less");
+        }
+
         Value = value;
     }
 
@@ -38,4 +50,36 @@ public record ExternalId
     public string Value { get; }
 
     public static ExternalId New() => new(Guid.NewGuid());
+
+    /// <summary>
+    /// Hashes the given <paramref name="values"/> input to create a string, and ensures that the length is less than
+    /// or equal to the <see cref="MaxLength"/>.
+    /// </summary>
+    /// <remarks>
+    /// The hashing algorithm used is SHA256, which has a low chance of collision. The hashing algorithm ensures
+    /// the "avalanche effect", which means that even if the input only changes by 1 bit, the output will be completely
+    /// different.
+    /// </remarks>
+    /// <returns>An <see cref="ExternalId"/> that contains a hashed value. The output will be the same given that the input is the same.</returns>
+    public static ExternalId HashValuesWithMaxLength(params string[] values)
+    {
+        if (values.Length == 0)
+            throw new ArgumentException("At least one value must be provided.", nameof(values));
+
+        // Combine all values into a single string.
+        var combinedInputString = string.Join(string.Empty, values);
+
+        // Hash the combined input string using SHA256 (low collision chance).
+        var inputAsHash = SHA256.HashData(Encoding.UTF8.GetBytes(combinedInputString));
+
+        // Use standard Base64 and trim padding ('==' characters) if present.
+        var asBase64String = Convert.ToBase64String(inputAsHash).TrimEnd('=');
+
+        // Truncate to maximum MaxLength characters.
+        var hashedValue = asBase64String.Length <= MaxLength
+            ? asBase64String
+            : asBase64String.Substring(0, MaxLength);
+
+        return new ExternalId(hashedValue);
+    }
 }

--- a/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests.cs
+++ b/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests.cs
@@ -14,7 +14,6 @@
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.BuildingBlocks.Interfaces;
-using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.Bundles;
 using Energinet.DataHub.EDI.OutgoingMessages.Infrastructure.DataAccess;
 using Energinet.DataHub.EDI.OutgoingMessages.IntegrationTests.Fixtures;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces;
@@ -118,24 +117,6 @@ public class WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests : OutgoingMe
             start: start,
             end: end,
             relatedToMessageId: relatedToMessageId2);
-
-        // Need to create a bundle up front, else an exception will be thrown when trying to create the same bundle for both messages.
-        // The easiest way to do that, is just to enqueue another message, to the same receiver, before running the tests
-        using (var setupScope = ServiceProvider.CreateScope())
-        {
-            var existingMessage = CreateAcceptedForwardMeteredDataMessage(
-                externalId: ExternalId.New(), // Using a new external id, so the messages are not the same (idempotency check)
-                receiver: receiver,
-                start: start,
-                end: end,
-                relatedToMessageId: MessageId.New());
-
-            var setupOutgoingMessagesClient = setupScope.ServiceProvider.GetRequiredService<IOutgoingMessagesClient>();
-            var setupDbContext = setupScope.ServiceProvider.GetRequiredService<ActorMessageQueueContext>();
-
-            await setupOutgoingMessagesClient.EnqueueAsync(existingMessage, CancellationToken.None);
-            await setupDbContext.SaveChangesAsync(CancellationToken.None);
-        }
 
         // When enqueueing the messages
         var outgoingMessagesClient = ServiceProvider.GetRequiredService<IOutgoingMessagesClient>();

--- a/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests.cs
+++ b/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests.cs
@@ -47,7 +47,7 @@ public class WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests : OutgoingMe
     }
 
     [Fact]
-    public async Task Given_TwoMessagesWithSameIdempotencyData_When_EnqueueingForwardMeteredDataSeparately_Then_OnlyOneMessageIsEnqueued()
+    public async Task Given_TwoMessagesWithSameIdempotencyData_When_EnqueueingForwardMeteredDataSeparately_Then_OneMessageIsEnqueued()
     {
         // Given multiple messages with the same idempotency data
         var externalId = ExternalId.New();

--- a/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests.cs
+++ b/source/OutgoingMessages.IntegrationTests/OutgoingMessages/WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests.cs
@@ -75,6 +75,7 @@ public class WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests : OutgoingMe
         var outgoingMessagesClient = ServiceProvider.GetRequiredService<IOutgoingMessagesClient>();
         var unitOfWork = ServiceProvider.GetRequiredService<ActorMessageQueueContext>();
 
+        // We need to save changes between enqueues to not fail on idempotency unique constraint in database
         await outgoingMessagesClient.EnqueueAsync(message1, CancellationToken.None);
         await unitOfWork.SaveChangesAsync(CancellationToken.None);
 
@@ -163,10 +164,7 @@ public class WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests : OutgoingMe
         var outgoingMessagesClient = ServiceProvider.GetRequiredService<IOutgoingMessagesClient>();
         var unitOfWork = ServiceProvider.GetRequiredService<IUnitOfWork>();
 
-        // We need to save changes between enqueues to not fail on unique index for bundling
         await outgoingMessagesClient.EnqueueAsync(message1, CancellationToken.None);
-        await unitOfWork.CommitTransactionAsync(CancellationToken.None);
-
         await outgoingMessagesClient.EnqueueAsync(message2, CancellationToken.None);
         await unitOfWork.CommitTransactionAsync(CancellationToken.None);
 
@@ -213,10 +211,7 @@ public class WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests : OutgoingMe
         var outgoingMessagesClient = ServiceProvider.GetRequiredService<IOutgoingMessagesClient>();
         var unitOfWork = ServiceProvider.GetRequiredService<IUnitOfWork>();
 
-        // We need to save changes between enqueues to not fail on unique index for bundling
         await outgoingMessagesClient.EnqueueAsync(message1, CancellationToken.None);
-        await unitOfWork.CommitTransactionAsync(CancellationToken.None);
-
         await outgoingMessagesClient.EnqueueAsync(message2, CancellationToken.None);
         await unitOfWork.CommitTransactionAsync(CancellationToken.None);
 
@@ -263,10 +258,7 @@ public class WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests : OutgoingMe
         var outgoingMessagesClient = ServiceProvider.GetRequiredService<IOutgoingMessagesClient>();
         var unitOfWork = ServiceProvider.GetRequiredService<IUnitOfWork>();
 
-        // We need to save changes between enqueues to not fail on unique index for bundling
         await outgoingMessagesClient.EnqueueAsync(message1, CancellationToken.None);
-        await unitOfWork.CommitTransactionAsync(CancellationToken.None);
-
         await outgoingMessagesClient.EnqueueAsync(message2, CancellationToken.None);
         await unitOfWork.CommitTransactionAsync(CancellationToken.None);
 
@@ -315,10 +307,7 @@ public class WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests : OutgoingMe
         var outgoingMessagesClient = ServiceProvider.GetRequiredService<IOutgoingMessagesClient>();
         var unitOfWork = ServiceProvider.GetRequiredService<IUnitOfWork>();
 
-        // We need to save changes between enqueues to not fail on unique index for bundling
         await outgoingMessagesClient.EnqueueAsync(message1, CancellationToken.None);
-        await unitOfWork.CommitTransactionAsync(CancellationToken.None);
-
         await outgoingMessagesClient.EnqueueAsync(message2, CancellationToken.None);
         await unitOfWork.CommitTransactionAsync(CancellationToken.None);
 
@@ -363,7 +352,7 @@ public class WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests : OutgoingMe
         var outgoingMessagesClient = ServiceProvider.GetRequiredService<IOutgoingMessagesClient>();
         var unitOfWork = ServiceProvider.GetRequiredService<IUnitOfWork>();
 
-        // We need to save changes between enqueues to not fail on unique index for bundling
+        // We need to save changes between enqueues to not fail on idempotency unique constraint in database
         await outgoingMessagesClient.EnqueueAsync(message, CancellationToken.None);
         await unitOfWork.CommitTransactionAsync(CancellationToken.None);
 
@@ -381,7 +370,7 @@ public class WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests : OutgoingMe
     }
 
     [Fact]
-    public async Task Given_TwoMessagesWithSameData_When_EnqueueingMissingMeasurementsLog_Then_OneMessageIsEnqueued()
+    public async Task Given_TwoMessagesWithSameIdempotencyData_When_EnqueueingMissingMeasurementsLog_Then_OneMessageIsEnqueued()
     {
         var orchestrationInstanceId = Guid.NewGuid();
         var meteringPointId = MeteringPointId.From("1234567890123");
@@ -397,7 +386,7 @@ public class WhenEnqueueingMultipleOutgoingMessagesIdempotencyTests : OutgoingMe
         var outgoingMessagesClient = ServiceProvider.GetRequiredService<IOutgoingMessagesClient>();
         var unitOfWork = ServiceProvider.GetRequiredService<IUnitOfWork>();
 
-        // We need to save changes between enqueues to not fail on unique index for bundling
+        // We need to save changes between enqueues to not fail on idempotency unique constraint in database
         await outgoingMessagesClient.EnqueueAsync(message, CancellationToken.None);
         await unitOfWork.CommitTransactionAsync(CancellationToken.None);
 

--- a/source/OutgoingMessages.Interfaces/Models/MissingMeasurementMessages/MissingMeasurementMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/MissingMeasurementMessages/MissingMeasurementMessageDto.cs
@@ -19,7 +19,6 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MissingMeasur
 public sealed class MissingMeasurementMessageDto(
     EventId eventId,
     Guid orchestrationInstanceId,
-    string meteringPointId,
     Actor receiver,
     BusinessReason businessReason,
     string gridAreaCode,
@@ -31,7 +30,9 @@ public sealed class MissingMeasurementMessageDto(
         eventId: eventId,
         businessReasonName: businessReason.Name,
         receiverRole: receiver.ActorRole,
-        externalId: ExternalId.HashValuesWithMaxLength(orchestrationInstanceId.ToString("N"), meteringPointId),
+        externalId: ExternalId.HashValuesWithMaxLength(
+            orchestrationInstanceId.ToString("N"),
+            missingMeasurement.MeteringPointId.Value),
         relatedToMessageId: null)
 {
     public MissingMeasurement MissingMeasurement { get; } = missingMeasurement;

--- a/source/OutgoingMessages.Interfaces/Models/MissingMeasurementMessages/MissingMeasurementMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/MissingMeasurementMessages/MissingMeasurementMessageDto.cs
@@ -18,19 +18,21 @@ namespace Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MissingMeasur
 
 public sealed class MissingMeasurementMessageDto(
     EventId eventId,
-    ExternalId externalId,
+    Guid orchestrationInstanceId,
+    string meteringPointId,
     Actor receiver,
     BusinessReason businessReason,
     string gridAreaCode,
     MissingMeasurement missingMeasurement)
-    : OutgoingMessageDto(DocumentType.ReminderOfMissingMeasureData,
-        receiver.ActorNumber,
-        null,
-        eventId,
-        businessReason.Name,
-        receiver.ActorRole,
-        externalId,
-        null)
+    : OutgoingMessageDto(
+        documentType: DocumentType.ReminderOfMissingMeasureData,
+        receiverNumber: receiver.ActorNumber,
+        processId: null,
+        eventId: eventId,
+        businessReasonName: businessReason.Name,
+        receiverRole: receiver.ActorRole,
+        externalId: ExternalId.HashValuesWithMaxLength(orchestrationInstanceId.ToString("N"), meteringPointId),
+        relatedToMessageId: null)
 {
     public MissingMeasurement MissingMeasurement { get; } = missingMeasurement;
 

--- a/source/OutgoingMessages.UnitTests/Domain/ExternalIdTests.cs
+++ b/source/OutgoingMessages.UnitTests/Domain/ExternalIdTests.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+
+namespace Energinet.DataHub.EDI.OutgoingMessages.UnitTests.Domain;
+
+public class ExternalIdTests
+{
+    [Fact]
+    public void Given_ManyDifferentInputs_When_HashValuesWithMaxLength_Then_ValuesAreStillUnique()
+    {
+        // Create 10 almost equal metering point ids (0000000000001, 0000000000002, etc.)
+        var meteringPointIds = Enumerable.Range(0, 10)
+            .Select(i => i.ToString().PadLeft(totalWidth: 13, paddingChar: '0'));
+
+        // Create 100.000 orchestration instance ids (guids)
+        var orchestrationInstanceIds = Enumerable.Range(0, 100000)
+            .Select(_ => Guid.NewGuid());
+
+        // Create external ids from each orchestration instance id and metering point id
+        var externalIds = orchestrationInstanceIds.SelectMany(
+            orchestrationInstanceId => meteringPointIds.Select(
+                meteringPointId => ExternalId.HashValuesWithMaxLength(
+                        orchestrationInstanceId.ToString("N"),
+                        meteringPointId)
+                    .Value));
+
+        // Ensure no values are equal
+        Assert.Distinct(externalIds.ToList());
+    }
+
+    [Fact]
+    public void Given_ManyEqualInputs_When_HashValuesWithMaxLength_Then_ValuesAreStillEqual()
+    {
+        const string meteringPointId = "1234567890123";
+        var orchestrationInstanceId = Guid.NewGuid();
+
+        // Create a million external ids from the same orchestration instance id and metering point id
+        var externalIds = Enumerable.Range(0, 1000000)
+            .Select(_ => ExternalId.HashValuesWithMaxLength(orchestrationInstanceId.ToString("N"), meteringPointId))
+            .ToList();
+
+        // Ensure all values are equal
+        Assert.All(externalIds, item => Assert.Equal(externalIds.First(), item));
+    }
+}


### PR DESCRIPTION
<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Set missing measurement logs external id from orchestration instance id and metering point id. The external id has a max length of 36 characters in the database, so a hash is created that has a max 36 character length.

This pull request is related to this issue: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/758

## Checklist

<!-- markdown-link-check-disable -->
- [x] Subsystem test executed [deploy to dev_002/dev_003](https://github.com/Energinet-DataHub/dh3-environments/actions/workflows/edi-cd.yml) => https://github.com/Energinet-DataHub/dh3-environments/actions/runs/15046586881
<!-- markdown-link-check-enable -->

- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Is there time to monitor state of the release to Production?
