### PR TITLE
feat: enqueue brs024 reject messages

### DIFF
--- a/source/BuildingBlocks.Domain/Models/DocumentType.cs
+++ b/source/BuildingBlocks.Domain/Models/DocumentType.cs
@@ -30,6 +30,7 @@ public class DocumentType : EnumerationType
     public static readonly DocumentType ReminderOfMissingMeasureData = new(nameof(ReminderOfMissingMeasureData), MessageCategory.MeasureData, 9);
 
     public static readonly DocumentType RequestMeasurements = new(nameof(RequestMeasurements), MessageCategory.MeasureData, 10);
+    public static readonly DocumentType RejectRequestMeasurements = new(nameof(RejectRequestMeasurements), MessageCategory.MeasureData, 11);
 
     /// <summary>
     /// Represents the document type in the Edi system.

--- a/source/OutgoingMessages.Application/OutgoingMessageFactory.cs
+++ b/source/OutgoingMessages.Application/OutgoingMessageFactory.cs
@@ -20,6 +20,7 @@ using Energinet.DataHub.EDI.OutgoingMessages.Domain.Models.OutgoingMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.EnergyResultMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.EnergyResultMessages.Request;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MeteredDataForMeteringPoint;
+using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MeteredDataForMeteringPoint.Request;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MissingMeasurementMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.WholesaleResultMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.WholesaleResultMessages.Request;
@@ -499,6 +500,35 @@ public static class OutgoingMessageFactory
             periodStartedAt: message.MissingMeasurement.Date,
             dataCount: 1,
             meteringPointId: message.MissingMeasurement.MeteringPointId);
+    }
+
+    /// <summary>
+    /// This method create a single outgoing message, for the receiver, based on the rejected energyResultMessage.
+    /// </summary>
+    public static OutgoingMessage CreateMessage(
+        RejectRequestMeasurementsMessageDto rejectedMessage,
+        ISerializer serializer,
+        Instant timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(rejectedMessage);
+
+        return new OutgoingMessage(
+            eventId: rejectedMessage.EventId,
+            documentType: rejectedMessage.DocumentType,
+            receiver: Receiver.Create(rejectedMessage.ReceiverNumber, rejectedMessage.ReceiverRole),
+            documentReceiver: Receiver.Create(rejectedMessage.DocumentReceiverNumber, rejectedMessage.DocumentReceiverRole),
+            processId: rejectedMessage.ProcessId,
+            businessReason: rejectedMessage.BusinessReason,
+            serializedContent: serializer.Serialize(rejectedMessage.Series),
+            createdAt: timestamp,
+            messageCreatedFromProcess: ProcessType.RequestMeasurements,
+            relatedToMessageId: rejectedMessage.RelatedToMessageId,
+            gridAreaCode: null,
+            externalId: rejectedMessage.ExternalId,
+            calculationId: null,
+            periodStartedAt: null,
+            dataCount: rejectedMessage.Series.RejectReasons.Count);
     }
 
     private static ActorRole GetChargeOwnerRole(ActorNumber chargeOwnerId)

--- a/source/OutgoingMessages.Application/OutgoingMessagesClient.cs
+++ b/source/OutgoingMessages.Application/OutgoingMessagesClient.cs
@@ -19,6 +19,7 @@ using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.Dequeue;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.EnergyResultMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.EnergyResultMessages.Request;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MeteredDataForMeteringPoint;
+using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MeteredDataForMeteringPoint.Request;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MissingMeasurementMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.Peek;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.WholesaleResultMessages;
@@ -265,6 +266,18 @@ public class OutgoingMessagesClient : IOutgoingMessagesClient
 
         var messageId = await _enqueueMessage.EnqueueAsync(message, cancellationToken).ConfigureAwait(false);
 
+        return messageId.Value;
+    }
+
+    public async Task<Guid> EnqueueAsync(
+        RejectRequestMeasurementsMessageDto rejectRequestMeasurementsMessageDto,
+        CancellationToken cancellationToken)
+    {
+        var message = OutgoingMessageFactory.CreateMessage(
+            rejectRequestMeasurementsMessageDto,
+            _serializer,
+            _clock.GetCurrentInstant());
+        var messageId = await _enqueueMessage.EnqueueAsync(message, cancellationToken).ConfigureAwait(false);
         return messageId.Value;
     }
 }

