### PR TITLE
feat: Implement walking skeleton of Send Measurements from the UI

### DIFF
--- a/source/B2CWebApi.AppTests/B2CWebApiRequests.cs
+++ b/source/B2CWebApi.AppTests/B2CWebApiRequests.cs
@@ -179,6 +179,16 @@ public static class B2CWebApiRequests
         return request;
     }
 
+    public static HttpRequestMessage CreateSendMeasurementsV1Request(SendMeasurementsRequestV1 request)
+    {
+        var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/SendMeasurements")
+        {
+            Content = CreateJsonContent(request),
+        };
+
+        return httpRequest;
+    }
+
     private static StringContent CreateJsonContent(object payload)
     {
         var serializedObject = JsonSerializer.Serialize(payload);

--- a/source/B2CWebApi.AppTests/Tests/SendMeasurementsRequestTests.cs
+++ b/source/B2CWebApi.AppTests/Tests/SendMeasurementsRequestTests.cs
@@ -40,7 +40,7 @@ public class SendMeasurementsRequestTests : IAsyncLifetime
     private Claim[] RequiredActorClaims =>
     [
         new("actornumber", "1234567890123"),
-        new("marketroles", ActorRole.MeteredDataResponsible.Name), // TODO: Update to the correct role ?
+        new("marketroles", ActorRole.MeteredDataResponsible.Name), // TODO #1670: Update to the correct role ?
     ];
 
     public static TheoryData<MeteringPointType, Resolution, Quality> RequestsWithAllResolutions()
@@ -110,7 +110,6 @@ public class SendMeasurementsRequestTests : IAsyncLifetime
         Quality quality)
     {
         // Arrange
-
         const int positions = 2;
         var resolutionAsDuration = resolution switch
         {

--- a/source/B2CWebApi.AppTests/Tests/SendMeasurementsTests.cs
+++ b/source/B2CWebApi.AppTests/Tests/SendMeasurementsTests.cs
@@ -1,0 +1,117 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Security.Claims;
+using Energinet.DataHub.EDI.B2CWebApi.AppTests.Fixture;
+using Energinet.DataHub.EDI.B2CWebApi.Controllers;
+using Energinet.DataHub.EDI.B2CWebApi.Models.V1;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using NodaTime;
+using Xunit;
+using Xunit.Abstractions;
+using MeteringPointType = Energinet.DataHub.EDI.B2CWebApi.Models.V1.MeteringPointType;
+using Quality = Energinet.DataHub.EDI.B2CWebApi.Models.V1.Quality;
+using Resolution = Energinet.DataHub.EDI.B2CWebApi.Models.V1.Resolution;
+
+namespace Energinet.DataHub.EDI.B2CWebApi.AppTests.Tests;
+
+[Collection(nameof(B2CWebApiCollectionFixture))]
+public class SendMeasurementsTests : IAsyncLifetime
+{
+    private readonly B2CWebApiFixture _fixture;
+
+    public SendMeasurementsTests(B2CWebApiFixture fixture, ITestOutputHelper logger)
+    {
+        _fixture = fixture;
+        _fixture.SetTestOutputHelper(logger);
+    }
+
+    private Claim[] RequiredActorClaims =>
+    [
+        new("actornumber", "1234567890123"),
+        new("marketroles", ActorRole.MeteredDataResponsible.Name), // TODO: Update to the correct role
+    ];
+
+    public static TheoryData<MeteringPointType, Resolution, Quality> RequestsWithAllResolutions()
+    {
+        var theoryData = new TheoryData<MeteringPointType, Resolution, Quality>();
+
+        foreach (var resolution in Enum.GetValues<Resolution>())
+        {
+            theoryData.Add(MeteringPointType.Consumption, resolution, Quality.Measured);
+        }
+
+        return theoryData;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _fixture.SetTestOutputHelper(null);
+        return Task.CompletedTask;
+    }
+
+    [Theory]
+    [MemberData(nameof(RequestsWithAllResolutions))]
+    public async Task Given_SendMeasurementsRequest_When_ValidRequest_Then_Success(
+        MeteringPointType meteringPointType,
+        Resolution resolution,
+        Quality quality)
+    {
+        // Arrange
+
+        const int positions = 2;
+        var resolutionAsDuration = resolution switch
+        {
+            Resolution.QuarterHourly => Duration.FromMinutes(15),
+            Resolution.Hourly => Duration.FromHours(1),
+            _ => throw new ArgumentOutOfRangeException(nameof(resolution), resolution, "Unhandled resolution"),
+        };
+
+        var start = Instant.FromUtc(2025, 06, 11, 13, 00);
+        var end = start.Plus(resolutionAsDuration * positions);
+
+        var request = new SendMeasurementsRequestV1(
+            "123456789012345678",
+            meteringPointType,
+            resolution,
+            quality,
+            start.ToDateTimeOffset(),
+            end.ToDateTimeOffset(),
+            new List<SendMeasurementsRequestV1.Measurement>()
+            {
+                // 2 positions, must match the "positions" const above
+                new(1, 42.123m),
+                new(2, 1337m),
+            });
+
+        using var httpRequest = B2CWebApiRequests.CreateSendMeasurementsV1Request(request);
+        httpRequest.Headers.Authorization = await _fixture.OpenIdJwtManager.JwtProvider
+            .CreateInternalTokenAuthenticationHeaderAsync(
+                roles: [SendMeasurementsController.RequiredRole],
+                extraClaims: RequiredActorClaims);
+
+        // Act
+        var response = await _fixture.WebApiClient.SendAsync(httpRequest);
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.True(response.IsSuccessStatusCode, $"Request failed with status code: {response.StatusCode}, response: {responseContent}");
+    }
+}

--- a/source/B2CWebApi/Controllers/SendMeasurementsController.cs
+++ b/source/B2CWebApi/Controllers/SendMeasurementsController.cs
@@ -42,7 +42,7 @@ public class SendMeasurementsController(
 
     [ApiVersion("1.0")]
     [HttpPost]
-    [Authorize(Roles = RequiredRole)] // TODO #1670: Update with correct role?
+    [Authorize(Roles = RequiredRole)]
     public async Task<ActionResult> RequestAsync(
         SendMeasurementsRequestV1 request,
         CancellationToken cancellationToken)

--- a/source/B2CWebApi/Controllers/SendMeasurementsController.cs
+++ b/source/B2CWebApi/Controllers/SendMeasurementsController.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+using System.Text.Json;
+using Asp.Versioning;
+using Energinet.DataHub.Core.App.Common.Users;
+using Energinet.DataHub.EDI.B2CWebApi.Factories.V1;
+using Energinet.DataHub.EDI.B2CWebApi.Models.V1;
+using Energinet.DataHub.EDI.B2CWebApi.Security;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.IncomingMessages.Interfaces;
+using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Energinet.DataHub.EDI.B2CWebApi.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class SendMeasurementsController(
+    UserContext<FrontendUser> userContext,
+    SendMeasurementsDtoFactory sendMeasurementsDtoFactory,
+    IIncomingMessageClient incomingMessageClient) : ControllerBase
+{
+    public const string RequiredRole = "send-measurements:update"; // TODO: Update with correct role?
+
+    private readonly UserContext<FrontendUser> _userContext = userContext;
+    private readonly SendMeasurementsDtoFactory _sendMeasurementsDtoFactory = sendMeasurementsDtoFactory;
+    private readonly IIncomingMessageClient _incomingMessageClient = incomingMessageClient;
+
+    [ApiVersion("1.0")]
+    [HttpPost]
+    [Authorize(Roles = RequiredRole)] // TODO: Update with correct role?
+    public async Task<ActionResult> RequestAsync(
+        SendMeasurementsRequestV1 request,
+        CancellationToken cancellationToken)
+    {
+        var currentUser = _userContext.CurrentUser;
+        var sendMeasurementsDto = _sendMeasurementsDtoFactory.CreateDto(
+            Actor.From(currentUser.ActorNumber, currentUser.MarketRole),
+            request);
+
+        var incomingMessageStream = await CreateJsonStreamFromStringAsync(sendMeasurementsDto).ConfigureAwait(false);
+        var responseMessage = await _incomingMessageClient.ReceiveIncomingMarketMessageAsync(
+                incomingMessageStream,
+                DocumentFormat.Json,
+                IncomingDocumentType.B2CSendMeasurements,
+                DocumentFormat.Json,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return responseMessage.IsErrorResponse
+            ? BadRequest(responseMessage.MessageBody)
+            : Ok(responseMessage.MessageBody);
+    }
+
+    private static async Task<IncomingMarketMessageStream> CreateJsonStreamFromStringAsync(SendMeasurementsDto dto)
+    {
+        var memoryStream = new MemoryStream();
+        await JsonSerializer.SerializeAsync(memoryStream, dto).ConfigureAwait(false);
+
+        return new IncomingMarketMessageStream(memoryStream);
+    }
+}

--- a/source/B2CWebApi/Controllers/SendMeasurementsController.cs
+++ b/source/B2CWebApi/Controllers/SendMeasurementsController.cs
@@ -34,7 +34,7 @@ public class SendMeasurementsController(
     SendMeasurementsDtoFactory sendMeasurementsDtoFactory,
     IIncomingMessageClient incomingMessageClient) : ControllerBase
 {
-    public const string RequiredRole = "send-measurements:update"; // TODO: Update with correct role?
+    public const string RequiredRole = "send-measurements:update"; // TODO #1670: Update with correct role?
 
     private readonly UserContext<FrontendUser> _userContext = userContext;
     private readonly SendMeasurementsDtoFactory _sendMeasurementsDtoFactory = sendMeasurementsDtoFactory;
@@ -42,7 +42,7 @@ public class SendMeasurementsController(
 
     [ApiVersion("1.0")]
     [HttpPost]
-    [Authorize(Roles = RequiredRole)] // TODO: Update with correct role?
+    [Authorize(Roles = RequiredRole)] // TODO #1670: Update with correct role?
     public async Task<ActionResult> RequestAsync(
         SendMeasurementsRequestV1 request,
         CancellationToken cancellationToken)

--- a/source/B2CWebApi/Extensions/DependencyInjection/SendMeasurementsExtensions.cs
+++ b/source/B2CWebApi/Extensions/DependencyInjection/SendMeasurementsExtensions.cs
@@ -12,23 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.B2CWebApi.Factories.V1;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
-public sealed class Actor(ActorNumber actorNumber, ActorRole actorRole)
+namespace Energinet.DataHub.EDI.B2CWebApi.Extensions.DependencyInjection;
+
+public static class SendMeasurementsExtensions
 {
-    public ActorNumber ActorNumber { get; init; } = actorNumber;
-
-    public ActorRole ActorRole { get; init; } = actorRole;
-
-    public static Actor From(string actorNumber, string actorRoleName)
+    public static IServiceCollection AddSendMeasurements(
+        this IServiceCollection services)
     {
-        return new Actor(
-            ActorNumber.Create(actorNumber),
-            ActorRole.FromName(actorRoleName));
-    }
+        services.TryAddTransient<SendMeasurementsDtoFactory>();
 
-    public override string ToString()
-    {
-        return $"ActorNumber: {ActorNumber.Value}, ActorRole: {ActorRole.Name}";
+        return services;
     }
 }

--- a/source/B2CWebApi/Factories/V1/SendMeasurementsDtoFactory.cs
+++ b/source/B2CWebApi/Factories/V1/SendMeasurementsDtoFactory.cs
@@ -38,10 +38,10 @@ public class SendMeasurementsDtoFactory(
             MeteringPointId: MeteringPointId.From(request.MeteringPointId),
             MeteringPointType: MapMeteringPointType(request.MeteringPointType),
             Sender: sender,
-            CreatedAt: _clock.GetCurrentInstant(),
+            CreatedAt: _clock.GetCurrentInstant().ToDateTimeOffset(),
             Resolution: MapResolution(request.Resolution),
-            Start: request.Start.ToInstant(),
-            End: request.End.ToInstant(),
+            Start: request.Start,
+            End: request.End,
             Measurements: request.Measurements.Select(
                 m => new SendMeasurementsDto.MeasurementDto(
                     m.Position,

--- a/source/B2CWebApi/Factories/V1/SendMeasurementsDtoFactory.cs
+++ b/source/B2CWebApi/Factories/V1/SendMeasurementsDtoFactory.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.EDI.B2CWebApi.Models.V1;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
+using NodaTime;
+using NodaTime.Extensions;
+using MeteringPointType = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.MeteringPointType;
+using Quality = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Quality;
+using Resolution = Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.Resolution;
+
+namespace Energinet.DataHub.EDI.B2CWebApi.Factories.V1;
+
+public class SendMeasurementsDtoFactory(
+    IClock clock)
+{
+    private readonly IClock _clock = clock;
+
+    public SendMeasurementsDto CreateDto(
+        Actor sender,
+        SendMeasurementsRequestV1 request)
+    {
+        return new SendMeasurementsDto(
+            MessageId: MessageId.New(),
+            TransactionId: TransactionId.New(),
+            MeteringPointId: MeteringPointId.From(request.MeteringPointId),
+            MeteringPointType: MapMeteringPointType(request.MeteringPointType),
+            Sender: sender,
+            CreatedAt: _clock.GetCurrentInstant(),
+            Resolution: MapResolution(request.Resolution),
+            Start: request.Start.ToInstant(),
+            End: request.End.ToInstant(),
+            Measurements: request.Measurements.Select(
+                m => new SendMeasurementsDto.MeasurementDto(
+                    m.Position,
+                    m.Quantity,
+                    MapQuality(request.Quality)))
+                .ToList());
+    }
+
+    private static Resolution MapResolution(Models.V1.Resolution resolution) => resolution switch
+    {
+        Models.V1.Resolution.Hourly => Resolution.Hourly,
+        Models.V1.Resolution.QuarterHourly => Resolution.QuarterHourly,
+        _ => throw new ArgumentOutOfRangeException(nameof(resolution), resolution, "Invalid resolution."),
+    };
+
+    private static MeteringPointType MapMeteringPointType(Models.V1.MeteringPointType type) => type switch
+    {
+        Models.V1.MeteringPointType.Production => MeteringPointType.Production,
+        Models.V1.MeteringPointType.Consumption => MeteringPointType.Consumption,
+        Models.V1.MeteringPointType.Exchange => MeteringPointType.Exchange,
+
+        _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Invalid metering point type."),
+    };
+
+    private static Quality MapQuality(Models.V1.Quality quality) => quality switch
+    {
+        Models.V1.Quality.Calculated => Quality.Calculated,
+        Models.V1.Quality.Measured => Quality.Measured,
+        _ => throw new ArgumentOutOfRangeException(nameof(quality), quality, "Invalid quality."),
+    };
+}

--- a/source/B2CWebApi/Factories/V1/SendMeasurementsDtoFactory.cs
+++ b/source/B2CWebApi/Factories/V1/SendMeasurementsDtoFactory.cs
@@ -52,6 +52,7 @@ public class SendMeasurementsDtoFactory(
 
     private static Resolution MapResolution(Models.V1.Resolution resolution) => resolution switch
     {
+        // TODO #1670: What are the valid resolutions?
         Models.V1.Resolution.Hourly => Resolution.Hourly,
         Models.V1.Resolution.QuarterHourly => Resolution.QuarterHourly,
         _ => throw new ArgumentOutOfRangeException(nameof(resolution), resolution, "Invalid resolution."),
@@ -59,6 +60,7 @@ public class SendMeasurementsDtoFactory(
 
     private static MeteringPointType MapMeteringPointType(Models.V1.MeteringPointType type) => type switch
     {
+        // TODO #1670: What are the valid metering point types?
         Models.V1.MeteringPointType.Production => MeteringPointType.Production,
         Models.V1.MeteringPointType.Consumption => MeteringPointType.Consumption,
         Models.V1.MeteringPointType.Exchange => MeteringPointType.Exchange,
@@ -68,6 +70,7 @@ public class SendMeasurementsDtoFactory(
 
     private static Quality MapQuality(Models.V1.Quality quality) => quality switch
     {
+        // TODO #1670: What are the valid qualities?
         Models.V1.Quality.Calculated => Quality.Calculated,
         Models.V1.Quality.Measured => Quality.Measured,
         _ => throw new ArgumentOutOfRangeException(nameof(quality), quality, "Invalid quality."),

--- a/source/B2CWebApi/Models/V1/Quality.cs
+++ b/source/B2CWebApi/Models/V1/Quality.cs
@@ -12,23 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+namespace Energinet.DataHub.EDI.B2CWebApi.Models.V1;
 
-public sealed class Actor(ActorNumber actorNumber, ActorRole actorRole)
+public enum Quality
 {
-    public ActorNumber ActorNumber { get; init; } = actorNumber;
-
-    public ActorRole ActorRole { get; init; } = actorRole;
-
-    public static Actor From(string actorNumber, string actorRoleName)
-    {
-        return new Actor(
-            ActorNumber.Create(actorNumber),
-            ActorRole.FromName(actorRoleName));
-    }
-
-    public override string ToString()
-    {
-        return $"ActorNumber: {ActorNumber.Value}, ActorRole: {ActorRole.Name}";
-    }
+    Calculated,
+    Measured,
 }

--- a/source/B2CWebApi/Models/V1/Resolution.cs
+++ b/source/B2CWebApi/Models/V1/Resolution.cs
@@ -17,4 +17,6 @@ namespace Energinet.DataHub.EDI.B2CWebApi.Models.V1;
 public enum Resolution
 {
     Monthly,
+    Hourly,
+    QuarterHourly,
 }

--- a/source/B2CWebApi/Models/V1/SendMeasurementsRequestV1.cs
+++ b/source/B2CWebApi/Models/V1/SendMeasurementsRequestV1.cs
@@ -12,23 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+namespace Energinet.DataHub.EDI.B2CWebApi.Models.V1;
 
-public sealed class Actor(ActorNumber actorNumber, ActorRole actorRole)
+public record SendMeasurementsRequestV1(
+    string MeteringPointId,
+    MeteringPointType MeteringPointType,
+    Resolution Resolution,
+    Quality Quality,
+    DateTimeOffset Start,
+    DateTimeOffset End,
+    IReadOnlyCollection<SendMeasurementsRequestV1.Measurement> Measurements)
 {
-    public ActorNumber ActorNumber { get; init; } = actorNumber;
-
-    public ActorRole ActorRole { get; init; } = actorRole;
-
-    public static Actor From(string actorNumber, string actorRoleName)
-    {
-        return new Actor(
-            ActorNumber.Create(actorNumber),
-            ActorRole.FromName(actorRoleName));
-    }
-
-    public override string ToString()
-    {
-        return $"ActorNumber: {ActorNumber.Value}, ActorRole: {ActorRole.Name}";
-    }
+    public record Measurement(
+        int Position,
+        decimal Quantity);
 }

--- a/source/B2CWebApi/Program.cs
+++ b/source/B2CWebApi/Program.cs
@@ -58,6 +58,8 @@ builder.Services
     .AddOutboxContext(builder.Configuration)
     .AddOutboxClient<OutboxContext>()
 
+    .AddSendMeasurements()
+
     // Modules
     .AddDataAccessUnitOfWorkModule()
     .AddIncomingMessagesModule(builder.Configuration)

--- a/source/BuildingBlocks.Domain/Models/IncomingDocumentType.cs
+++ b/source/BuildingBlocks.Domain/Models/IncomingDocumentType.cs
@@ -22,6 +22,7 @@ public class IncomingDocumentType : EnumerationType
     public static readonly IncomingDocumentType B2CRequestWholesaleSettlement = new(nameof(B2CRequestWholesaleSettlement));
     public static readonly IncomingDocumentType NotifyValidatedMeasureData = new(nameof(NotifyValidatedMeasureData));
     public static readonly IncomingDocumentType RequestValidatedMeasurements = new(nameof(RequestValidatedMeasurements));
+    public static readonly IncomingDocumentType B2CSendMeasurements = new(nameof(B2CSendMeasurements));
 
     private IncomingDocumentType(string name)
         : base(name)

--- a/source/BuildingBlocks.Domain/Models/MessageId.cs
+++ b/source/BuildingBlocks.Domain/Models/MessageId.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Text.Json.Serialization;
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Exceptions;
 
 namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
@@ -22,6 +23,7 @@ namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
 [Serializable]
 public readonly record struct MessageId
 {
+    [JsonConstructor]
     private MessageId(string value)
     {
         Value = value;

--- a/source/IncomingMessages.Application/DelegateIncomingMessage.cs
+++ b/source/IncomingMessages.Application/DelegateIncomingMessage.cs
@@ -161,6 +161,7 @@ public class DelegateIncomingMessage
             { IncomingDocumentType.RequestWholesaleSettlement, ProcessType.RequestWholesaleResults },
             { IncomingDocumentType.B2CRequestWholesaleSettlement, ProcessType.RequestWholesaleResults },
             { IncomingDocumentType.NotifyValidatedMeasureData, ProcessType.IncomingMeteredDataForMeteringPoint },
+            { IncomingDocumentType.B2CSendMeasurements, ProcessType.IncomingMeteredDataForMeteringPoint },
             { IncomingDocumentType.RequestValidatedMeasurements, ProcessType.RequestMeasurements },
         };
 

--- a/source/IncomingMessages.Application/UseCases/ReceiveIncomingMarketMessage.cs
+++ b/source/IncomingMessages.Application/UseCases/ReceiveIncomingMarketMessage.cs
@@ -205,6 +205,8 @@ public class ReceiveIncomingMarketMessage
                 return DocumentType.RequestWholesaleSettlement;
             case var incomingDocType when incomingDocType == IncomingDocumentType.NotifyValidatedMeasureData:
                 return DocumentType.NotifyValidatedMeasureData;
+            case var incomingDocType when incomingDocType == IncomingDocumentType.B2CSendMeasurements:
+                return DocumentType.NotifyValidatedMeasureData;
             case var incomingDocType when incomingDocType == IncomingDocumentType.RequestValidatedMeasurements:
                 return DocumentType.RequestMeasurements;
             default:

--- a/source/IncomingMessages.Domain/MessageParsers/RSM012/SendMeasurementsB2CJsonMessageParser.cs
+++ b/source/IncomingMessages.Domain/MessageParsers/RSM012/SendMeasurementsB2CJsonMessageParser.cs
@@ -35,7 +35,7 @@ public class SendMeasurementsB2CJsonMessageParser(
 
     protected override IIncomingMessage MapIncomingMessage(SendMeasurementsDto incomingMessageDto)
     {
-        // TODO: Correct pattern?
+        // TODO #1670: Correct pattern?
         var instantPatternWithoutSeconds = InstantPattern.CreateWithInvariantCulture("yyyy-MM-dd'T'HH:mm'Z'");
 
         var series = new MeteredDataForMeteringPointSeries(

--- a/source/IncomingMessages.Domain/MessageParsers/RSM012/SendMeasurementsB2CJsonMessageParser.cs
+++ b/source/IncomingMessages.Domain/MessageParsers/RSM012/SendMeasurementsB2CJsonMessageParser.cs
@@ -1,0 +1,66 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Globalization;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.DataHub;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.BuildingBlocks.Interfaces;
+using Energinet.DataHub.EDI.IncomingMessages.Domain.Messages;
+using Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
+using NodaTime.Text;
+
+namespace Energinet.DataHub.EDI.IncomingMessages.Domain.MessageParsers.RSM012;
+
+public class SendMeasurementsB2CJsonMessageParser(
+    ISerializer serializer)
+    : B2CJsonMessageParserBase<SendMeasurementsDto>(serializer)
+{
+    public override IncomingDocumentType DocumentType => IncomingDocumentType.B2CSendMeasurements;
+
+    public override DocumentFormat DocumentFormat => DocumentFormat.Json;
+
+    protected override IIncomingMessage MapIncomingMessage(SendMeasurementsDto incomingMessageDto)
+    {
+        var series = new MeteredDataForMeteringPointSeries(
+            TransactionId: incomingMessageDto.TransactionId.Value,
+            Resolution: incomingMessageDto.Resolution.Code,
+            StartDateTime: InstantPattern.General.Format(incomingMessageDto.Start),
+            EndDateTime: InstantPattern.General.Format(incomingMessageDto.End),
+            ProductNumber: ProductType.EnergyActive.Code, // TODO: Correct product number
+            RegisteredAt: InstantPattern.General.Format(incomingMessageDto.CreatedAt),
+            ProductUnitType: MeasurementUnit.KilowattHour.Code, // TODO: Correct product unit type?
+            MeteringPointType: incomingMessageDto.MeteringPointType.Code,
+            MeteringPointLocationId: incomingMessageDto.MeteringPointId.Value,
+            SenderNumber: incomingMessageDto.Sender.ActorNumber.Value,
+            EnergyObservations: incomingMessageDto.Measurements
+                .Select(
+                    m => new EnergyObservation(
+                        m.Position.ToString(),
+                        m.Quantity.ToString(NumberFormatInfo.InvariantInfo),
+                        m.Quality.Code))
+                .ToList());
+
+        return new MeteredDataForMeteringPointMessageBase(
+            messageId: incomingMessageDto.MessageId.Value,
+            messageType: BuildingBlocks.Domain.Models.DocumentType.NotifyValidatedMeasureData.Name, // TODO: Correct message type
+            createdAt: InstantPattern.General.Format(incomingMessageDto.CreatedAt),
+            senderNumber: incomingMessageDto.Sender.ActorNumber.Value,
+            receiverNumber: DataHubDetails.DataHubActorNumber.Value,
+            senderRoleCode: incomingMessageDto.Sender.ActorRole.Code,
+            businessReason: BusinessReason.PeriodicMetering.Code,
+            receiverRoleCode: ActorRole.SystemOperator.Code, // TODO: Correct receiver role code?
+            businessType: "A", // TODO: Correct business type?
+            series: [series]);
+    }
+}

--- a/source/IncomingMessages.Infrastructure/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
+++ b/source/IncomingMessages.Infrastructure/Extensions/DependencyInjection/IncomingMessagesExtensions.cs
@@ -163,6 +163,7 @@ public static class IncomingMessagesExtensions
         services.AddTransient<IMessageParser, MeteredDataForMeteringPointJsonMessageParser>();
         services.AddTransient<IMessageParser, MeteredDataForMeteringPointEbixMessageParser>();
         services.AddTransient<IMessageParser, MeteredDataForMeteringPointXmlMessageParser>();
+        services.AddTransient<IMessageParser, SendMeasurementsB2CJsonMessageParser>();
 
         services.AddTransient<IMessageParser, WholesaleSettlementXmlMessageParser>();
         services.AddTransient<IMessageParser, WholesaleSettlementJsonMessageParser>();

--- a/source/IncomingMessages.IntegrationTests/MessageParsers/GivenNewDocumentTypeTests.cs
+++ b/source/IncomingMessages.IntegrationTests/MessageParsers/GivenNewDocumentTypeTests.cs
@@ -32,6 +32,8 @@ public class GivenNewIncomingDocumentTypeTests : IncomingMessagesTestBase
         (IncomingDocumentType.B2CRequestWholesaleSettlement, DocumentFormat.Ebix),
         (IncomingDocumentType.B2CRequestAggregatedMeasureData, DocumentFormat.Xml),
         (IncomingDocumentType.B2CRequestWholesaleSettlement, DocumentFormat.Xml),
+        (IncomingDocumentType.B2CSendMeasurements, DocumentFormat.Xml),
+        (IncomingDocumentType.B2CSendMeasurements, DocumentFormat.Ebix),
     };
 
     public GivenNewIncomingDocumentTypeTests(IncomingMessagesTestFixture incomingMessagesTestFixture, ITestOutputHelper testOutputHelper)

--- a/source/IncomingMessages.Interfaces/Models/SendMeasurementsDto.cs
+++ b/source/IncomingMessages.Interfaces/Models/SendMeasurementsDto.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
-using NodaTime;
 
 namespace Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
 

--- a/source/IncomingMessages.Interfaces/Models/SendMeasurementsDto.cs
+++ b/source/IncomingMessages.Interfaces/Models/SendMeasurementsDto.cs
@@ -21,10 +21,10 @@ public record SendMeasurementsDto(
     MessageId MessageId,
     TransactionId TransactionId,
     Actor Sender,
-    Instant CreatedAt,
+    DateTimeOffset CreatedAt,
     Resolution Resolution,
-    Instant Start,
-    Instant End,
+    DateTimeOffset Start,
+    DateTimeOffset End,
     MeteringPointId MeteringPointId,
     MeteringPointType MeteringPointType,
     IReadOnlyCollection<SendMeasurementsDto.MeasurementDto> Measurements)

--- a/source/IncomingMessages.Interfaces/Models/SendMeasurementsDto.cs
+++ b/source/IncomingMessages.Interfaces/Models/SendMeasurementsDto.cs
@@ -12,23 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using Energinet.DataHub.EDI.BuildingBlocks.Domain.Models;
+using NodaTime;
 
-public sealed class Actor(ActorNumber actorNumber, ActorRole actorRole)
+namespace Energinet.DataHub.EDI.IncomingMessages.Interfaces.Models;
+
+public record SendMeasurementsDto(
+    MessageId MessageId,
+    TransactionId TransactionId,
+    Actor Sender,
+    Instant CreatedAt,
+    Resolution Resolution,
+    Instant Start,
+    Instant End,
+    MeteringPointId MeteringPointId,
+    MeteringPointType MeteringPointType,
+    IReadOnlyCollection<SendMeasurementsDto.MeasurementDto> Measurements)
 {
-    public ActorNumber ActorNumber { get; init; } = actorNumber;
-
-    public ActorRole ActorRole { get; init; } = actorRole;
-
-    public static Actor From(string actorNumber, string actorRoleName)
-    {
-        return new Actor(
-            ActorNumber.Create(actorNumber),
-            ActorRole.FromName(actorRoleName));
-    }
-
-    public override string ToString()
-    {
-        return $"ActorNumber: {ActorNumber.Value}, ActorRole: {ActorRole.Name}";
-    }
+    public record MeasurementDto(
+        int Position,
+        decimal Quantity,
+        Quality Quality);
 }

--- a/source/Tests/B2CWebApi/Mappers/DocumentTypeMapperTests.cs
+++ b/source/Tests/B2CWebApi/Mappers/DocumentTypeMapperTests.cs
@@ -79,6 +79,7 @@ public class DocumentTypeMapperTests
         supportedDocumentTypes = supportedDocumentTypes
             .Where(x =>
                 x != IncomingDocumentType.NotifyValidatedMeasureData.Name
+                && x != IncomingDocumentType.B2CSendMeasurements.Name
                 && x != IncomingDocumentType.RequestValidatedMeasurements.Name
                 && x != Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.DocumentType.RequestMeasurements.Name
                 && x != Energinet.DataHub.EDI.BuildingBlocks.Domain.Models.DocumentType.RejectRequestMeasurements.Name);


### PR DESCRIPTION
<!-- TITLE

Prefix with one of these:
- feat: A new feature including tests
- fix: A bug fix, this can also add test to cover the bug
- docs: Changes in documentation
- style: Style changes, formatting
- refac: Refactoring
- perf: Performance improvements
- test: Add missing tests
- build: Changes to the build process
- chore: updating dependencies

Read more at https://github.com/Mech0z/GitHubGuidelines

-->

## Description

Add support for BRS-021 Send Measurements from the UI/BFF to EDI, through the B2C app.

- Add controller & endpoint for send measurements.
- Add send measurements request & incoming message DTO.
- Add document type and parser.
- Add app test for the request.

This pull request is related to this issue: https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/843

## Checklist

<!-- markdown-link-check-disable -->
- [ ] Subsystem test executed [deploy to dev_002/dev_003](https://github.com/Energinet-DataHub/dh3-environments/actions/workflows/edi-cd.yml)
<!-- markdown-link-check-enable -->

- [ ] Has it been considered whether data is being delivered to the wrong actor?
- [ ] Is there time to monitor state of the release to Production?
