### PR TITLE
perf: Add specific ebIX index for peek bundle

### DIFF
--- a/source/ApplyDBMigrationsApp/ApplyDBMigrationsApp.csproj
+++ b/source/ApplyDBMigrationsApp/ApplyDBMigrationsApp.csproj
@@ -218,6 +218,7 @@ limitations under the License.
     <EmbeddedResource Include="Scripts\Model\202503271548 Create index IX_OutgoingMessages_BundleMetadataForMessagesReadyToBeBundled.sql" />
     <EmbeddedResource Include="Scripts\Model\202503280930 Create index IX_OutgoingMessages_MessagesForBundle.sql" />
     <EmbeddedResource Include="Scripts\Model\202503311523 Add RelatedToMessageId to index IX_OutgoingMessages_BundleMetadataForMessagesReadyToBeBundled.sql" />
+    <EmbeddedResource Include="Scripts\Model\202506041337 Update index IX_Bundles_NextBundleToPeek on Bundles table.sql" />
     <EmbeddedResource Include="Scripts\Model\202504101204 Add DataCount to OutgoingMessages.sql" />
     <EmbeddedResource Include="Scripts\Model\202504161255 Add MeteringPointId to OutgoingMessages.sql" />
     <EmbeddedResource Include="Scripts\Model\202504221058 Add PaginationCursorValue to MeteringPointArchivedMessages.sql" />

--- a/source/ApplyDBMigrationsApp/Scripts/Model/202506041337 Update index IX_Bundles_NextBundleToPeek on Bundles table.sql
+++ b/source/ApplyDBMigrationsApp/Scripts/Model/202506041337 Update index IX_Bundles_NextBundleToPeek on Bundles table.sql
@@ -1,0 +1,25 @@
+-- Should match the query in BundlesRepository.GetNextBundleToPeekAsync()
+
+-- Drop existing index
+DROP INDEX IX_Bundles_NextBundleToPeek
+GO
+
+CREATE INDEX IX_Bundles_NextBundleToPeek
+    ON [dbo].[Bundles] (
+        ActorMessageQueueId,
+        DequeuedAt,
+        ClosedAt,
+        MessageCategory,
+        Created) -- Created is last in the index because it is only used to sort the query
+    WHERE DequeuedAt IS NULL;
+GO
+
+-- ebIX index doesn't include the message category, since ebIX queries messages for all categories
+CREATE INDEX IX_Bundles_NextBundleToPeek_ebIX
+    ON [dbo].[Bundles] (
+        ActorMessageQueueId,
+        DequeuedAt,
+        ClosedAt,
+        Created) -- Created is last in the index because it is only used to sort the query
+    WHERE DequeuedAt IS NULL;
+GO

--- a/source/ApplyDBMigrationsApp/Scripts/Model/202506041337 Update index IX_Bundles_NextBundleToPeek on Bundles table.sql
+++ b/source/ApplyDBMigrationsApp/Scripts/Model/202506041337 Update index IX_Bundles_NextBundleToPeek on Bundles table.sql
@@ -14,7 +14,7 @@ CREATE INDEX IX_Bundles_NextBundleToPeek
     WHERE DequeuedAt IS NULL;
 GO
 
--- ebIX index doesn't include the message category, since ebIX queries messages for all categories
+-- ebIX index doesn't include the message category, since the ebIX query is for all categories
 CREATE INDEX IX_Bundles_NextBundleToPeek_ebIX
     ON [dbo].[Bundles] (
         ActorMessageQueueId,

--- a/source/ApplyDBMigrationsApp/Scripts/Model/202506041337 Update index IX_Bundles_NextBundleToPeek on Bundles table.sql
+++ b/source/ApplyDBMigrationsApp/Scripts/Model/202506041337 Update index IX_Bundles_NextBundleToPeek on Bundles table.sql
@@ -1,7 +1,7 @@
 -- Should match the query in BundlesRepository.GetNextBundleToPeekAsync()
 
 -- Drop existing index
-DROP INDEX IX_Bundles_NextBundleToPeek
+DROP INDEX IX_Bundles_NextBundleToPeek ON [dbo].[Bundles]
 GO
 
 -- DequeuedAt does not need to be included in the key columns since the index is filtered on DequeuedAt IS NULL

--- a/source/ApplyDBMigrationsApp/Scripts/Model/202506041337 Update index IX_Bundles_NextBundleToPeek on Bundles table.sql
+++ b/source/ApplyDBMigrationsApp/Scripts/Model/202506041337 Update index IX_Bundles_NextBundleToPeek on Bundles table.sql
@@ -4,10 +4,10 @@
 DROP INDEX IX_Bundles_NextBundleToPeek
 GO
 
+-- DequeuedAt does not need to be included in the key columns since the index is filtered on DequeuedAt IS NULL
 CREATE INDEX IX_Bundles_NextBundleToPeek
     ON [dbo].[Bundles] (
         ActorMessageQueueId,
-        DequeuedAt,
         ClosedAt,
         MessageCategory,
         Created) -- Created is last in the index because it is only used to sort the query
@@ -18,7 +18,6 @@ GO
 CREATE INDEX IX_Bundles_NextBundleToPeek_ebIX
     ON [dbo].[Bundles] (
         ActorMessageQueueId,
-        DequeuedAt,
         ClosedAt,
         Created) -- Created is last in the index because it is only used to sort the query
     WHERE DequeuedAt IS NULL;

--- a/source/OutgoingMessages.Infrastructure/Repositories/Bundles/BundleRepository.cs
+++ b/source/OutgoingMessages.Infrastructure/Repositories/Bundles/BundleRepository.cs
@@ -63,7 +63,7 @@ public class BundleRepository(
         MessageCategory messageCategory,
         CancellationToken cancellationToken = default)
     {
-        // This query should be covered by the "IX_Bundles_NextBundleToPeek" index
+        // This query should be covered by the "IX_Bundles_NextBundleToPeek" or "IX_Bundles_NextBundleToPeek_ebIX" index
         // Get the oldest bundle that is:
         // - In the given actor message queue & category
         // - Not dequeued


### PR DESCRIPTION
<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Since ebIX peek does not include message category, it is more performant to have a separate index for the ebIX query. This should improve peek performance, since `Created` is now the last column in the index, and it is only used for sorting in the queries.

## Checklist

<!-- markdown-link-check-disable -->
- [ ] Subsystem test executed [deploy to dev_002/dev_003](https://github.com/Energinet-DataHub/dh3-environments/actions/workflows/edi-cd.yml)
<!-- markdown-link-check-enable -->

- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Is there time to monitor state of the release to Production?