--- a/source/OutgoingMessages.Application/UseCases/DelegateMessage.cs
+++ b/source/OutgoingMessages.Application/UseCases/DelegateMessage.cs
@@ -47,6 +47,7 @@ public class DelegateMessage
         // because the receiver must be the same as the one who made the request
         if (messageToEnqueue.MessageCreatedFromProcess == ProcessType.RequestWholesaleResults
             || messageToEnqueue.MessageCreatedFromProcess == ProcessType.RequestEnergyResults
+            || messageToEnqueue.MessageCreatedFromProcess == ProcessType.RequestMeasurements
             // Acknowledgement messages are not delegated
             || messageToEnqueue.DocumentType == DocumentType.Acknowledgement)
         {

--- a/source/OutgoingMessages.Interfaces/IOutgoingMessagesClient.cs
+++ b/source/OutgoingMessages.Interfaces/IOutgoingMessagesClient.cs
@@ -16,6 +16,7 @@ using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.Dequeue;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.EnergyResultMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.EnergyResultMessages.Request;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MeteredDataForMeteringPoint;
+using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MeteredDataForMeteringPoint.Request;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MissingMeasurementMessages;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.Peek;
 using Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.WholesaleResultMessages;
@@ -132,5 +133,13 @@ public interface IOutgoingMessagesClient
     /// <returns>The Id for the created OutgoingMessage</returns>
     Task<Guid> EnqueueAsync(
         MissingMeasurementMessageDto missingMeasurementMessageDto,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Enqueue a rejected measurements message, no commit.
+    /// <returns>The Id for the created OutgoingMessage</returns>
+    /// </summary>
+    Task<Guid> EnqueueAsync(
+        RejectRequestMeasurementsMessageDto rejectRequestMeasurementsMessageDto,
         CancellationToken cancellationToken);
 }

--- a/source/OutgoingMessages.Interfaces/Models/MeteredDataForMeteringPoint/Request/RejectRequestMeasurementsMessageDto.cs
+++ b/source/OutgoingMessages.Interfaces/Models/MeteredDataForMeteringPoint/Request/RejectRequestMeasurementsMessageDto.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+
+namespace Energinet.DataHub.EDI.OutgoingMessages.Interfaces.Models.MeteredDataForMeteringPoint.Request;
+
+public class RejectRequestMeasurementsMessageDto : OutgoingMessageDto
+{
+    public RejectRequestMeasurementsMessageDto(
+        ActorNumber receiverNumber,
+        Guid processId,
+        EventId eventId,
+        string businessReason,
+        ActorRole receiverRole,
+        MessageId relatedToMessageId,
+        RejectRequestMeasurementsMessageSerie series,
+        ActorNumber documentReceiverNumber,
+        ActorRole documentReceiverRole)
+        : base(
+            DocumentType.RejectRequestMeasurements,
+            receiverNumber,
+            processId,
+            eventId,
+            businessReason,
+            receiverRole,
+            ExternalId.New(),
+            relatedToMessageId)
+    {
+        Series = series;
+        DocumentReceiverNumber = documentReceiverNumber;
+        DocumentReceiverRole = documentReceiverRole;
+    }
+
+    public RejectRequestMeasurementsMessageSerie Series { get; }
+
+    public ActorNumber DocumentReceiverNumber { get; }
+
+    public ActorRole DocumentReceiverRole { get; }
+}
+
+public record RejectRequestMeasurementsMessageSerie(
+    TransactionId TransactionId,
+    IReadOnlyCollection<RejectRequestMeasurementsMessageRejectReason> RejectReasons,
+    TransactionId OriginalTransactionIdReference);
+
+public record RejectRequestMeasurementsMessageRejectReason(string ErrorCode, string ErrorMessage);


### PR DESCRIPTION
<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

*Explain what this PR changes and why these changes are necessary. Give enough context for someone unfamiliar with the task to understand the purpose.*

Enqueue new outgoing message for rejected measurements requests. 

This pull request is related to this issue: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/813

## Checklist

<!-- markdown-link-check-disable -->
- [ ] Subsystem test executed [deploy to dev_002/dev_003](https://github.com/Energinet-DataHub/dh3-environments/actions/workflows/edi-cd.yml)
<!-- markdown-link-check-enable -->

- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Is there time to monitor state of the release to Production?
