### PR TITLE
feat: Add missing measure data to document types for archived messages client

### DIFF
--- a/source/B2CWebApi/Mappers/DocumentTypeMapper.cs
+++ b/source/B2CWebApi/Mappers/DocumentTypeMapper.cs
@@ -29,6 +29,7 @@ public static class DocumentTypeMapper
         { Models.DocumentType.RequestWholesaleSettlement, IncomingDocumentType.RequestWholesaleSettlement.Name },
         { Models.DocumentType.B2CRequestWholesaleSettlement, IncomingDocumentType.B2CRequestWholesaleSettlement.Name },
         { Models.DocumentType.Acknowledgement, DocumentType.Acknowledgement.Name },
+        { Models.DocumentType.ReminderOfMissingMeasureData, DocumentType.ReminderOfMissingMeasureData.Name },
     };
 
     public static List<string>? FromDocumentTypes(IReadOnlyCollection<Models.DocumentType>? documentTypes)

--- a/source/B2CWebApi/Mappers/DocumentTypeMapper.cs
+++ b/source/B2CWebApi/Mappers/DocumentTypeMapper.cs
@@ -29,7 +29,7 @@ public static class DocumentTypeMapper
         { Models.DocumentType.RequestWholesaleSettlement, IncomingDocumentType.RequestWholesaleSettlement.Name },
         { Models.DocumentType.B2CRequestWholesaleSettlement, IncomingDocumentType.B2CRequestWholesaleSettlement.Name },
         { Models.DocumentType.Acknowledgement, DocumentType.Acknowledgement.Name },
-        { Models.DocumentType.ReminderOfMissingMeasureData, DocumentType.ReminderOfMissingMeasureData.Name },
+        { Models.DocumentType.ReminderOfMissingMeasurements, DocumentType.ReminderOfMissingMeasureData.Name },
     };
 
     public static List<string>? FromDocumentTypes(IReadOnlyCollection<Models.DocumentType>? documentTypes)

--- a/source/B2CWebApi/Models/DocumentTypes.cs
+++ b/source/B2CWebApi/Models/DocumentTypes.cs
@@ -26,5 +26,5 @@ public enum DocumentType
     RequestWholesaleSettlement = 6,
     B2CRequestWholesaleSettlement = 7,
     Acknowledgement = 8,
-    ReminderOfMissingMeasureData = 9,
+    ReminderOfMissingMeasurements = 9,
 }

--- a/source/B2CWebApi/Models/DocumentTypes.cs
+++ b/source/B2CWebApi/Models/DocumentTypes.cs
@@ -26,4 +26,5 @@ public enum DocumentType
     RequestWholesaleSettlement = 6,
     B2CRequestWholesaleSettlement = 7,
     Acknowledgement = 8,
+    ReminderOfMissingMeasureData = 9,
 }

--- a/source/SubsystemTests/Drivers/B2C/Client/B2CEdiClientV3.cs
+++ b/source/SubsystemTests/Drivers/B2C/Client/B2CEdiClientV3.cs
@@ -398,7 +398,7 @@ namespace Energinet.DataHub.EDI.SubsystemTests.Drivers.B2C.ClientV3
 
         Acknowledgement = 8,
 
-        ReminderOfMissingMeasureData = 9,
+        ReminderOfMissingMeasurements = 9,
 
     }
 

--- a/source/SubsystemTests/Drivers/B2C/Client/B2CEdiClientV3.cs
+++ b/source/SubsystemTests/Drivers/B2C/Client/B2CEdiClientV3.cs
@@ -18,10 +18,6 @@
 //----------------------
 
 using System.IO;
-// ReSharper disable ArrangeNamespaceBody
-// ReSharper disable EnforceForeachStatementBraces
-// ReSharper disable ArrangeThisQualifier
-// ReSharper disable ArrangeRedundantParentheses
 
 #pragma warning disable 108 // Disable "CS0108 '{derivedDto}.ToJson()' hides inherited member '{dtoBase}.ToJson()'. Use the new keyword if hiding was intended."
 #pragma warning disable 114 // Disable "CS0114 '{derivedDto}.RaisePropertyChanged(String)' hides inherited member 'dtoBase.RaisePropertyChanged(String)'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword."
@@ -401,6 +397,8 @@ namespace Energinet.DataHub.EDI.SubsystemTests.Drivers.B2C.ClientV3
         B2CRequestWholesaleSettlement = 7,
 
         Acknowledgement = 8,
