### PR TITLE
fix: Start and End should be in correct format when RequestingEnergy

### DIFF
--- a/source/B2CWebApi/Factories/V1/RequestAggregatedMeasureDataDtoFactoryV1.cs
+++ b/source/B2CWebApi/Factories/V1/RequestAggregatedMeasureDataDtoFactoryV1.cs
@@ -17,6 +17,7 @@ using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
 using NodaTime;
+using NodaTime.Extensions;
 using ActorRole = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.ActorRole;
 using BusinessReason = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.BusinessReason;
 using MeteringPointType = Energinet.DataHub.EDI.B2CWebApi.Models.V1.MeteringPointType;
@@ -44,8 +45,8 @@ public static class RequestAggregatedMeasureDataDtoFactoryV1
             Id: TransactionId.New().Value,
             MarketEvaluationPointType: MapEvaluationPointTypeCode(request),
             MarketEvaluationSettlementMethod: MapSettlementMethodCode(request),
-            StartDateAndOrTimeDateTime: request.StartDate.ToString(),
-            EndDateAndOrTimeDateTime: request.EndDate.ToString(),
+            StartDateAndOrTimeDateTime: request.StartDate.ToInstant().ToString(),
+            EndDateAndOrTimeDateTime: request.EndDate.ToInstant().ToString(),
             MeteringGridAreaDomainId: request.GridAreaCode,
             EnergySupplierMarketParticipantId: request.EnergySupplierId,
             BalanceResponsiblePartyMarketParticipantId: request.BalanceResponsibleId,

--- a/source/B2CWebApi/Factories/V1/RequestAggregatedMeasureDataDtoFactoryV1.cs
+++ b/source/B2CWebApi/Factories/V1/RequestAggregatedMeasureDataDtoFactoryV1.cs
@@ -18,6 +18,7 @@ using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
 using NodaTime;
 using NodaTime.Extensions;
+using NodaTime.Text;
 using ActorRole = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.ActorRole;
 using BusinessReason = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.BusinessReason;
 using MeteringPointType = Energinet.DataHub.EDI.B2CWebApi.Models.V1.MeteringPointType;
@@ -45,8 +46,8 @@ public static class RequestAggregatedMeasureDataDtoFactoryV1
             Id: TransactionId.New().Value,
             MarketEvaluationPointType: MapEvaluationPointTypeCode(request),
             MarketEvaluationSettlementMethod: MapSettlementMethodCode(request),
-            StartDateAndOrTimeDateTime: request.StartDate.ToInstant().ToString(),
-            EndDateAndOrTimeDateTime: request.EndDate.ToInstant().ToString(),
+            StartDateAndOrTimeDateTime: InstantPattern.General.Format(request.StartDate.ToInstant()),
+            EndDateAndOrTimeDateTime: InstantPattern.General.Format(request.EndDate.ToInstant()),
             MeteringGridAreaDomainId: request.GridAreaCode,
             EnergySupplierMarketParticipantId: request.EnergySupplierId,
             BalanceResponsiblePartyMarketParticipantId: request.BalanceResponsibleId,

--- a/source/Tests/B2CWebApi/Factories/RequestAggregatedMeasureDataDtoFactoryV1Test.cs
+++ b/source/Tests/B2CWebApi/Factories/RequestAggregatedMeasureDataDtoFactoryV1Test.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text.RegularExpressions;
+using Energinet.DataHub.EDI.B2CWebApi.Factories.V1;
+using Energinet.DataHub.EDI.B2CWebApi.Models.V1;
+using NodaTime;
+using Xunit;
+
+namespace Energinet.DataHub.EDI.Tests.B2CWebApi.Factories;
+
+public class RequestAggregatedMeasureDataDtoFactoryV1Test
+{
+    [Fact]
+    public void CreateRequestAggregatedMeasureDataDto_ShouldReturnValidDto()
+    {
+        // Act
+        var result = RequestAggregatedMeasureDataDtoFactoryV1.Create(
+            new RequestAggregatedMeasureDataMarketRequestV1(
+                BusinessReason.PreliminaryAggregation,
+                null,
+                SettlementMethod.NonProfiled,
+                MeteringPointType.Consumption,
+                new DateTimeOffset(2021, 1, 1, 22, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2021, 1, 31, 22, 0, 0, TimeSpan.Zero),
+                "804",
+                "6454843448453",
+                null),
+            "1234567895412",
+            "EnergySupplier",
+            Instant.FromUtc(2021, 1, 1, 22, 00));
+
+        // Assert
+        Assert.True(IsIsoUtcFormat(result.Serie.First().StartDateAndOrTimeDateTime));
+        Assert.True(IsIsoUtcFormat(result.Serie.First().EndDateAndOrTimeDateTime!));
+    }
+
+    private bool IsIsoUtcFormat(string input)
+    {
+        return Regex.IsMatch(input, @"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$");
+    }
+}


### PR DESCRIPTION
<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description
This pull request introduces changes to enhance date handling in the `RequestAggregatedMeasureDataDtoFactoryV1` class and adds unit tests for validation. 

Converting `DateTimeOffset` to `Instant` for ISO UTC compliance and introducing a new test class to ensure the correctness of the DTO creation.


https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/internal-repo/1746


https://energinet.service-now.com/now/nav/ui/classic/params/target/incident.do%3Fsys_id%3Df3a64213c339aa10f73f2bf0e00131f6

## Checklist

<!-- markdown-link-check-disable -->
- [ ] Subsystem test executed [deploy to dev_002/dev_003](https://github.com/Energinet-DataHub/dh3-environments/actions/workflows/edi-cd.yml)
<!-- markdown-link-check-enable -->

- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Is there time to monitor state of the release to Production?
