### PR TITLE
feat: Update reject reason error for energy/wholesale requests

### DIFF
--- a/source/OutgoingMessages.Application/ActorRequestsClient.cs
+++ b/source/OutgoingMessages.Application/ActorRequestsClient.cs
@@ -42,7 +42,7 @@ public class ActorRequestsClient(
 
     private static readonly RejectedEnergyResultMessageRejectReason _noEnergyDataForRequestedGridArea = new(
         ErrorMessage: "D46",
-        ErrorCode: "Forkert netområde / invalid grid area");
+        ErrorCode: "Ingen data i dette netområde / No data in the requested grid area");
 
     private static readonly RejectedWholesaleServicesMessageRejectReason _noWholesaleDataAvailable = new(
         ErrorMessage: "E0H",
@@ -50,7 +50,7 @@ public class ActorRequestsClient(
 
     private static readonly RejectedWholesaleServicesMessageRejectReason _noWholesaleDataForRequestedGridArea = new(
         ErrorMessage: "D46",
-        ErrorCode: "Forkert netområde / invalid grid area");
+        ErrorCode: "Ingen data i dette netområde / No data in the requested grid area");
 
     private readonly IOutgoingMessagesClient _outgoingMessagesClient = outgoingMessagesClient;
     private readonly IAggregatedTimeSeriesQueries _aggregatedTimeSeriesQueries = aggregatedTimeSeriesQueries;


### PR DESCRIPTION
<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Update the reject reason for `E0H` to better state, that there is no data available for the provided grid area.

This pull request is related to this issue: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/internal-repo/1656

## Checklist

<!-- markdown-link-check-disable -->
- [x] Subsystem test executed [deploy to dev_002/dev_003](https://github.com/Energinet-DataHub/dh3-environments/actions/workflows/edi-cd.yml): https://github.com/Energinet-DataHub/dh3-environments/actions/runs/15204126963
<!-- markdown-link-check-enable -->

- [x] Has it been considered whether data is being delivered to the wrong actor?
- [x] Is there time to monitor state of the release to Production?