+
+        ReminderOfMissingMeasureData = 9,
 
     }
 

--- a/source/SubsystemTests/Drivers/B2C/Client/swaggerV3.json
+++ b/source/SubsystemTests/Drivers/B2C/Client/swaggerV3.json
@@ -135,7 +135,7 @@
               "RequestWholesaleSettlement",
               "B2CRequestWholesaleSettlement",
               "Acknowledgement",
-              "ReminderOfMissingMeasureData"
+              "ReminderOfMissingMeasurements"
             ],
             "allOf": [
               {
@@ -217,7 +217,7 @@
           "RequestWholesaleSettlement",
           "B2CRequestWholesaleSettlement",
           "Acknowledgement",
-          "ReminderOfMissingMeasureData"
+          "ReminderOfMissingMeasurements"
         ],
         "enum": [
           0,

--- a/source/SubsystemTests/Drivers/B2C/Client/swaggerV3.json
+++ b/source/SubsystemTests/Drivers/B2C/Client/swaggerV3.json
@@ -134,7 +134,8 @@
               "B2CRequestAggregatedMeasureData",
               "RequestWholesaleSettlement",
               "B2CRequestWholesaleSettlement",
-              "Acknowledgement"
+              "Acknowledgement",
+              "ReminderOfMissingMeasureData"
             ],
             "allOf": [
               {
@@ -215,7 +216,8 @@
           "B2CRequestAggregatedMeasureData",
           "RequestWholesaleSettlement",
           "B2CRequestWholesaleSettlement",
-          "Acknowledgement"
+          "Acknowledgement",
+          "ReminderOfMissingMeasureData"
         ],
         "enum": [
           0,
@@ -226,7 +228,8 @@
           5,
           6,
           7,
-          8
+          8,
+          9
         ]
       },
       "Energinet.DataHub.EDI.B2CWebApi.Models.FieldToSortBy": {

--- a/source/Tests/B2CWebApi/Mappers/DocumentTypeMapperTests.cs
+++ b/source/Tests/B2CWebApi/Mappers/DocumentTypeMapperTests.cs
@@ -65,9 +65,17 @@ public class DocumentTypeMapperTests
                         .Where(dt => dt != null)
                         .Select(dt => dt!.Name));
 
-        supportedDocumentTypes = supportedDocumentTypes.Distinct();
+        supportedDocumentTypes = supportedDocumentTypes.Distinct().ToList();
 
-        // TODO - Remove this line when all DocumentTypes are supported in B2C
+        if (supportedDocumentTypes.Contains(
+                Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.DocumentType.ReminderOfMissingMeasureData.Name))
+        {
+            // The b2c document type has another name than the b2b document type
+            supportedDocumentTypes = supportedDocumentTypes.Append(DocumentType.ReminderOfMissingMeasurements.ToString());
+            supportedDocumentTypes = supportedDocumentTypes.Where(documentType =>
+                documentType != Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.DocumentType.ReminderOfMissingMeasureData.Name);
+        }
+
         supportedDocumentTypes = supportedDocumentTypes
             .Where(x =>
                 x != IncomingDocumentType.NotifyValidatedMeasureData.Name);

--- a/source/Tests/B2CWebApi/Mappers/DocumentTypeMapperTests.cs
+++ b/source/Tests/B2CWebApi/Mappers/DocumentTypeMapperTests.cs
@@ -70,8 +70,7 @@ public class DocumentTypeMapperTests
         // TODO - Remove this line when all DocumentTypes are supported in B2C
         supportedDocumentTypes = supportedDocumentTypes
             .Where(x =>
-                x != IncomingDocumentType.NotifyValidatedMeasureData.Name
-                        && x != Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.DocumentType.ReminderOfMissingMeasureData.Name);
+                x != IncomingDocumentType.NotifyValidatedMeasureData.Name);
 
         // Act & Assert
         documentTypes.Should().BeEquivalentTo(supportedDocumentTypes.ToList());


### PR DESCRIPTION
<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

This pull request exposes the document type `ReminderOgMissingMeasureData` in the `archivedMessagesSearchController`

This pull request is related to this issue: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/749

## Checklist

<!-- markdown-link-check-disable -->
- [ ] Subsystem test executed [deploy to dev_002/dev_003](https://github.com/Energinet-DataHub/dh3-environments/actions/workflows/edi-cd.yml) https://github.com/Energinet-DataHub/dh3-environments/actions/runs/15206963935
<!-- markdown-link-check-enable -->

- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Is there time to monitor state of the release to Production?
